### PR TITLE
Fix possible source of race condition in RR

### DIFF
--- a/index.js
+++ b/index.js
@@ -39057,8 +39057,8 @@ var main = async () => {
   const store = new S3Store(new import_client_s32.S3Client({ region: "eu-west-1" }));
   const keyPrefix = riffraffPrefix(mfest);
   core3.info(`S3 prefix: ${keyPrefix}`);
-  await store.put(Buffer.from(manifestJSON, "utf8"), "riffraff-builds", keyPrefix + "/build.json");
   await sync(store, stagingDir, "riffraff-artifact", keyPrefix);
+  await store.put(Buffer.from(manifestJSON, "utf8"), "riffraff-builds", keyPrefix + "/build.json");
   core3.info("Upload complete.");
 };
 try {

--- a/index.ts
+++ b/index.ts
@@ -89,12 +89,15 @@ export const main = async (): Promise<void> => {
 
   core.info(`S3 prefix: ${keyPrefix}`);
 
+  await sync(store, stagingDir, "riffraff-artifact", keyPrefix);
+
+  // Do this bit last to avoid any race conditions, as this is the file that
+  // triggers RR CD.
   await store.put(
     Buffer.from(manifestJSON, "utf8"),
     "riffraff-builds",
     keyPrefix + "/build.json"
   );
-  await sync(store, stagingDir, "riffraff-artifact", keyPrefix);
 
   core.info("Upload complete.");
 };


### PR DESCRIPTION
*Note, this is somewhat of a guess and may not resolve the issue but seems sensible to do anyway given how RR works. *

Apps Metering are seeing some RR deploy failures (e.g. [here](https://riffraff.gutools.co.uk/deployment/view/f78a8db0-69c7-48ef-b09d-9440f34a7ddc)), where RR is saying artifact files do not exist. This is possibly a race
condition caused by the order this action uploads files.

RR builds are triggered by the build.json upload so let's do that last to avoid any issues.

Note, `sbt-riffraff-artifact` also does this ordering (manifest last), which reinforces that this is the way to go here: https://github.com/guardian/sbt-riffraff-artifact/blob/main/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala#L148.