### PR TITLE
chore: Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      aws-sdk:
+        patterns:
+          - '@aws-sdk/*'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
## What does this change?
Configure Dependabot to update the AWS SDK libraries together, and to update GitHub Actions.

It makes sense to use the same version of each of the AWS SDK libraries. This change will also reduce the number of Dependabot PRs. For example https://github.com/guardian/actions-riff-raff/pull/154 and https://github.com/guardian/actions-riff-raff/pull/155 would be one.