### PR TITLE
feat: Handle Riff-Raff upload error, and PR commenting error separately

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -59071,6 +59071,13 @@ var main = async (options) => {
       keyPrefix + "/build.json"
     );
     core4.info("Upload complete.");
+  } catch (err) {
+    core4.error(
+      "Error uploading to Riff-Raff. Does the repository have an IAM Role? See https://github.com/guardian/riffraff-platform"
+    );
+    throw err;
+  }
+  try {
     const pullRequestNumber = await getPullRequestNumber(pullRequestComment);
     if (pullRequestNumber) {
       core4.info(`Commenting on PR ${pullRequestNumber}`);
@@ -59081,9 +59088,7 @@ var main = async (options) => {
       );
     }
   } catch (err) {
-    core4.error(
-      "Error uploading to Riff-Raff. Does the repository have an IAM Role? See https://github.com/guardian/riffraff-platform"
-    );
+    core4.error("Error commenting on PR. Do you have the correct permissions?");
     throw err;
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,16 @@ export const main = async (options: Options): Promise<void> => {
 		);
 
 		core.info('Upload complete.');
+	} catch (err) {
+		core.error(
+			'Error uploading to Riff-Raff. Does the repository have an IAM Role? See https://github.com/guardian/riffraff-platform',
+		);
 
+		// throw to fail the action
+		throw err;
+	}
+
+	try {
 		const pullRequestNumber = await getPullRequestNumber(pullRequestComment);
 		if (pullRequestNumber) {
 			core.info(`Commenting on PR ${pullRequestNumber}`);
@@ -144,15 +153,9 @@ export const main = async (options: Options): Promise<void> => {
 			);
 		}
 	} catch (err) {
-		core.error(
-			'Error uploading to Riff-Raff. Does the repository have an IAM Role? See https://github.com/guardian/riffraff-platform',
-		);
+		core.error('Error commenting on PR. Do you have the correct permissions?');
 
-		/*
-    We've caught every exception, not just AWS credential errors.
-    Re-throw it so that GHA can handle it.
-    TODO: Catch a more specific error type.
-     */
+		// throw to fail the action
 		throw err;
 	}
 };


### PR DESCRIPTION
## What does this change?
We're printing `Error uploading to Riff-Raff. Does the repository have an IAM Role? See https://github.com/guardian/riffraff-platform'` on every exception. This is misleading!

<details><summary>Confusing message</summary>
<p>

<img width="994" alt="image" src="https://github.com/guardian/actions-riff-raff/assets/836140/4232704d-f3d5-4fad-b791-2ebd899e97cd">

</p>
</details> 

Catch exceptions from S3 upload, and PR commenting separately and provide a more tailored comment.

This addresses an earlier comment https://github.com/guardian/actions-riff-raff/pull/126#discussion_r1575960846.