### PR TITLE
Revert "chore(deps-dev): bump @types/node from 22.10.1 to 22.10.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@guardian/tsconfig": "^1.0.0",
         "@types/jest": "29.5.14",
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "22.10.2",
+        "@types/node": "22.10.1",
         "jest": "29.7.0",
         "ts-jest": "29.2.5",
         "typescript": "5.5.2"
@@ -3584,10 +3584,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@guardian/tsconfig": "^1.0.0",
     "@types/jest": "29.5.14",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "22.10.2",
+    "@types/node": "22.10.1",
     "jest": "29.7.0",
     "ts-jest": "29.2.5",
     "typescript": "5.5.2"


### PR DESCRIPTION
Reverts guardian/actions-riff-raff#186

Due to failing builds