### PR TITLE
Set node version explicitly instead of looking up `.nvmrc`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,7 +37,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version-file: ${{ github.action_path }}/.nvmrc
+        node-version: "18.17.0"
     - name: Action
       run: node ${{ github.action_path }}/dist/index.js
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -37,7 +37,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version-file: .nvmrc
+        node-version-file: ${{ github.action_path }}/.nvmrc
     - name: Action
       run: node ${{ github.action_path }}/dist/index.js
       shell: bash


### PR DESCRIPTION
Some projects using the action might not have an `.nvmrc` file, which causes the action to fail. This change sets a node version of "18.17.0" explicitly, instead of reading an `.nvmrc` file.

Thanks @coldlink for flagging