### PR TITLE
Fix link to topics docs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function validateTopics(topics: string[]): void {
 	if (!hasValidTopic) {
 		const topicList = deployableTopics.join(', ');
 		throw new RiffRaffUploadError(
-			`No valid repository topic found. Add one of ${topicList}. See https://github.com/guardian/recommendations/blob/main/github.md#topics.`,
+			`No valid repository topic found. Add one of ${topicList}. See https://github.com/guardian/recommendations/blob/main/github.md#topics`,
 		);
 	} else {
 		core.info('Valid topic found');


### PR DESCRIPTION
In the github actions web UI, the full stop is currently being included in the link text, breaking the anchor behaviour (e.g. in https://github.com/guardian/interactives/actions/runs/8689341331/job/23826835782). Removing the full stop should fix it.