### PR TITLE
fix: Support `riff-raff.yaml` files without top-level `stacks`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,8 @@ name: "guardian/actions-riff-raff"
 description: "Build and upload Riff Raff artifacts."
 inputs:
   app:
-    description: Riff Raff app name.
-    required: true
+    description: Riff Raff app name. Either this or projectName should be set.
+    required: false
   config:
     description: Riff Raff configuration (what would normally go in a riff-raff.yaml file). Use `|` to provide a multiline string here. The format should be the same as a normal riff-raff.yaml but with an additional 'sources' list property that can be added to deployments. See the README.md for more info on how this works.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -38343,7 +38343,7 @@ var defaultProjectName = (app, stacks) => {
   return `${stacks[0]}::${app}`;
 };
 var main = async () => {
-  const app = core3.getInput("app", { required: true });
+  const app = core3.getInput("app");
   const config = core3.getInput("config");
   const configPath = core3.getInput("configPath");
   const projectName = core3.getInput("projectName");
@@ -38353,12 +38353,19 @@ var main = async () => {
   if (!config && !configPath) {
     throw new Error("Must specify either config or configPath.");
   }
-  const configObj = config ? load(config) : readConfigFile(configPath);
-  core3.info(
-    `Inputs are: dryRun: ${dryRun}; app: ${app}; config: ${JSON.stringify(
-      configObj
-    )}}`
-  );
+  if (!app && !projectName) {
+    throw new Error("Must specify either app or projectName.");
+  }
+  const configObjFromInput = config ? load(config) : readConfigFile(configPath);
+  const configObj = {
+    ...{ stacks: [] },
+    ...configObjFromInput
+  };
+  if (configObj.stacks.length !== 1 && !projectName) {
+    throw new Error(
+      `Unable to determine project name as 'projectName' is not set and unable to determine a unique stack value from the loaded config. If deploying to multiple stacks, explicitly set the 'projectName' input.`
+    );
+  }
   const deployments = Object.entries(configObj.deployments).map(
     ([name2, { sources = [], ...rest }]) => {
       return {


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A valid `riff-raff.yaml` file does not need to have `stacks` defined at the top level; it can be defined per deployment instead.

<details>
<summary>Example `riff-raff.yaml` without top level `stacks`</summary>

```yaml
allowedStages:
  - PROD
deployments:
  lambda-upload-eu-west-1-playground-cdk-playground-lambda:
    type: aws-lambda
    stacks:
      - playground
    regions:
      - eu-west-1
    app: cdk-playground-lambda
    contentDirectory: cdk-playground-lambda
    parameters:
      bucketSsmLookup: true
      lookupByTags: true
      fileName: cdk-playground-lambda.zip
    actions:
      - uploadLambda
  asg-upload-eu-west-1-playground-cdk-playground:
    type: autoscaling
    actions:
      - uploadArtifacts
    regions:
      - eu-west-1
    stacks:
      - playground
    app: cdk-playground
    parameters:
      bucketSsmLookup: true
      prefixApp: true
    contentDirectory: cdk-playground
  cfn-eu-west-1-playground-cdk-playground:
    type: cloud-formation
    regions:
      - eu-west-1
    stacks:
      - playground
    app: cdk-playground
    contentDirectory: cdk.out
    parameters:
      templateStagePaths:
        PROD: CdkPlayground.template.json
      amiParameter: AMICdkplayground
      amiTags:
        BuiltBy: amigo
        Recipe: arm64-bionic-java11-deploy-infrastructure
        AmigoStage: PROD
    dependencies:
      - lambda-upload-eu-west-1-playground-cdk-playground-lambda
      - asg-upload-eu-west-1-playground-cdk-playground
  lambda-update-eu-west-1-playground-cdk-playground-lambda:
    type: aws-lambda
    stacks:
      - playground
    regions:
      - eu-west-1
    app: cdk-playground-lambda
    contentDirectory: cdk-playground-lambda
    parameters:
      bucketSsmLookup: true
      lookupByTags: true
      fileName: cdk-playground-lambda.zip
    actions:
      - updateLambda
    dependencies:
      - cfn-eu-west-1-playground-cdk-playground
  asg-update-eu-west-1-playground-cdk-playground:
    type: autoscaling
    actions:
      - deploy
    regions:
      - eu-west-1
    stacks:
      - playground
    app: cdk-playground
    parameters:
      bucketSsmLookup: true
      prefixApp: true
    dependencies:
      - cfn-eu-west-1-playground-cdk-playground
    contentDirectory: cdk-playground
```

</details>

We currently use the value of stacks to create a default project name.

In this change we require `stacks` to have exactly 1 item for this, else require the `projectName` input to be set.

An alternative to this, is to make the `projectName` input required and remove the automatic project name logic. This would be a breaking change.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Not sure yet...