### PR TITLE
Use `aws-actions/configure-aws-credentials@v2` in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
     # Your usual build steps here...
 
     # Exchange OIDC JWT ID token for temporary AWS credentials to allow uploading to S3
-    - uses: aws-actions/configure-aws-credentials@v1
+    - uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-region: eu-west-1
         role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
The only change between v1 and v2 is the [underlying Node version used by the action](https://github.com/aws-actions/configure-aws-credentials/blob/60a5c129d08a5f7e035925bfdf8521e4d0f83a3a/README.md#recent-updates).