### PR TITLE
refactor: Read all configuration early

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,126 @@
+import * as core from '@actions/core';
+import * as yaml from 'js-yaml';
+import { read } from './file';
+import type { RiffraffYaml } from './riffraff';
+
+// getInput is like core.getInput but returns undefined for the empty string.
+const getInput = (
+	name: string,
+	options?: core.InputOptions,
+): string | undefined => {
+	const got = core.getInput(name, options);
+	return got === '' ? undefined : got;
+};
+
+const readConfigFile = (path: string): object => {
+	const data = read(path);
+	return yaml.load(data) as object;
+};
+
+const getProjectName = ({ stacks }: RiffraffYaml): string => {
+	const appInput = getInput('app');
+	const projectNameInput = getInput('projectName');
+
+	if (!appInput && !projectNameInput) {
+		throw new Error('Must specify either app or projectName.');
+	}
+
+	if (projectNameInput) {
+		return projectNameInput;
+	}
+
+	const numberOfStacks = stacks.length;
+
+	if (numberOfStacks === 1 && appInput) {
+		const stack = stacks[0] as string;
+		return `${stack}::${appInput}`;
+	} else {
+		throw new Error(
+			`Unable to generate a project name as multiple stacks detected (${stacks.join(
+				',',
+			)}).`,
+		);
+	}
+};
+
+const getRiffRaffYaml = (): RiffraffYaml => {
+	const configInput = getInput('config');
+	const configPathInput = getInput('configPath');
+
+	if (!configInput && !configPathInput) {
+		throw new Error('Must specify either config or configPath.');
+	}
+
+	const configObjFromInput = (
+		configInput
+			? yaml.load(configInput)
+			: readConfigFile(configPathInput as string)
+	) as RiffraffYaml;
+
+	return {
+		/*
+    A valid `riff-raff.yaml` does not need to have `stacks` at the root level, it can be defined within each individual deployment.
+    This action uses the top level `stacks` to create a default project name.
+    This is a little hack to enable this behaviour, else we'd have to start validating `stacks` within each deployment.
+    We create a default project name if and only if `stacks` has a single value.
+     */
+		...{ stacks: [] },
+
+		...configObjFromInput,
+	};
+};
+
+const envOrUndefined = (variableName: string): string | undefined => {
+	const maybeEnvVar = process.env[variableName];
+	return maybeEnvVar && maybeEnvVar.trim() !== ''
+		? maybeEnvVar.trim()
+		: undefined;
+};
+
+const branchName = (): string | undefined => {
+	// `GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).
+	// `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge`).
+	// Either can be the empty string ¯\_(ツ)_/¯
+	// See https://docs.github.com/en/actions/learn-github-actions/environment-variables
+	const branchName =
+		envOrUndefined('GITHUB_HEAD_REF') ?? envOrUndefined('GITHUB_REF');
+	return branchName ? branchName.replace('refs/heads/', '') : undefined;
+};
+
+const vcsURL = (): string | undefined => {
+	const repoFromEnv = envOrUndefined('GITHUB_REPOSITORY');
+	return repoFromEnv ? `https://github.com/${repoFromEnv}` : undefined;
+};
+
+export interface Configuration {
+	projectName: string;
+	riffRaffYaml: RiffraffYaml;
+	dryRun: boolean;
+	buildNumber: string;
+	branchName: string;
+	vcsURL: string;
+	revision: string;
+	stagingDirInput?: string;
+}
+
+export function getConfiguration(): Configuration {
+	const riffRaffYaml = getRiffRaffYaml();
+	const projectName = getProjectName(riffRaffYaml);
+	const dryRunInput = getInput('dryRun');
+	const buildNumberInput = getInput('buildNumber');
+	const stagingDirInput = getInput('stagingDir');
+
+	const buildNumber =
+		buildNumberInput ?? envOrUndefined('GITHUB_RUN_NUMBER') ?? 'dev';
+
+	return {
+		projectName,
+		riffRaffYaml,
+		dryRun: dryRunInput === 'true',
+		buildNumber,
+		branchName: branchName() ?? 'dev',
+		vcsURL: vcsURL() ?? 'dev',
+		revision: envOrUndefined('GITHUB_SHA') ?? 'dev',
+		stagingDirInput,
+	};
+}

--- a/src/riffraff.test.ts
+++ b/src/riffraff.test.ts
@@ -1,4 +1,4 @@
-import { manifest, riffraffPrefix } from './riffraff';
+import { riffraffPrefix } from './riffraff';
 import type { Manifest } from './riffraff';
 
 describe('riffraff', () => {
@@ -16,13 +16,5 @@ describe('riffraff', () => {
 		const want = 'example/10';
 
 		expect(got).toBe(want);
-	});
-
-	it('should fallback to "dev" when buildNumber empty', () => {
-		delete process.env.GITHUB_RUN_NUMBER;
-		const got = manifest('example', undefined);
-		const want = 'dev';
-
-		expect(got.buildNumber).toBe(want);
 	});
 });

--- a/src/riffraff.ts
+++ b/src/riffraff.ts
@@ -7,39 +7,19 @@ export type Manifest = {
 	startTime: Date;
 };
 
-const envOrUndefined = (variableName: string): string | undefined => {
-	const maybeEnvVar = process.env[variableName];
-	return maybeEnvVar && maybeEnvVar.trim() !== ''
-		? maybeEnvVar.trim()
-		: undefined;
-};
-
-const branchName = (): string | undefined => {
-	// `GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).
-	// `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge`).
-	// Either can be the empty string ¯\_(ツ)_/¯
-	// See https://docs.github.com/en/actions/learn-github-actions/environment-variables
-	const branchName =
-		envOrUndefined('GITHUB_HEAD_REF') ?? envOrUndefined('GITHUB_REF');
-	return branchName ? branchName.replace('refs/heads/', '') : undefined;
-};
-
-const vcsURL = (): string | undefined => {
-	return process.env.GITHUB_REPOSITORY
-		? 'https://github.com/' + process.env.GITHUB_REPOSITORY
-		: undefined;
-};
-
 export const manifest = (
 	projectName: string,
-	buildNumber?: string,
+	buildNumber: string,
+	branch: string,
+	vcsURL: string,
+	revision: string,
 ): Manifest => {
 	return {
-		branch: branchName() ?? 'dev',
-		vcsURL: vcsURL() ?? 'dev',
-		revision: process.env.GITHUB_SHA ?? 'dev',
-		buildNumber: buildNumber ?? process.env.GITHUB_RUN_NUMBER ?? 'dev',
-		projectName: projectName,
+		branch,
+		vcsURL,
+		revision,
+		buildNumber,
+		projectName,
 		startTime: new Date(),
 	};
 };


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In this change we build a configuration object at the very start of execution, allowing us to fail fast if there are any errors.

This change also co-locates all configuration into a single place, making it easier to reason about.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Tested in https://github.com/guardian/devx-logs/pull/21 and things are working as expected:

<img width="883" alt="image" src="https://user-images.githubusercontent.com/836140/189204324-6402801f-daeb-4f4f-adf6-66555ca85d83.png">