### PR TITLE
Block deploys of repos without appropriate topics

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -63831,10 +63831,15 @@ var RiffRaffUploadError = class extends Error {
   }
 };
 function validateTopics(topics) {
-  const validTopicsForDeployment = ["production", "hackday", "prototype", "learning"];
-  const hasValidTopic = topics.some((topic) => validTopicsForDeployment.includes(topic));
+  const deployableTopics = ["production", "hackday", "prototype", "learning"];
+  const hasValidTopic = topics.some(
+    (topic) => deployableTopics.includes(topic)
+  );
   if (!hasValidTopic) {
-    throw new RiffRaffUploadError(`No valid repository topic found. Please add one of ${validTopicsForDeployment.join(", ")}`);
+    const topicList = deployableTopics.join(", ");
+    throw new RiffRaffUploadError(
+      `No valid repository topic found. Add one of ${topicList}`
+    );
   } else {
     core4.info("Valid topic found");
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -63834,14 +63834,14 @@ function validateTopics(topics) {
   const validTopicsForDeployment = ["production", "hackday", "prototype", "learning"];
   const hasValidTopic = topics.some((topic) => validTopicsForDeployment.includes(topic));
   if (!hasValidTopic) {
-    throw new RiffRaffUploadError(`No valid topic found in topics: ${topics}`);
+    throw new RiffRaffUploadError(`No valid repository topic found. Please add one of ${validTopicsForDeployment.join(", ")}`);
   } else {
     core4.info("Valid topic found");
   }
 }
 var main = async (options) => {
   const config = getConfiguration();
-  validateTopics(import_github2.context.payload.repository.topics);
+  validateTopics(import_github2.context.payload.repository?.topics);
   core4.debug(JSON.stringify(config, null, 2));
   const {
     riffRaffYaml,

--- a/dist/index.js
+++ b/dist/index.js
@@ -63824,9 +63824,24 @@ var sync = async (store, dir, bucket, keyPrefix) => {
 };
 
 // src/index.ts
+var RiffRaffUploadError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "RiffRaffUploadError";
+  }
+};
+function validateTopics(topics) {
+  const validTopicsForDeployment = ["production", "hackday", "prototype", "learning"];
+  const hasValidTopic = topics.some((topic) => validTopicsForDeployment.includes(topic));
+  if (!hasValidTopic) {
+    throw new RiffRaffUploadError(`No valid topic found in topics: ${topics}`);
+  } else {
+    core4.info("Valid topic found");
+  }
+}
 var main = async (options) => {
   const config = getConfiguration();
-  core4.info(JSON.stringify(import_github2.context.payload.repository.topics, null, 2));
+  validateTopics(import_github2.context.payload.repository.topics);
   core4.debug(JSON.stringify(config, null, 2));
   const {
     riffRaffYaml,

--- a/dist/index.js
+++ b/dist/index.js
@@ -63826,6 +63826,7 @@ var sync = async (store, dir, bucket, keyPrefix) => {
 // src/index.ts
 var main = async (options) => {
   const config = getConfiguration();
+  core4.info(JSON.stringify(import_github2.context.payload.repository.topics, null, 2));
   core4.debug(JSON.stringify(config, null, 2));
   const {
     riffRaffYaml,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,26 @@ interface Options {
 	WithSummary: boolean; // Use to disable summary when running locally.
 }
 
+class RiffRaffUploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RiffRaffUploadError';
+  }
+}
+
+function validateTopics(topics: string[]): void {
+  const validTopicsForDeployment = ['production', 'hackday', 'prototype', 'learning']
+  const hasValidTopic = topics.some((topic) => validTopicsForDeployment.includes(topic))
+  if (!hasValidTopic) {
+    throw new RiffRaffUploadError(`No valid topic found in topics: ${topics}`)
+  }
+  else {core.info('Valid topic found')}
+}
+
 export const main = async (options: Options): Promise<void> => {
 	const config = getConfiguration();
 
-  core.info(JSON.stringify(context.payload.repository!.topics, null, 2));
-
+  validateTopics(context.payload.repository!.topics);
 
 	core.debug(JSON.stringify(config, null, 2));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,24 +15,30 @@ interface Options {
 }
 
 class RiffRaffUploadError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'RiffRaffUploadError';
-  }
+	constructor(message: string) {
+		super(message);
+		this.name = 'RiffRaffUploadError';
+	}
 }
 
 function validateTopics(topics: string[]): void {
-  const validTopicsForDeployment = ['production', 'hackday', 'prototype', 'learning']
-  const hasValidTopic = topics.some((topic) => validTopicsForDeployment.includes(topic))
-  if (!hasValidTopic) {
-    throw new RiffRaffUploadError(`No valid repository topic found. Please add one of ${validTopicsForDeployment.join(', ')}`)
-  }
-  else {core.info('Valid topic found')}
+	const deployableTopics = ['production', 'hackday', 'prototype', 'learning'];
+	const hasValidTopic = topics.some((topic) =>
+		deployableTopics.includes(topic),
+	);
+	if (!hasValidTopic) {
+		const topicList = deployableTopics.join(', ');
+		throw new RiffRaffUploadError(
+			`No valid repository topic found. Add one of ${topicList}`,
+		);
+	} else {
+		core.info('Valid topic found');
+	}
 }
 
 export const main = async (options: Options): Promise<void> => {
 	const config = getConfiguration();
-  validateTopics(context.payload.repository?.topics as string[]);
+	validateTopics(context.payload.repository?.topics as string[]);
 
 	core.debug(JSON.stringify(config, null, 2));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { commentOnPullRequest } from './pr-comment';
 import type { Deployment } from './riffraff';
 import { manifest, riffraffPrefix } from './riffraff';
 import { S3Store, sync } from './s3';
+import {PayloadRepository} from "@actions/github/lib/interfaces";
 
 interface Options {
 	WithSummary: boolean; // Use to disable summary when running locally.
@@ -16,6 +17,9 @@ interface Options {
 
 export const main = async (options: Options): Promise<void> => {
 	const config = getConfiguration();
+
+  core.info(JSON.stringify(context.payload.repository!.topics, null, 2));
+
 
 	core.debug(JSON.stringify(config, null, 2));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import { commentOnPullRequest } from './pr-comment';
 import type { Deployment } from './riffraff';
 import { manifest, riffraffPrefix } from './riffraff';
 import { S3Store, sync } from './s3';
-import {PayloadRepository} from "@actions/github/lib/interfaces";
 
 interface Options {
 	WithSummary: boolean; // Use to disable summary when running locally.
@@ -26,15 +25,14 @@ function validateTopics(topics: string[]): void {
   const validTopicsForDeployment = ['production', 'hackday', 'prototype', 'learning']
   const hasValidTopic = topics.some((topic) => validTopicsForDeployment.includes(topic))
   if (!hasValidTopic) {
-    throw new RiffRaffUploadError(`No valid topic found in topics: ${topics}`)
+    throw new RiffRaffUploadError(`No valid repository topic found. Please add one of ${validTopicsForDeployment.join(', ')}`)
   }
   else {core.info('Valid topic found')}
 }
 
 export const main = async (options: Options): Promise<void> => {
 	const config = getConfiguration();
-
-  validateTopics(context.payload.repository!.topics);
+  validateTopics(context.payload.repository?.topics as string[]);
 
 	core.debug(JSON.stringify(config, null, 2));
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The action will not upload anything to riff-raff if the repository does not have an appropriate topic.

## How to test

Find a repo using this action. Switch the version to this branch. Run the action twice, both with and without valid topics

## How can we measure success?

The number of unlabelled repos should go down significantly.

## Have we considered potential risks?

This may introduce some friction to the deploy process. But adding a topic is not an onerous task, and means that DevX do not have to chase teams up about this later

## Images

Failure:

<img width="1007" alt="Screenshot showing failure for the unhappy path" src="https://github.com/guardian/anghammarad-config/assets/67543397/db882baf-4fd8-42bd-b613-fc81e51c38dd">

Success: 
<img width="271" alt="Screenshot showing success for the happy path" src="https://github.com/guardian/anghammarad-config/assets/67543397/99e407ec-964e-483f-9f29-aee8e9e638d9">
