### PR TITLE
feat!: Remove the `app` input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           dryRun: true
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: superSecretRole
-          app: foo
+          projectName: deploy::foo
           contentDirectories: |
             upload:
               - my-sources

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
 
       - uses: guardian/actions-riff-raff@v4
         with:
-          app: foo
+          projectName: deploy::foo
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           config: |
@@ -64,14 +64,6 @@ jobs:
 
 ## Available inputs
 
-### `app`
-*Required* (unless setting `projectName`)
-
-The app name, used for the creating Riff-Raff project name with the format `stack::app`.
-Where `stack` is read from the provided `riff-raff.yaml` config.
-
-Note: If you have multiple stacks specified, use `projectName` instead.
-
 ### `roleArn`
 
 _Required_
@@ -79,7 +71,7 @@ _Required_
 The ARN for a role that the action assumes using AssumeRoleWithWebIdentity. This is required to upload artifacts to the Riff-Raff bucket.
 
 ### `projectName`
-Used instead of `app` to override the default Riff-Raff project naming strategy.
+The Riff-Raff project name to upload files for.
 
 ### `config`
 *Required* (unless setting `configPath`)
@@ -92,7 +84,7 @@ config as a multiline string.
 ```yaml
 - uses: guardian/actions-riff-raff@v2
   with:
-    app: foo
+    projectName: deploy::foo
     config: | # <-- the pipe is important!
       stacks:
         - deploy
@@ -163,7 +155,7 @@ stacks: [ deploy ]
 deployments:
   cloudformation: # <-- this is a package name
     type: cloud-formation
-    app: prism
+    projectName: deploy::prism
     parameters:
       templateStagePaths:
         CODE: Prism-CODE.template.json
@@ -232,7 +224,7 @@ stacks: [ deploy ]
 deployments:
   my-cloudformation-deployment:
     type: cloud-formation
-    app: prism
+    projectName: deploy::prism
     contentDirectory: cfn-templates
     parameters:
       templateStagePaths:

--- a/action.yaml
+++ b/action.yaml
@@ -1,9 +1,6 @@
 name: "guardian/actions-riff-raff"
 description: "Build and upload Riff Raff artifacts."
 inputs:
-  app:
-    description: Riff Raff app name. Either this or projectName should be set.
-    required: false
   roleArn:
     description: Role to assume using AssumeRoleWithWebIdentity with Github OIDC token to upload files to RiffRaff S3 bucket.
     required: true
@@ -14,8 +11,8 @@ inputs:
     description: Use this to specify the path of a riff-raff.yaml file if you'd rather that than enter the config in your workflow file directly.
     required: false
   projectName:
-    description: "Determines Riffraff project name. Use this to override the default `stack::app` naming convention."
-    required: false
+    description: The Riff-Raff project the artifacts are for.
+    required: true
   dryRun:
     description: If set to true, logs the output but does not upload deployments to the Riff Raff S3 bucket.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -59338,26 +59338,12 @@ var readConfigFile = (path2) => {
   const data = read(path2);
   return load(data);
 };
-var getProjectName = ({ stacks }) => {
-  const appInput = getInput2("app");
-  const projectNameInput = getInput2("projectName");
-  if (!appInput && !projectNameInput) {
-    throw new Error("Must specify either app or projectName.");
+var getProjectName = () => {
+  const projectNameInput = getInput2("projectName", { required: true });
+  if (!projectNameInput) {
+    throw new Error("projectName not supplied");
   }
-  if (projectNameInput) {
-    return projectNameInput;
-  }
-  const numberOfStacks = stacks.length;
-  if (numberOfStacks === 1 && appInput) {
-    const stack = stacks[0];
-    return `${stack}::${appInput}`;
-  } else {
-    throw new Error(
-      `Unable to generate a project name as multiple stacks detected (${stacks.join(
-        ","
-      )}).`
-    );
-  }
+  return projectNameInput;
 };
 var isSources = (obj) => {
   if (typeof obj === "object") {
@@ -59449,7 +59435,7 @@ var getRoleArn = () => {
 };
 function getConfiguration() {
   const riffRaffYaml = getRiffRaffYaml();
-  const projectName = getProjectName(riffRaffYaml);
+  const projectName = getProjectName();
   const roleArn = getRoleArn();
   const dryRunInput = getInput2("dryRun");
   const buildNumberInput = getInput2("buildNumber");

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,30 +16,14 @@ const readConfigFile = (path: string): object => {
 	return yaml.load(data) as object;
 };
 
-const getProjectName = ({ stacks }: RiffraffYaml): string => {
-	const appInput = getInput('app');
-	const projectNameInput = getInput('projectName');
+const getProjectName = (): string => {
+	const projectNameInput = getInput('projectName', { required: true });
 
-	if (!appInput && !projectNameInput) {
-		throw new Error('Must specify either app or projectName.');
+	if (!projectNameInput) {
+		throw new Error('projectName not supplied');
 	}
 
-	if (projectNameInput) {
-		return projectNameInput;
-	}
-
-	const numberOfStacks = stacks.length;
-
-	if (numberOfStacks === 1 && appInput) {
-		const stack = stacks[0] as string;
-		return `${stack}::${appInput}`;
-	} else {
-		throw new Error(
-			`Unable to generate a project name as multiple stacks detected (${stacks.join(
-				',',
-			)}).`,
-		);
-	}
+	return projectNameInput;
 };
 
 type Sources = Record<string, string[]>;
@@ -191,7 +175,7 @@ const getRoleArn = (): string => {
 
 export function getConfiguration(): Configuration {
 	const riffRaffYaml = getRiffRaffYaml();
-	const projectName = getProjectName(riffRaffYaml);
+	const projectName = getProjectName();
 	const roleArn = getRoleArn();
 	const dryRunInput = getInput('dryRun');
 	const buildNumberInput = getInput('buildNumber');

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,7 +29,7 @@ describe('action', () => {
 		child_process.execSync(`touch ${artifactDir}/image.jpg`);
 
 		const input = `dryRun: true
-app: foo
+projectName: deploy::foo
 githubToken: ${process.env['GITHUB_SECRET'] ?? 'dev'}
 stagingDir: staging
 roleArn: superSecretRole


### PR DESCRIPTION
## What does this change?
BREAKING CHANGE: Remove `app` input in favour of `projectName`

The `app` input is used to build half of the Riff-Raff project name. The other half comes from the `stacks` listed in the `riff-raff.yaml` file.

This is quite complex, especially when compared to the `projectName` input which is the Riff-Raff project name verbatim.

To migrate, replace the `app` input with the Riff-Raff project name. If this is not known, the build logs can be used.
https://github.com/guardian/riffraff-platform can be used also.