### PR TITLE
Display build number in summary and support offsetting of Riff Raff Build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ A path to a `riff-raff.yaml` file.
 ### `buildNumber`
 Used to override the default build number, for example, if you want to offset it.
 
+### `buildNumberOffset`
+If provided, this should be a number which will be added to the
+`buildNumber`. This can be used, for example, when migrating from another build
+system, to force the build numbers produced by this action to continue after the
+last build from the previous build system. For example, if the last build from
+the previous system was build 45, setting this offset to 45 will mean that the
+first build produced by this action will be 46.
+
 ### `contentDirectories`
 *Required*
 

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,9 @@ inputs:
   buildNumber:
     description: If set, will be used for the build number. (Typically this is read from process.env.GITHUB_RUN_NUMBER.)
     required: false
+  buildNumberOffset:
+    description: If set, will be added to the build number. (e.g. to offset builds to count from builds generated from a previous build tool)
+    required: false
   stagingDir:
     description: Used to set staging directory. You should not need to set this; it is intended for internal (testing) use only.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -38337,9 +38337,6 @@ var vcsURL = () => {
   return repoFromEnv ? `https://github.com/${repoFromEnv}` : void 0;
 };
 var offsetBuildNumber = (buildNumber, offset) => {
-  if (typeof offset === "undefined") {
-    return buildNumber;
-  }
   const intOffset = parseInt(offset);
   const intBuildNumber = parseInt(buildNumber);
   if (isNaN(intOffset) || isNaN(intBuildNumber)) {
@@ -38353,7 +38350,7 @@ function getConfiguration() {
   const projectName = getProjectName(riffRaffYaml);
   const dryRunInput = getInput2("dryRun");
   const buildNumberInput = getInput2("buildNumber");
-  const buildNumberOffset = getInput2("buildNumberOffset");
+  const buildNumberOffset = getInput2("buildNumberOffset") ?? "0";
   const stagingDirInput = getInput2("stagingDir");
   const baseBuildNumber = buildNumberInput ?? envOrUndefined("GITHUB_RUN_NUMBER") ?? "dev";
   const buildNumber = offsetBuildNumber(baseBuildNumber, buildNumberOffset);
@@ -38437,7 +38434,10 @@ var main = async () => {
   );
   const manifestJSON = JSON.stringify(mfest);
   const stagingDir = stagingDirInput ?? fs3.mkdtempSync("staging-");
-  await core4.summary.addHeading("Riff-Raff").addTable([["Build number", buildNumber]]).write();
+  await core4.summary.addHeading("Riff-Raff").addTable([
+    ["Project name", projectName],
+    ["Build number", buildNumber]
+  ]).write();
   core4.info("writting rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, dump(riffRaffYaml));
   deployments.forEach((deployment) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38345,7 +38345,7 @@ var offsetBuildNumber = (buildNumber, offset) => {
   if (isNaN(intOffset) || isNaN(intBuildNumber)) {
     return buildNumber;
   } else {
-    return `${buildNumber + offsetBuildNumber}`;
+    return `${buildNumber + intOffset}`;
   }
 };
 function getConfiguration() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38342,7 +38342,7 @@ var offsetBuildNumber = (buildNumber, offset) => {
   if (isNaN(intOffset) || isNaN(intBuildNumber)) {
     return buildNumber;
   } else {
-    return `${intBuildNumber + intOffset}`;
+    return (intBuildNumber + intOffset).toString();
   }
 };
 function getConfiguration() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38423,6 +38423,7 @@ var main = async () => {
   );
   const manifestJSON = JSON.stringify(mfest);
   const stagingDir = stagingDirInput ?? fs3.mkdtempSync("staging-");
+  await core4.summary.addTable([["Riff-raff build Number", buildNumber]]).write();
   core4.info("writting rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, dump(riffRaffYaml));
   deployments.forEach((deployment) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38345,7 +38345,7 @@ var offsetBuildNumber = (buildNumber, offset) => {
   if (isNaN(intOffset) || isNaN(intBuildNumber)) {
     return buildNumber;
   } else {
-    return `${buildNumber + intOffset}`;
+    return `${intBuildNumber + intOffset}`;
   }
 };
 function getConfiguration() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38336,13 +38336,27 @@ var vcsURL = () => {
   const repoFromEnv = envOrUndefined("GITHUB_REPOSITORY");
   return repoFromEnv ? `https://github.com/${repoFromEnv}` : void 0;
 };
+var offsetBuildNumber = (buildNumber, offset) => {
+  if (typeof offset === "undefined") {
+    return buildNumber;
+  }
+  const intOffset = parseInt(offset);
+  const intBuildNumber = parseInt(buildNumber);
+  if (isNaN(intOffset) || isNaN(intBuildNumber)) {
+    return buildNumber;
+  } else {
+    return `${buildNumber + offsetBuildNumber}`;
+  }
+};
 function getConfiguration() {
   const riffRaffYaml = getRiffRaffYaml();
   const projectName = getProjectName(riffRaffYaml);
   const dryRunInput = getInput2("dryRun");
   const buildNumberInput = getInput2("buildNumber");
+  const buildNumberOffset = getInput2("buildNumberOffset");
   const stagingDirInput = getInput2("stagingDir");
-  const buildNumber = buildNumberInput ?? envOrUndefined("GITHUB_RUN_NUMBER") ?? "dev";
+  const baseBuildNumber = buildNumberInput ?? envOrUndefined("GITHUB_RUN_NUMBER") ?? "dev";
+  const buildNumber = offsetBuildNumber(baseBuildNumber, buildNumberOffset);
   return {
     projectName,
     riffRaffYaml,
@@ -38423,7 +38437,7 @@ var main = async () => {
   );
   const manifestJSON = JSON.stringify(mfest);
   const stagingDir = stagingDirInput ?? fs3.mkdtempSync("staging-");
-  await core4.summary.addTable([["Riff-raff build Number", buildNumber]]).write();
+  await core4.summary.addHeading("Riff-Raff").addTable([["Build number", buildNumber]]).write();
   core4.info("writting rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, dump(riffRaffYaml));
   deployments.forEach((deployment) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,13 +129,7 @@ export interface Configuration {
 	stagingDirInput?: string;
 }
 
-const offsetBuildNumber = (
-	buildNumber: string,
-	offset: string | undefined,
-): string => {
-	if (typeof offset === 'undefined') {
-		return buildNumber;
-	}
+const offsetBuildNumber = (buildNumber: string, offset: string): string => {
 	const intOffset = parseInt(offset);
 	const intBuildNumber = parseInt(buildNumber);
 	if (isNaN(intOffset) || isNaN(intBuildNumber)) {
@@ -150,7 +144,7 @@ export function getConfiguration(): Configuration {
 	const projectName = getProjectName(riffRaffYaml);
 	const dryRunInput = getInput('dryRun');
 	const buildNumberInput = getInput('buildNumber');
-	const buildNumberOffset = getInput('buildNumberOffset');
+	const buildNumberOffset = getInput('buildNumberOffset') ?? '0';
 	const stagingDirInput = getInput('stagingDir');
 
 	const baseBuildNumber =

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,7 @@ const offsetBuildNumber = (buildNumber: string, offset: string | undefined): str
 	if(isNaN(intOffset) || isNaN(intBuildNumber)) {
 		return buildNumber;
 	} else {
-		return `${buildNumber + intOffset}`;
+		return `${intBuildNumber + intOffset}`;
 	}
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,7 @@ const offsetBuildNumber = (buildNumber: string, offset: string | undefined): str
 	if(isNaN(intOffset) || isNaN(intBuildNumber)) {
 		return buildNumber;
 	} else {
-		return `${buildNumber + offsetBuildNumber}`;
+		return `${buildNumber + intOffset}`;
 	}
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,7 +135,7 @@ const offsetBuildNumber = (buildNumber: string, offset: string): string => {
 	if (isNaN(intOffset) || isNaN(intBuildNumber)) {
 		return buildNumber;
 	} else {
-		return `${intBuildNumber + intOffset}`;
+		return (intBuildNumber + intOffset).toString();
 	}
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,15 +129,31 @@ export interface Configuration {
 	stagingDirInput?: string;
 }
 
+const offsetBuildNumber = (buildNumber: string, offset: string | undefined): string => {
+	if(typeof offset === 'undefined') {
+		return buildNumber;
+	}
+	const intOffset = parseInt(offset);
+	const intBuildNumber = parseInt(buildNumber);
+	if(isNaN(intOffset) || isNaN(intBuildNumber)) {
+		return buildNumber;
+	} else {
+		return `${buildNumber + offsetBuildNumber}`;
+	}
+}
+
 export function getConfiguration(): Configuration {
 	const riffRaffYaml = getRiffRaffYaml();
 	const projectName = getProjectName(riffRaffYaml);
 	const dryRunInput = getInput('dryRun');
 	const buildNumberInput = getInput('buildNumber');
+	const buildNumberOffset = getInput('buildNumberOffset');
 	const stagingDirInput = getInput('stagingDir');
 
-	const buildNumber =
+	const baseBuildNumber =
 		buildNumberInput ?? envOrUndefined('GITHUB_RUN_NUMBER') ?? 'dev';
+
+	const buildNumber = offsetBuildNumber(baseBuildNumber, buildNumberOffset);
 
 	return {
 		projectName,

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,18 +129,21 @@ export interface Configuration {
 	stagingDirInput?: string;
 }
 
-const offsetBuildNumber = (buildNumber: string, offset: string | undefined): string => {
-	if(typeof offset === 'undefined') {
+const offsetBuildNumber = (
+	buildNumber: string,
+	offset: string | undefined,
+): string => {
+	if (typeof offset === 'undefined') {
 		return buildNumber;
 	}
 	const intOffset = parseInt(offset);
 	const intBuildNumber = parseInt(buildNumber);
-	if(isNaN(intOffset) || isNaN(intBuildNumber)) {
+	if (isNaN(intOffset) || isNaN(intBuildNumber)) {
 		return buildNumber;
 	} else {
 		return `${intBuildNumber + intOffset}`;
 	}
-}
+};
 
 export function getConfiguration(): Configuration {
 	const riffRaffYaml = getRiffRaffYaml();

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,10 @@ export const main = async (): Promise<void> => {
 
 	await core.summary
 		.addHeading('Riff-Raff')
-		.addTable([['Build number', buildNumber]])
+		.addTable([
+			['Project name', projectName],
+			['Build number', buildNumber],
+		])
 		.write();
 
 	core.info('writting rr yaml...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,9 @@ export const main = async (): Promise<void> => {
 	const stagingDir = stagingDirInput ?? fs.mkdtempSync('staging-');
 
 	await core.summary
-		.addTable([['Riff-raff build Number', buildNumber]])
-		.write()
+		.addHeading('Riff-Raff')
+		.addTable([['Build number', buildNumber]])
+		.write();
 
 	core.info('writting rr yaml...');
 	write(`${stagingDir}/riff-raff.yaml`, yaml.dump(riffRaffYaml));

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export const main = async (): Promise<void> => {
 	// same workflow (this has happened!).
 	const stagingDir = stagingDirInput ?? fs.mkdtempSync('staging-');
 
+	await core.summary
+		.addTable([['Riff-raff build Number', buildNumber]])
+		.write()
+
 	core.info('writting rr yaml...');
 	write(`${stagingDir}/riff-raff.yaml`, yaml.dump(riffRaffYaml));
 


### PR DESCRIPTION
## What does this change?

This change address what I believe is a common use case, where a project has switched from a previous build tool to GitHub actions, and we want the GitHub Actions Riff-Raff build number to start counting from the last build number in the previous tool.

This also adds a "Riff Raff" section to the job summary which outputs the build number selected (whether or not it has been modified).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

If you provide the optional `buildNumberOffset` argument when calling this action, that value should be added to the build number (e.g. in the default case, without also providing a `buildNumber` parameter, this would get added to the GitHub Run Number).

If this optional parameter is not provided then the build number should remain unchanged.

In either case, after running the action, you should be able to click on the run to see it's summary, and at the bottom you will see a Riff Raff section outputting the build number.

An example of where I have run this on an actual build can be seen here:

https://github.com/guardian/kindle-publication-check/actions/runs/3439230129

## Images

This is an example of the output added to the job summary:

<img width="438" alt="image" src="https://user-images.githubusercontent.com/2242307/201172475-bc0daef4-977c-4491-963f-4e45df158f19.png">
