### PR TITLE
Ensure staging dir changes across runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ Use the `dryRun` flag to print outputs rather than upload.
 
 ## Local development
 
-Edit the Typescript as usual and remember to build (`npm run build`) before
-committing.
+Edit the Typescript as usual and **remember to build** (`npm run build`) before
+committing to ensure `index.js` is updated.

--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ Use the `dryRun` flag to print outputs rather than upload.
 
 Edit the Typescript as usual and **remember to build** (`npm run build`) before
 committing to ensure `index.js` is updated.
+
+After merging into `main`, assuming it is not a breaking change (please avoid
+these for as long as possible!), write to the `v1` tag and also add a new
+`v1.x.x` tag as appropriate and create a release for that too.

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,9 @@ inputs:
   buildNumber:
     description: If set, will be used for the build number. (Typically this is read from process.env.GITHUB_RUN_NUMBER.)
     required: false
+  stagingDir:
+    description: Used to set staging directory. You should not need to set this; it is intended for internal (testing) use only.
+    required: false
 runs:
   using: "node16"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ var require_file_command = __commonJS({
     };
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.issueCommand = void 0;
-    var fs3 = __importStar(require("fs"));
+    var fs4 = __importStar(require("fs"));
     var os = __importStar(require("os"));
     var utils_1 = require_utils();
     function issueCommand(command, message) {
@@ -212,10 +212,10 @@ var require_file_command = __commonJS({
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
       }
-      if (!fs3.existsSync(filePath)) {
+      if (!fs4.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
       }
-      fs3.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+      fs4.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
         encoding: "utf8"
       });
     }
@@ -39005,6 +39005,7 @@ var deleteRecursively = (obj, key) => {
 };
 
 // index.ts
+var fs3 = __toESM(require("fs"));
 var readConfigFile = (path2) => {
   const data = read(path2);
   return load(data);
@@ -39022,6 +39023,7 @@ var main = async () => {
   const projectName = core3.getInput("projectName");
   const dryRun = core3.getInput("dryRun");
   const buildNumber = core3.getInput("buildNumber");
+  const stagingDirOverride = core3.getInput("stagingDir");
   if (!config && !configPath) {
     throw new Error("Must specify either config or configPath.");
   }
@@ -39040,7 +39042,7 @@ var main = async () => {
   const name = projectName ? projectName : defaultProjectName(app, configObj.stacks);
   const mfest = manifest(name, buildNumber);
   const manifestJSON = JSON.stringify(mfest);
-  const stagingDir = "staging";
+  const stagingDir = stagingDirOverride || fs3.mkdtempSync("staging-");
   core3.info("writting rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, rrYaml);
   deployments.forEach((deployment) => {

--- a/index.test.ts
+++ b/index.test.ts
@@ -21,6 +21,7 @@ describe("action", () => {
 
     const input = `dryRun: true
 app: foo
+stagingDir: staging
 config: |
   stacks:
     - deploy
@@ -37,6 +38,7 @@ config: |
         publicReadAcl: false`;
 
     const staging = "staging";
+    child_process.execSync("rm -rf staging*");
 
     const want = [`${staging}/riff-raff.yaml`, `${staging}/upload/foo.txt`];
 


### PR DESCRIPTION
The action may be invoked in multiple steps within a workflow. We need to ensure a different staging directory is used each time to avoid sharing files here.

cc @tomrf1 and @tjmw 