### PR TITLE
Error if contentDirectories invalid

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38297,7 +38297,9 @@ var getProjectName = ({ stacks }) => {
 };
 var isSources = (obj) => {
   if (typeof obj === "object") {
-    return Object.values(obj).every((source) => Array.isArray(source));
+    return Object.values(obj).every(
+      (source) => Array.isArray(source)
+    );
   }
   return false;
 };
@@ -38305,12 +38307,14 @@ var getDeployments = () => {
   const input = getInput2("contentDirectories", { required: true });
   const contentDirectoriesInput = input ? load(input) : {};
   if (!isSources(contentDirectoriesInput)) {
-    throw new Error(`Invalid contentDirectories. Each value must be a list of sources, but got: ${input ?? ""}`);
+    throw new Error(
+      `Invalid contentDirectories. Each value must be a list of sources, but got: ${input ?? ""}`
+    );
   }
   if (isSources(contentDirectoriesInput)) {
-    const deployments = Object.entries(contentDirectoriesInput).map(
-      ([name, sources]) => ({ name, sources })
-    );
+    const deployments = Object.entries(
+      contentDirectoriesInput
+    ).map(([name, sources]) => ({ name, sources }));
     const totalDeployments = deployments.reduce(
       (acc, { sources }) => acc + sources.length,
       0
@@ -38322,7 +38326,9 @@ var getDeployments = () => {
     }
     return deployments;
   }
-  throw new Error(`Invalid contentDirectories. Each value must be a list of sources, but got: ${input ?? ""}`);
+  throw new Error(
+    `Invalid contentDirectories. Each value must be a list of sources, but got: ${input ?? ""}`
+  );
 };
 var getRiffRaffYaml = () => {
   const configInput = getInput2("config");

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "jest",
     "tsc": "tsc --noEmit",
     "lint": "eslint src --ext .ts --no-error-on-unmatched-pattern",
-    "format": "prettier --check \"src/**/*.ts\""
+    "format": "prettier --check \"src/**/*.ts\"",
+    "format-fix": "prettier --write \"src/**/*.ts\""
   },
   "repository": {
     "type": "git",

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,45 +46,52 @@ const getProjectName = ({ stacks }: RiffraffYaml): string => {
 type Sources = Record<string, string[]>;
 
 const isSources = (obj: unknown): obj is Sources => {
-  if (typeof obj === 'object'){
-    return Object.values(obj as object).every(source => Array.isArray(source))
-  }
+	if (typeof obj === 'object') {
+		return Object.values(obj as object).every((source) =>
+			Array.isArray(source),
+		);
+	}
 
-  return false;
-
-}
+	return false;
+};
 
 const getDeployments = (): Deployment[] => {
 	const input = getInput('contentDirectories', { required: true });
 
-	const contentDirectoriesInput = input
-		? (yaml.load(input))
-		: {};
+	const contentDirectoriesInput = input ? yaml.load(input) : {};
 
-  if (!isSources(contentDirectoriesInput)) {
-    throw new Error(`Invalid contentDirectories. Each value must be a list of sources, but got: ${input ?? ''}`)
-  }
+	if (!isSources(contentDirectoriesInput)) {
+		throw new Error(
+			`Invalid contentDirectories. Each value must be a list of sources, but got: ${
+				input ?? ''
+			}`,
+		);
+	}
 
-  if (isSources(contentDirectoriesInput)) {
-    const deployments: Deployment[] = Object.entries(contentDirectoriesInput).map(
-      ([name, sources]) => ({ name, sources }),
-    );
+	if (isSources(contentDirectoriesInput)) {
+		const deployments: Deployment[] = Object.entries(
+			contentDirectoriesInput,
+		).map(([name, sources]) => ({ name, sources }));
 
-    const totalDeployments: number = deployments.reduce(
-      (acc, { sources }) => acc + sources.length,
-      0,
-    );
+		const totalDeployments: number = deployments.reduce(
+			(acc, { sources }) => acc + sources.length,
+			0,
+		);
 
-    if (totalDeployments === 0) {
-      throw new Error(
-        'Not configured with any deployment sources, no files will be uploaded to Riff-Raff.',
-      );
-    }
+		if (totalDeployments === 0) {
+			throw new Error(
+				'Not configured with any deployment sources, no files will be uploaded to Riff-Raff.',
+			);
+		}
 
-    return deployments;
-  }
+		return deployments;
+	}
 
-  throw new Error(`Invalid contentDirectories. Each value must be a list of sources, but got: ${input ?? ''}`)
+	throw new Error(
+		`Invalid contentDirectories. Each value must be a list of sources, but got: ${
+			input ?? ''
+		}`,
+	);
 };
 
 const getRiffRaffYaml = (): RiffraffYaml => {

--- a/src/file.ts
+++ b/src/file.ts
@@ -33,7 +33,7 @@ export const write = (filePath: string, data: string): void => {
 
 // Copy file or (recursive copy of) directory.
 export const cp = (sources: string[], destDir: string): void => {
-  child_process.execSync(`mkdir -p ${destDir}`); // ensure destDir exists
+	child_process.execSync(`mkdir -p ${destDir}`); // ensure destDir exists
 
 	sources.forEach((src) => {
 		const info = fs.lstatSync(src);


### PR DESCRIPTION
Designed to avoid the rather cryptic:

```
Run guardian/actions-riff-raff@v2
writting rr yaml...
Error: TypeError: sources.forEach is not a function
Error: sources.forEach is not a function
```

which I got on a project recently when I accidentally specified a contentDirectory as a single value rather than yaml list.