### PR TITLE
Fix build number

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2050,7 +2050,7 @@ var require_core = __commonJS({
       process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
     }
     exports.addPath = addPath;
-    function getInput2(name, options) {
+    function getInput3(name, options) {
       const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
       if (options && options.required && !val) {
         throw new Error(`Input required and not supplied: ${name}`);
@@ -2060,16 +2060,16 @@ var require_core = __commonJS({
       }
       return val.trim();
     }
-    exports.getInput = getInput2;
+    exports.getInput = getInput3;
     function getMultilineInput(name, options) {
-      const inputs = getInput2(name, options).split("\n").filter((x) => x !== "");
+      const inputs = getInput3(name, options).split("\n").filter((x) => x !== "");
       return inputs;
     }
     exports.getMultilineInput = getMultilineInput;
     function getBooleanInput(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
-      const val = getInput2(name, options);
+      const val = getInput3(name, options);
       if (trueValue.includes(val))
         return true;
       if (falseValue.includes(val))
@@ -38342,14 +38342,18 @@ var defaultProjectName = (app, stacks) => {
   }
   return `${stacks[0]}::${app}`;
 };
+var getInput2 = (name, options) => {
+  const got = core3.getInput(name, options);
+  return got === "" ? void 0 : got;
+};
 var main = async () => {
-  const app = core3.getInput("app");
-  const config = core3.getInput("config");
-  const configPath = core3.getInput("configPath");
-  const projectName = core3.getInput("projectName");
-  const dryRun = core3.getInput("dryRun");
-  const buildNumber = core3.getInput("buildNumber");
-  const stagingDirOverride = core3.getInput("stagingDir");
+  const app = getInput2("app");
+  const config = getInput2("config");
+  const configPath = getInput2("configPath");
+  const projectName = getInput2("projectName");
+  const dryRun = getInput2("dryRun");
+  const buildNumber = getInput2("buildNumber");
+  const stagingDirOverride = getInput2("stagingDir");
   if (!config && !configPath) {
     throw new Error("Must specify either config or configPath.");
   }
@@ -38380,7 +38384,7 @@ var main = async () => {
   const name = projectName ? projectName : defaultProjectName(app, configObj.stacks);
   const mfest = manifest(name, buildNumber);
   const manifestJSON = JSON.stringify(mfest);
-  const stagingDir = stagingDirOverride || fs3.mkdtempSync("staging-");
+  const stagingDir = stagingDirOverride ?? fs3.mkdtempSync("staging-");
   core3.info("writting rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, rrYaml);
   deployments.forEach((deployment) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,20 @@ const defaultProjectName = (app: string, stacks: string[]): string => {
 	return `${stacks[0]}::${app}`;
 };
 
+// getInput is like core.getInput but returns undefined for the empty string.
+const getInput = (name: string, options?: core.InputOptions): string | undefined => {
+  const got = core.getInput(name, options);
+  return got === "" ? undefined : got;
+}
+
 export const main = async (): Promise<void> => {
-	const app = core.getInput('app');
-	const config = core.getInput('config');
-	const configPath = core.getInput('configPath');
-	const projectName = core.getInput('projectName');
-	const dryRun = core.getInput('dryRun');
-	const buildNumber = core.getInput('buildNumber');
-	const stagingDirOverride = core.getInput('stagingDir');
+	const app = getInput('app');
+	const config = getInput('config');
+	const configPath = getInput('configPath');
+	const projectName = getInput('projectName');
+	const dryRun = getInput('dryRun');
+	const buildNumber = getInput('buildNumber');
+	const stagingDirOverride = getInput('stagingDir');
 
 	if (!config && !configPath) {
 		throw new Error('Must specify either config or configPath.');
@@ -40,7 +46,7 @@ export const main = async (): Promise<void> => {
 	}
 
 	const configObjFromInput = (
-		config ? yaml.load(config) : readConfigFile(configPath)
+		config ? yaml.load(config) : readConfigFile(configPath as string)
 	) as RiffraffYaml;
 
 	const configObj: RiffraffYaml = {
@@ -77,13 +83,13 @@ export const main = async (): Promise<void> => {
 
 	const name = projectName
 		? projectName
-		: defaultProjectName(app, configObj.stacks);
+		: defaultProjectName(app as string, configObj.stacks);
 	const mfest = manifest(name, buildNumber);
 	const manifestJSON = JSON.stringify(mfest);
 
 	// Ensure unique name as multiple steps may run using this action within the
 	// same workflow (this has happened!).
-	const stagingDir = stagingDirOverride || fs.mkdtempSync('staging-');
+	const stagingDir = stagingDirOverride ?? fs.mkdtempSync('staging-');
 
 	core.info('writting rr yaml...');
 	write(`${stagingDir}/riff-raff.yaml`, rrYaml);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,13 @@ const defaultProjectName = (app: string, stacks: string[]): string => {
 };
 
 // getInput is like core.getInput but returns undefined for the empty string.
-const getInput = (name: string, options?: core.InputOptions): string | undefined => {
-  const got = core.getInput(name, options);
-  return got === "" ? undefined : got;
-}
+const getInput = (
+	name: string,
+	options?: core.InputOptions,
+): string | undefined => {
+	const got = core.getInput(name, options);
+	return got === '' ? undefined : got;
+};
 
 export const main = async (): Promise<void> => {
 	const app = getInput('app');

--- a/src/riffraff.test.ts
+++ b/src/riffraff.test.ts
@@ -1,4 +1,4 @@
-import { riffraffPrefix } from './riffraff';
+import { manifest, riffraffPrefix } from './riffraff';
 import type { Manifest } from './riffraff';
 
 describe('riffraff', () => {
@@ -16,5 +16,13 @@ describe('riffraff', () => {
 		const want = 'example/10';
 
 		expect(got).toBe(want);
+	});
+
+  it('should fallback to "dev" when buildNumber empty', () => {
+		delete process.env.GITHUB_RUN_NUMBER;
+    const got = manifest("example", undefined);
+    const want = "dev";
+
+    expect(got.buildNumber).toBe(want);
 	});
 });

--- a/src/riffraff.test.ts
+++ b/src/riffraff.test.ts
@@ -18,11 +18,11 @@ describe('riffraff', () => {
 		expect(got).toBe(want);
 	});
 
-  it('should fallback to "dev" when buildNumber empty', () => {
+	it('should fallback to "dev" when buildNumber empty', () => {
 		delete process.env.GITHUB_RUN_NUMBER;
-    const got = manifest("example", undefined);
-    const want = "dev";
+		const got = manifest('example', undefined);
+		const want = 'dev';
 
-    expect(got.buildNumber).toBe(want);
+		expect(got.buildNumber).toBe(want);
 	});
 });


### PR DESCRIPTION
* coerce buildNumber input empty string into undefined for clarity (and the same for other inputs too)
* adds a test to ensure we use `dev` as fallback for build number. We do not test for the empty string handling though as we want to assume inputs are good at this point

(Fixes bug from https://github.com/guardian/actions-riff-raff/pull/15.)