### PR TITLE
Support full riff-raff.yaml config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,11 +31,15 @@ jobs:
         with:
           dryRun: true
           app: foo
-          stack: deploy
+          stacks: |
+            - deploy
+          regions: |
+            - eu-west-1
           deployments: |
             upload:
               type: aws-s3
-              sources: my-sources
+              sources:
+                - my-sources
               parameters:
                 bucket: aws-some-bucket
                 cacheControl: private

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,16 +31,20 @@ jobs:
         with:
           dryRun: true
           app: foo
-          stacks: |
-            - deploy
-          regions: |
-            - eu-west-1
-          deployments: |
-            upload:
-              type: aws-s3
-              sources:
-                - my-sources
-              parameters:
-                bucket: aws-some-bucket
-                cacheControl: private
-                publicReadAcl: false
+          config: |
+            stacks:
+              - deploy
+            regions:
+              - eu-west-1
+            allowedStages:
+              - CODE
+              - PROD
+            deployments:
+              upload:
+                type: aws-s3
+                sources:
+                  - my-sources
+                parameters:
+                  bucket: aws-some-bucket
+                  cacheControl: private
+                  publicReadAcl: false

--- a/README.md
+++ b/README.md
@@ -12,27 +12,43 @@ https://github.com/guardian/node-riffraff-artifact.
 To use, add (something like) the following to your workflow file:
 
 ```
-- uses: guardian/actions-riff-raff@main
+- uses: guardian/actions-riff-raff@v1.0.0
   with:
     app: foo
-    stack: deploy
-    deployments: |
-      upload:
-        type: aws-s3
-        sources: test-data
-        parameters:
-          bucket: aws-some-bucket
-          cacheControl: private
-          publicReadAcl: false
+    config: |
+      stacks:
+        - deploy
+      regions:
+        - eu-west-1
+      allowedStages:
+        - CODE
+        - PROD
+      deployments:
+        upload:
+          type: aws-s3
+          sources:
+            - test-data
+          parameters:
+            bucket: aws-some-bucket
+            cacheControl: private
+            publicReadAcl: false
 ```
 
-By default, `stack::app` will be the Riffraff project name. Use the (optional)
-`projectName` setting to override this.
+Note, inputs can only be strings in Github Actions so `|` is used to provide the
+config as a multiline string.
 
-The `deployments` section structure is equivalent to the same section of a
-`riff-raff.yaml` file with an additional field per deployment called `sources` that
-can point to a (comma-separated) list of files and directories, all of which will
-be included in the package for the deployment.
+By default, `stack::app` will be the Riffraff project name. Use the (optional)
+`projectName` setting to override this. When multiple stacks are specified in
+the config, `projectName` becomes required and must be specified.
+
+The `config` section is equivalent to the contents of a `riff-raff.yaml` file
+with an additional (optional) field per deployment called `sources` that can
+point to a list of files and directories, all of which will be included in the
+package for the deployment.
+
+`configPath` can be used instead of `config` to point directly to a
+`riff-raff.yaml` file if you'd prefer that over storing the config directly in
+your workflow file.
 
 Note, you will need to provide credentials to upload to S3. Typically, this
 involves adding the following in your workflow file:
@@ -69,6 +85,7 @@ some-config.yaml
 The following deployment:
 
 ```
+...
 my-deployment:
   type: aws-s3
   sources: cfn,some-config.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -4,12 +4,12 @@ inputs:
   app:
     description: Riff Raff app name.
     required: true
-  stack:
-    description: Riff Raff stack name.
-    required: true
-  deployments:
-    description: "Riff Raff deployments. This is equivalent to the deployments section of a riff-raff.yaml file but with two additional properties: 'sources' (required - comma-separated list of the target files/directories for the deployment), and 'compression' (optional - 'gzip', 'tar', or the default 'none')."
-    required: true
+  config:
+    description: Riff Raff configuration (what would normally go in a riff-raff.yaml file). Use `|` to provide a multiline string here. The format should be the same as a normal riff-raff.yaml but with an additional 'sources' list property that can be added to deployments. See the README.md for more info on how this works.
+    required: false
+  configPath:
+    description: Use this to specify the path of a riff-raff.yaml file if you'd rather that than enter the config in your workflow file directly.
+    required: false
   projectName:
     description: "Determines Riffraff project name. Use this to override the default `stack::app` naming convention."
     required: false

--- a/deleteRecursively/deleteRecursively.test.ts
+++ b/deleteRecursively/deleteRecursively.test.ts
@@ -1,0 +1,20 @@
+import { deleteRecursively } from "./deleteRecursively";
+
+it("should remove unsupported fields from config", () => {
+  const myObj = {
+    deployments: {
+      cfn: { sources: ["foo", "bar"], apple: "tree", count: 100 },
+      s3: { sources: ["zap"], count: 20 },
+    },
+  };
+
+  const want = {
+    deployments: {
+      cfn: { apple: "tree", count: 100 },
+      s3: { count: 20 },
+    },
+  };
+
+  const got = deleteRecursively(myObj, "sources");
+  expect(got).toEqual(want);
+});

--- a/deleteRecursively/deleteRecursively.ts
+++ b/deleteRecursively/deleteRecursively.ts
@@ -1,0 +1,15 @@
+// Recursively delete a path like 'foo.bar' from an object
+export const deleteRecursively = (obj: any, key: string): any => {
+  if (key === "") return obj;
+
+  if (Array.isArray(obj)) {
+    obj.forEach((val) => deleteRecursively(val, key));
+  } else if (typeof obj === "object" && obj != null) {
+    delete obj[key];
+    Object.entries(obj).forEach(([_, v]) => {
+      deleteRecursively(v, key);
+    });
+  }
+
+  return obj;
+};

--- a/file/file.ts
+++ b/file/file.ts
@@ -20,6 +20,10 @@ export const walk = <A>(path: string, fn: (path: string) => A): A[] => {
   return []; // Ignore block devices, symlinks, etc.
 };
 
+export const read = (filePath: string): string => {
+  return fs.readFileSync(filePath, "utf-8")
+}
+
 // Write to file, creating any directories as required
 export const write = (filePath: string, data: string): void => {
   const dir = path.dirname(filePath);

--- a/index.js
+++ b/index.js
@@ -38989,6 +38989,21 @@ var riffraffPrefix = (m) => {
   return [m.projectName, m.buildNumber].join("/");
 };
 
+// deleteRecursively/deleteRecursively.ts
+var deleteRecursively = (obj, key) => {
+  if (key === "")
+    return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach((val) => deleteRecursively(val, key));
+  } else if (typeof obj === "object" && obj != null) {
+    delete obj[key];
+    Object.entries(obj).forEach(([_, v]) => {
+      deleteRecursively(v, key);
+    });
+  }
+  return obj;
+};
+
 // index.ts
 var readConfigFile = (path2) => {
   const data = read(path2);
@@ -39019,7 +39034,8 @@ var main = async () => {
       data: rest
     };
   });
-  const rrYaml = dump(configObj);
+  const rrObj = deleteRecursively(configObj, "sources");
+  const rrYaml = dump(rrObj);
   const name = projectName ? projectName : defaultProjectName(app, configObj.stacks);
   const mfest = manifest(name);
   const manifestJSON = JSON.stringify(mfest);

--- a/index.js
+++ b/index.js
@@ -38909,6 +38909,9 @@ var walk = (path2, fn) => {
   }
   return [];
 };
+var read = (filePath) => {
+  return fs.readFileSync(filePath, "utf-8");
+};
 var write = (filePath, data) => {
   const dir = path.dirname(filePath);
   child_process.execSync(`mkdir -p ${dir}`);
@@ -38972,50 +38975,56 @@ var branchName = () => {
 var vcsURL = () => {
   return process.env.GITHUB_REPOSITORY ? "https://github.com/" + process.env.GITHUB_REPOSITORY : void 0;
 };
-var manifest = (app, stack, projectName) => {
-  const name = projectName ? projectName : `${stack}::${app}`;
+var manifest = (projectName) => {
   return {
     branch: branchName() ?? "dev",
     vcsURL: vcsURL() ?? "dev",
     revision: process.env.GITHUB_SHA || "dev",
     buildNumber: process.env.GITHUB_RUN_NUMBER || "dev",
-    projectName: name,
+    projectName,
     startTime: new Date()
   };
-};
-var riffraffYaml = (stack, deployments) => {
-  const rrYaml = {
-    stacks: [stack],
-    regions: ["eu-west-1"],
-    deployments: deployments.reduce((acc, deployment) => __spreadProps(__spreadValues({}, acc), { [deployment.name]: deployment.data }), {})
-  };
-  return dump(rrYaml);
 };
 var riffraffPrefix = (m) => {
   return [m.projectName, m.buildNumber].join("/");
 };
 
 // index.ts
+var readConfigFile = (path2) => {
+  const data = read(path2);
+  return load(data);
+};
+var defaultProjectName = (app, stacks) => {
+  if (stacks.length < 1) {
+    throw new Error("Must provide at least one stack.");
+  }
+  return `${stacks[0]}::${app}`;
+};
 var main = async () => {
-  const app = core3.getInput("app");
-  const stack = core3.getInput("stack");
+  const app = core3.getInput("app", { required: true });
+  const config = core3.getInput("config");
+  const configPath = core3.getInput("configPath");
   const projectName = core3.getInput("projectName");
   const dryRun = core3.getInput("dryRun");
-  const deploymentsYaml = core3.getInput("deployments");
-  const deploymentsObj = load(deploymentsYaml);
-  core3.info(`Inputs are: dryRun: ${dryRun}; app: ${app}; stack: ${stack}; deployments: ${JSON.stringify(deploymentsObj)}`);
-  const deployments = Object.entries(deploymentsObj).map(([name, data]) => {
+  if (!config && !configPath) {
+    throw new Error("Must specify either config or configPath.");
+  }
+  const configObj = config ? load(config) : readConfigFile(configPath);
+  core3.info(`Inputs are: dryRun: ${dryRun}; app: ${app}; config: ${JSON.stringify(configObj)}}`);
+  const deployments = Object.entries(configObj.deployments).map(([name2, data]) => {
     const _a = data, { sources } = _a, rest = __objRest(_a, ["sources"]);
     return {
-      name,
-      sources: sources.split(",").map((source) => source.trim()),
+      name: name2,
+      sources: sources.map((source) => source.trim()),
       data: rest
     };
   });
-  const rrYaml = riffraffYaml(stack, deployments);
-  const mfest = manifest(app, stack, projectName);
+  const rrYaml = dump(configObj);
+  const name = projectName ? projectName : defaultProjectName(app, configObj.stacks);
+  const mfest = manifest(name);
   const manifestJSON = JSON.stringify(mfest);
   const stagingDir = "staging";
+  core3.info("writting rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, rrYaml);
   deployments.forEach((deployment) => {
     cp(deployment.sources, `${stagingDir}/${deployment.name}`);

--- a/index.test.ts
+++ b/index.test.ts
@@ -15,21 +15,26 @@ const readConfig = (yamlConfig: string): void => {
 };
 
 describe("action", () => {
-  it("should generate expected file structure", () => {
+  it("should generate expected file structure", async () => {
     child_process.execSync("rm -rf test-data");
     child_process.execSync("rm -rf staging");
 
     const input = `dryRun: true
 app: foo
-stack: deploy
-deployments: |
-  upload:
-    type: aws-s3
-    sources: test-data
-    parameters:
-      bucket: aws-some-bucket
-      cacheControl: private
-      publicReadAcl: false`;
+config: |
+  stacks:
+    - deploy
+  regions:
+    - eu-west-1
+  deployments:
+    upload:
+      type: aws-s3
+      sources:
+        - test-data
+      parameters:
+        bucket: aws-some-bucket
+        cacheControl: private
+        publicReadAcl: false`;
 
     const staging = "staging";
 
@@ -39,7 +44,7 @@ deployments: |
     child_process.execSync("touch test-data/foo.txt");
 
     readConfig(input);
-    main();
+    await main();
 
     const got = walk(staging, (path: string) => path);
 

--- a/index.ts
+++ b/index.ts
@@ -5,57 +5,66 @@ import { S3Client } from "@aws-sdk/client-s3";
 import type { Deployment, RiffraffYaml } from "./riffraff/riffraff";
 import { riffraffPrefix, manifest } from "./riffraff/riffraff";
 import { read, write, cp, printDir } from "./file/file";
+import { deleteRecursively } from "./deleteRecursively/deleteRecursively";
 
 const readConfigFile = (path: string): object => {
   const data = read(path);
   return yaml.load(data) as object;
-}
+};
 
 const defaultProjectName = (app: string, stacks: string[]): string => {
   if (stacks.length < 1) {
-    throw new Error("Must provide at least one stack.")
+    throw new Error("Must provide at least one stack.");
   }
 
   return `${stacks[0]}::${app}`;
-}
+};
 
 export const main = async (): Promise<void> => {
-  const app = core.getInput("app", {required: true});
+  const app = core.getInput("app", { required: true });
   const config = core.getInput("config");
   const configPath = core.getInput("configPath");
   const projectName = core.getInput("projectName");
   const dryRun = core.getInput("dryRun");
 
   if (!config && !configPath) {
-    throw new Error("Must specify either config or configPath.")
+    throw new Error("Must specify either config or configPath.");
   }
 
-  const configObj = (config ? yaml.load(config) : readConfigFile(configPath)) as RiffraffYaml;
+  const configObj = (
+    config ? yaml.load(config) : readConfigFile(configPath)
+  ) as RiffraffYaml;
   core.info(
-    `Inputs are: dryRun: ${dryRun}; app: ${app}; config: ${JSON.stringify(configObj)}}`
+    `Inputs are: dryRun: ${dryRun}; app: ${app}; config: ${JSON.stringify(
+      configObj
+    )}}`
   );
 
-  const deployments: Deployment[] = Object.entries(
-    configObj.deployments
-  ).map(([name, data]) => {
-    const { sources, ...rest } = data;
+  const deployments: Deployment[] = Object.entries(configObj.deployments).map(
+    ([name, data]) => {
+      const { sources, ...rest } = data;
 
-    return {
-      name: name,
-      sources: (sources as string[]).map((source) => source.trim()),
-      data: rest,
-    };
-  });
+      return {
+        name: name,
+        sources: (sources as string[]).map((source) => source.trim()),
+        data: rest,
+      };
+    }
+  );
 
-  const rrYaml = yaml.dump(configObj);
+  // ensure sources doesn't end up in rrYaml as RiffRaff errors with unexpected fields
+  const rrObj = deleteRecursively(configObj, "sources");
+  const rrYaml = yaml.dump(rrObj);
 
-  const name = projectName ? projectName : defaultProjectName(app, configObj.stacks);
+  const name = projectName
+    ? projectName
+    : defaultProjectName(app, configObj.stacks);
   const mfest = manifest(name);
   const manifestJSON = JSON.stringify(mfest);
 
   const stagingDir = "staging";
 
-  core.info("writting rr yaml...")
+  core.info("writting rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, rrYaml);
 
   deployments.forEach((deployment: Deployment) => {

--- a/riffraff/riffraff.test.ts
+++ b/riffraff/riffraff.test.ts
@@ -21,7 +21,7 @@ deployments:
       templatePath: Amiable.template.json
 `;
 
-    const got = riffraffYaml("deploy", [
+    const got = riffraffYaml(["deploy"], ["eu-west-1"], [
       {
         name: "amiable",
         sources: [],

--- a/riffraff/riffraff.ts
+++ b/riffraff/riffraff.ts
@@ -33,18 +33,14 @@ const vcsURL = (): string | undefined => {
 };
 
 export const manifest = (
-  app: string,
-  stack: string,
-  projectName?: string
+  projectName: string
 ): Manifest => {
-  const name = projectName ? projectName : `${stack}::${app}`;
-
   return {
     branch: branchName() ?? "dev",
     vcsURL: vcsURL() ?? "dev",
     revision: process.env.GITHUB_SHA || "dev",
     buildNumber: process.env.GITHUB_RUN_NUMBER || "dev",
-    projectName: name,
+    projectName: projectName,
     startTime: new Date(),
   };
 };
@@ -62,12 +58,13 @@ export type RiffraffYaml = {
 };
 
 export const riffraffYaml = (
-  stack: string,
+  stacks: string[],
+  regions: string[],
   deployments: Deployment[]
 ): string => {
   const rrYaml: RiffraffYaml = {
-    stacks: [stack],
-    regions: ["eu-west-1"],
+    stacks: stacks,
+    regions: regions,
     deployments: deployments.reduce(
       (acc, deployment) => ({ ...acc, [deployment.name]: deployment.data }),
       {}


### PR DESCRIPTION
Previously, a partial riff-raff config was accepted, with stack and region(s) specified separately. This approach didn't support multilpe regions or stacks and also would require changes if/as riff-raff.yaml adds new fields.

To improve things, let's just accept a full/raw riff-raff.yaml config, either inlined into the (GHA) workflow file or via a file path.

E.g. now something like:

```
- uses: guardian/actions-riff-raff@main
  with:
    app: foo
    config: |
      stacks:
        - deploy
      regions:
        - eu-west-1
      allowedStages:
        - CODE
        - PROD
      deployments:
        upload:
          type: aws-s3
          sources:
            - test-data
          parameters:
            bucket: aws-some-bucket
            cacheControl: private
            publicReadAcl: false
```