### PR TITLE
feat: Add a link to understand what's currently deployed

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -63728,6 +63728,12 @@ function getPreviewUrl(config) {
   url.searchParams.set("updateStrategy", "MostlyHarmless");
   return url;
 }
+function getWhatsOnUrl(config) {
+  const url = new URL("https://riffraff.gutools.co.uk/deployment/history");
+  url.searchParams.set("projectName", config.projectName);
+  url.searchParams.set("stage", config.commentingStage);
+  return url;
+}
 var marker = (projectName) => {
   return `<!-- guardian/actions-riff-raff for ${projectName} -->`;
 };
@@ -63735,6 +63741,7 @@ function getCommentMessage(config) {
   const { buildNumber, commentingStage, projectName } = config;
   const deployUrl = getDeployUrl(config).toString();
   const previewUrl = getPreviewUrl(config).toString();
+  const whatsOnUrl = getWhatsOnUrl(config).toString();
   const mainMessage = `[Deploy build ${buildNumber} of \`${projectName}\` to ${commentingStage}](${deployUrl})`;
   return [
     `### ${mainMessage}`,
@@ -63743,6 +63750,7 @@ function getCommentMessage(config) {
     "",
     `- ${mainMessage}`,
     `- [Deploy parts of build ${buildNumber} to ${commentingStage} by previewing it first](${previewUrl})`,
+    `- [What's on ${commentingStage} right now?](${whatsOnUrl})`,
     "</details>",
     "",
     "---",

--- a/src/pr-comment.ts
+++ b/src/pr-comment.ts
@@ -25,6 +25,15 @@ function getPreviewUrl(config: PullRequestCommentConfig): URL {
 	return url;
 }
 
+function getWhatsOnUrl(config: PullRequestCommentConfig): URL {
+	const url = new URL('https://riffraff.gutools.co.uk/deployment/history');
+
+	url.searchParams.set('projectName', config.projectName);
+	url.searchParams.set('stage', config.commentingStage);
+
+	return url;
+}
+
 const marker = (projectName: string) => {
 	return `<!-- guardian/actions-riff-raff for ${projectName} -->`;
 };
@@ -33,6 +42,7 @@ function getCommentMessage(config: PullRequestCommentConfig): string {
 	const { buildNumber, commentingStage, projectName } = config;
 	const deployUrl = getDeployUrl(config).toString();
 	const previewUrl = getPreviewUrl(config).toString();
+	const whatsOnUrl = getWhatsOnUrl(config).toString();
 
 	const mainMessage = `[Deploy build ${buildNumber} of \`${projectName}\` to ${commentingStage}](${deployUrl})`;
 
@@ -43,6 +53,7 @@ function getCommentMessage(config: PullRequestCommentConfig): string {
 		'',
 		`- ${mainMessage}`,
 		`- [Deploy parts of build ${buildNumber} to ${commentingStage} by previewing it first](${previewUrl})`,
+		`- [What's on ${commentingStage} right now?](${whatsOnUrl})`,
 		'</details>',
 		'',
 		'---',


### PR DESCRIPTION
## What does this change?
Before deploying, one might want to check if the previous occupant has finished their work. This change adds another link to the PR comment to a project's deployment history.

## How to test?
See the comment on https://github.com/guardian/service-catalogue/pull/565.

<img width="636" alt="image" src="https://github.com/guardian/actions-riff-raff/assets/836140/84ca2c54-bff6-4e90-8133-14736b60c05d">
