### PR TITLE
feat: Support repositories with multiple Riff-Raff projects

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -63735,7 +63735,7 @@ function getCommentMessage(config) {
   const { buildNumber, commentingStage, projectName } = config;
   const deployUrl = getDeployUrl(config).toString();
   const previewUrl = getPreviewUrl(config).toString();
-  const mainMessage = `[Deploy build ${buildNumber} of ${projectName} to ${commentingStage}](${deployUrl})`;
+  const mainMessage = `[Deploy build ${buildNumber} of \`${projectName}\` to ${commentingStage}](${deployUrl})`;
   return [
     `### ${mainMessage}`,
     "<details>",

--- a/dist/index.js
+++ b/dist/index.js
@@ -28739,8 +28739,8 @@ var require_SignatureV4 = __commonJS({
           signingService,
           priorSignature: signableMessage.priorSignature
         });
-        return promise.then((signature2) => {
-          return { message: signableMessage.message, signature: signature2 };
+        return promise.then((signature) => {
+          return { message: signableMessage.message, signature };
         });
       }
       async signString(stringToSign, { signingDate = /* @__PURE__ */ new Date(), signingRegion, signingService } = {}) {
@@ -28768,8 +28768,8 @@ var require_SignatureV4 = __commonJS({
           request.headers[constants_1.SHA256_HEADER] = payloadHash;
         }
         const canonicalHeaders = (0, getCanonicalHeaders_1.getCanonicalHeaders)(request, unsignableHeaders, signableHeaders);
-        const signature2 = await this.getSignature(longDate, scope, this.getSigningKey(credentials, region, shortDate, signingService), this.createCanonicalRequest(request, canonicalHeaders, payloadHash));
-        request.headers[constants_1.AUTH_HEADER] = `${constants_1.ALGORITHM_IDENTIFIER} Credential=${credentials.accessKeyId}/${scope}, SignedHeaders=${getCanonicalHeaderList(canonicalHeaders)}, Signature=${signature2}`;
+        const signature = await this.getSignature(longDate, scope, this.getSigningKey(credentials, region, shortDate, signingService), this.createCanonicalRequest(request, canonicalHeaders, payloadHash));
+        request.headers[constants_1.AUTH_HEADER] = `${constants_1.ALGORITHM_IDENTIFIER} Credential=${credentials.accessKeyId}/${scope}, SignedHeaders=${getCanonicalHeaderList(canonicalHeaders)}, Signature=${signature}`;
         return request;
       }
       createCanonicalRequest(request, canonicalHeaders, payloadHash) {
@@ -63728,12 +63728,14 @@ function getPreviewUrl(config) {
   url.searchParams.set("updateStrategy", "MostlyHarmless");
   return url;
 }
-var signature = "_From [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff)._";
+var marker = (projectName) => {
+  return `<!-- guardian/actions-riff-raff for ${projectName} -->`;
+};
 function getCommentMessage(config) {
-  const { buildNumber, commentingStage } = config;
+  const { buildNumber, commentingStage, projectName } = config;
   const deployUrl = getDeployUrl(config).toString();
   const previewUrl = getPreviewUrl(config).toString();
-  const mainMessage = `[Deploy build ${buildNumber} to ${commentingStage}](${deployUrl})`;
+  const mainMessage = `[Deploy build ${buildNumber} of ${projectName} to ${commentingStage}](${deployUrl})`;
   return [
     `### ${mainMessage}`,
     "<details>",
@@ -63744,7 +63746,8 @@ function getCommentMessage(config) {
     "</details>",
     "",
     "---",
-    signature
+    "_From [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff)._",
+    marker(projectName)
   ].join("\n");
 }
 async function commentOnPullRequest(pullRequestNumber, config) {
@@ -63757,7 +63760,7 @@ async function commentOnPullRequest(pullRequestNumber, config) {
   (0, import_core.debug)(`Total comments: ${comments.data.length}`);
   const previousComment = comments.data.find((comment2) => {
     const fromBot = comment2.user?.login === "github-actions[bot]";
-    const fromMe = comment2.body?.includes(signature) ?? false;
+    const fromMe = comment2.body?.includes(marker(config.projectName)) ?? false;
     return fromBot && fromMe;
   });
   if (previousComment) {

--- a/src/pr-comment.ts
+++ b/src/pr-comment.ts
@@ -34,7 +34,7 @@ function getCommentMessage(config: PullRequestCommentConfig): string {
 	const deployUrl = getDeployUrl(config).toString();
 	const previewUrl = getPreviewUrl(config).toString();
 
-	const mainMessage = `[Deploy build ${buildNumber} of ${projectName} to ${commentingStage}](${deployUrl})`;
+	const mainMessage = `[Deploy build ${buildNumber} of \`${projectName}\` to ${commentingStage}](${deployUrl})`;
 
 	return [
 		`### ${mainMessage}`,

--- a/src/pr-comment.ts
+++ b/src/pr-comment.ts
@@ -25,15 +25,16 @@ function getPreviewUrl(config: PullRequestCommentConfig): URL {
 	return url;
 }
 
-const signature =
-	'_From [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff)._';
+const marker = (projectName: string) => {
+	return `<!-- guardian/actions-riff-raff for ${projectName} -->`;
+};
 
 function getCommentMessage(config: PullRequestCommentConfig): string {
-	const { buildNumber, commentingStage } = config;
+	const { buildNumber, commentingStage, projectName } = config;
 	const deployUrl = getDeployUrl(config).toString();
 	const previewUrl = getPreviewUrl(config).toString();
 
-	const mainMessage = `[Deploy build ${buildNumber} to ${commentingStage}](${deployUrl})`;
+	const mainMessage = `[Deploy build ${buildNumber} of ${projectName} to ${commentingStage}](${deployUrl})`;
 
 	return [
 		`### ${mainMessage}`,
@@ -45,7 +46,8 @@ function getCommentMessage(config: PullRequestCommentConfig): string {
 		'</details>',
 		'',
 		'---',
-		signature,
+		'_From [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff)._',
+		marker(projectName),
 	].join('\n');
 }
 
@@ -65,7 +67,7 @@ export async function commentOnPullRequest(
 
 	const previousComment = comments.data.find((comment) => {
 		const fromBot = comment.user?.login === 'github-actions[bot]';
-		const fromMe = comment.body?.includes(signature) ?? false;
+		const fromMe = comment.body?.includes(marker(config.projectName)) ?? false;
 		return fromBot && fromMe;
 	});
 


### PR DESCRIPTION
## What does this change?
Use the project name to uniquely identify PR comments. This should provide support for repositories that hold multiple Riff-Raff projects, yielding a PR comment for each individual Riff-Raff project.

Note, as the way we're identifying previous comments is changing, we might see double comments for a short while.

❓ Is it be better to have a single comment, with more links? Or multiple comments, with fewer links?

## How to test
See https://github.com/guardian/editorial-tools-platform/pull/719.

## How can we measure success?
More use-cases are supported.