### PR TITLE
feat(commenting): Add `commentingEnabled` flag to control PR commenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ _Default: CODE_
 
 When commenting on a pull request, which stage should be used. Typically a pre-production stage.
 
+### `commentingEnabled`
+_Default: true_
+
+Whether to comment on the pull request with Riff-Raff deployment links. See also `commentingStage`.
+
+
 ## Detailed example
 To illustrate, given the following file structure:
 

--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ inputs:
     required: false
     description: When commenting on a pull request, which stage should be used. Typically a pre-production stage.
     default: CODE
+  commentingEnabled:
+    required: false
+    description: Whether to comment on the pull request with Riff-Raff deployment links. See also `commentingStage`.
+    default: 'true'
 runs:
   using: node20
   main: "dist/index.js"

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,6 +147,7 @@ export interface PullRequestCommentConfig {
 	buildNumber: string;
 	commentingStage: string;
 	githubToken: string;
+	commentingEnabled: boolean;
 }
 
 export interface Configuration {
@@ -203,6 +204,8 @@ export function getConfiguration(): Configuration {
 
 	const buildNumber = offsetBuildNumber(baseBuildNumber, buildNumberOffset);
 	const commentingStage = getInput('commentingStage') ?? 'CODE';
+	const commentingEnabled: boolean =
+		(getInput('commentingEnabled') ?? 'true') === 'true';
 
 	return {
 		projectName,
@@ -220,6 +223,7 @@ export function getConfiguration(): Configuration {
 			buildNumber,
 			commentingStage,
 			githubToken: githubToken(),
+			commentingEnabled,
 		},
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,21 +142,27 @@ export const main = async (options: Options): Promise<void> => {
 		throw err;
 	}
 
-	try {
-		const pullRequestNumber = await getPullRequestNumber(pullRequestComment);
-		if (pullRequestNumber) {
-			core.info(`Commenting on PR ${pullRequestNumber}`);
-			await commentOnPullRequest(pullRequestNumber, pullRequestComment);
-		} else {
-			core.info(
-				`Unable to calculate Pull Request number, so cannot add a comment. Event is ${context.eventName}`,
+	if (pullRequestComment.commentingEnabled) {
+		try {
+			const pullRequestNumber = await getPullRequestNumber(pullRequestComment);
+			if (pullRequestNumber) {
+				core.info(`Commenting on PR ${pullRequestNumber}`);
+				await commentOnPullRequest(pullRequestNumber, pullRequestComment);
+			} else {
+				core.info(
+					`Unable to calculate Pull Request number, so cannot add a comment. Event is ${context.eventName}`,
+				);
+			}
+		} catch (err) {
+			core.error(
+				'Error commenting on PR. Do you have the correct permissions?',
 			);
-		}
-	} catch (err) {
-		core.error('Error commenting on PR. Do you have the correct permissions?');
 
-		// throw to fail the action
-		throw err;
+			// throw to fail the action
+			throw err;
+		}
+	} else {
+		core.info('commentingEnabled is `false`, skipping comment');
 	}
 };
 


### PR DESCRIPTION
## What does this change?
If a repository builds for multiple Riff-Raff projects, receiving multiple comments (one per Riff-Raff project) can become noisy. For example https://github.com/guardian/support-service-lambdas/pull/2587.

This change introduces a flag (`commentingEnabled`) to disable comments entirely. By default `commentingEnabled` is set to `'true'`.

Note: this is more of a pragmatic change as in the ideal we'd still provide the deployment links, but grouped together under a single comment.
