### PR TITLE
chore(deps): Revert `@aws-sdk/client-s3` back to v3.703.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,16 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
-    groups:
-      aws-sdk:
-        patterns:
-          - '@aws-sdk/*'
+
+    # We've seen issues with versions of `@aws-sdk/client-s3` later than 3.703.0 where put object requests fail with:
+    #  > RequestTimeout: Your socket connection to the server was not read from or written to within the timeout period. Idle connections will be closed.
+    # Attempts to increase the timeout to 10 seconds was not successful for all cases.
+    # Prevent Dependabot from issuing updates to any of the AWS SDK libraries being used (listed individually, as Dependabot cannot ignore wildcards).
+    # Once we've identified and patched the root cause, we can revert this.
+    ignore:
+      - dependency-name: "@aws-sdk/client-s3"
+      - dependency-name: "@aws-sdk/credential-providers"
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/dist/index.js
+++ b/dist/index.js
@@ -236,10 +236,10 @@ var require_proxy = __commonJS({
       })();
       if (proxyVar) {
         try {
-          return new URL(proxyVar);
+          return new DecodedURL(proxyVar);
         } catch (_a) {
           if (!proxyVar.startsWith("http://") && !proxyVar.startsWith("https://"))
-            return new URL(`http://${proxyVar}`);
+            return new DecodedURL(`http://${proxyVar}`);
         }
       } else {
         return void 0;
@@ -282,6 +282,19 @@ var require_proxy = __commonJS({
       const hostLower = host.toLowerCase();
       return hostLower === "localhost" || hostLower.startsWith("127.") || hostLower.startsWith("[::1]") || hostLower.startsWith("[0:0:0:0:0:0:0:1]");
     }
+    var DecodedURL = class extends URL {
+      constructor(url, base) {
+        super(url, base);
+        this._decodedUsername = decodeURIComponent(super.username);
+        this._decodedPassword = decodeURIComponent(super.password);
+      }
+      get username() {
+        return this._decodedUsername;
+      }
+      get password() {
+        return this._decodedPassword;
+      }
+    };
   }
 });
 
@@ -1738,7 +1751,7 @@ var require_Dicer = __commonJS({
       if (this._headerFirst && this._isPreamble) {
         if (!this._part) {
           this._part = new PartStream(this._partOpts);
-          if (this._events.preamble) {
+          if (this.listenerCount("preamble") !== 0) {
             this.emit("preamble", this._part);
           } else {
             this._ignore();
@@ -1801,7 +1814,7 @@ var require_Dicer = __commonJS({
           }
         }
         if (this._dashes === 2) {
-          if (start + i < end && this._events.trailer) {
+          if (start + i < end && this.listenerCount("trailer") !== 0) {
             this.emit("trailer", data.slice(start + i, end));
           }
           this.reset();
@@ -1824,9 +1837,9 @@ var require_Dicer = __commonJS({
         this._part._read = function(n) {
           self2._unpause();
         };
-        if (this._isPreamble && this._events.preamble) {
+        if (this._isPreamble && this.listenerCount("preamble") !== 0) {
           this.emit("preamble", this._part);
-        } else if (this._isPreamble !== true && this._events.part) {
+        } else if (this._isPreamble !== true && this.listenerCount("part") !== 0) {
           this.emit("part", this._part);
         } else {
           this._ignore();
@@ -1989,7 +2002,7 @@ var require_decodeText = __commonJS({
         if (textDecoders.has(exports2.toString())) {
           try {
             return textDecoders.get(exports2).decode(data);
-          } catch (e) {
+          } catch {
           }
         }
         return typeof data === "string" ? data : data.toString();
@@ -2773,7 +2786,7 @@ var require_multipart = __commonJS({
               return skipPart(part);
             }
             ++nfiles;
-            if (!boy._events.file) {
+            if (boy.listenerCount("file") === 0) {
               self2.parser._ignore();
               return;
             }
@@ -17765,7 +17778,7 @@ var require_lib = __commonJS({
         if (this._keepAlive && useProxy) {
           agent = this._proxyAgent;
         }
-        if (this._keepAlive && !useProxy) {
+        if (!useProxy) {
           agent = this._agent;
         }
         if (agent) {
@@ -17794,13 +17807,10 @@ var require_lib = __commonJS({
           agent = tunnelAgent(agentOptions);
           this._proxyAgent = agent;
         }
-        if (this._keepAlive && !agent) {
+        if (!agent) {
           const options = { keepAlive: this._keepAlive, maxSockets };
           agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
           this._agent = agent;
-        }
-        if (!agent) {
-          agent = usingSsl ? https.globalAgent : http.globalAgent;
         }
         if (usingSsl && this._ignoreSslError) {
           agent.options = Object.assign(agent.options || {}, {
@@ -17819,7 +17829,7 @@ var require_lib = __commonJS({
         }
         const usingSsl = parsedUrl.protocol === "https:";
         proxyAgent = new undici_1.ProxyAgent(Object.assign({ uri: proxyUrl.href, pipelining: !this._keepAlive ? 0 : 1 }, (proxyUrl.username || proxyUrl.password) && {
-          token: `${proxyUrl.username}:${proxyUrl.password}`
+          token: `Basic ${Buffer.from(`${proxyUrl.username}:${proxyUrl.password}`).toString("base64")}`
         }));
         this._proxyAgentDispatcher = proxyAgent;
         if (usingSsl && this._ignoreSslError) {
@@ -19716,10 +19726,10 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       error2(message);
     }
     exports2.setFailed = setFailed2;
-    function isDebug2() {
+    function isDebug() {
       return process.env["RUNNER_DEBUG"] === "1";
     }
-    exports2.isDebug = isDebug2;
+    exports2.isDebug = isDebug;
     function debug3(message) {
       (0, command_1.issueCommand)("debug", {}, message);
     }
@@ -20116,30 +20126,6 @@ var require_before_after_hook = __commonJS({
   }
 });
 
-// node_modules/is-plain-object/dist/is-plain-object.js
-var require_is_plain_object = __commonJS({
-  "node_modules/is-plain-object/dist/is-plain-object.js"(exports2) {
-    "use strict";
-    Object.defineProperty(exports2, "__esModule", { value: true });
-    function isObject2(o) {
-      return Object.prototype.toString.call(o) === "[object Object]";
-    }
-    function isPlainObject(o) {
-      var ctor, prot;
-      if (isObject2(o) === false) return false;
-      ctor = o.constructor;
-      if (ctor === void 0) return true;
-      prot = ctor.prototype;
-      if (isObject2(prot) === false) return false;
-      if (prot.hasOwnProperty("isPrototypeOf") === false) {
-        return false;
-      }
-      return true;
-    }
-    exports2.isPlainObject = isPlainObject;
-  }
-});
-
 // node_modules/@octokit/endpoint/dist-node/index.js
 var require_dist_node2 = __commonJS({
   "node_modules/@octokit/endpoint/dist-node/index.js"(exports2, module2) {
@@ -20167,7 +20153,7 @@ var require_dist_node2 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_universal_user_agent = require_dist_node();
-    var VERSION = "9.0.2";
+    var VERSION = "9.0.5";
     var userAgent = `octokit-endpoint.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
     var DEFAULTS = {
       method: "GET",
@@ -20189,11 +20175,21 @@ var require_dist_node2 = __commonJS({
         return newObj;
       }, {});
     }
-    var import_is_plain_object = require_is_plain_object();
+    function isPlainObject(value) {
+      if (typeof value !== "object" || value === null)
+        return false;
+      if (Object.prototype.toString.call(value) !== "[object Object]")
+        return false;
+      const proto = Object.getPrototypeOf(value);
+      if (proto === null)
+        return true;
+      const Ctor = Object.prototype.hasOwnProperty.call(proto, "constructor") && proto.constructor;
+      return typeof Ctor === "function" && Ctor instanceof Ctor && Function.prototype.call(Ctor) === Function.prototype.call(value);
+    }
     function mergeDeep(defaults, options) {
       const result = Object.assign({}, defaults);
       Object.keys(options).forEach((key) => {
-        if ((0, import_is_plain_object.isPlainObject)(options[key])) {
+        if (isPlainObject(options[key])) {
           if (!(key in defaults))
             Object.assign(result, { [key]: options[key] });
           else
@@ -20258,10 +20254,13 @@ var require_dist_node2 = __commonJS({
       return matches.map(removeNonChars).reduce((a, b) => a.concat(b), []);
     }
     function omit(object, keysToOmit) {
-      return Object.keys(object).filter((option) => !keysToOmit.includes(option)).reduce((obj, key) => {
-        obj[key] = object[key];
-        return obj;
-      }, {});
+      const result = { __proto__: null };
+      for (const key of Object.keys(object)) {
+        if (keysToOmit.indexOf(key) === -1) {
+          result[key] = object[key];
+        }
+      }
+      return result;
     }
     function encodeReserved(str2) {
       return str2.split(/(%[0-9A-Fa-f]{2})/g).map(function(part) {
@@ -20685,17 +20684,27 @@ var require_dist_node5 = __commonJS({
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_endpoint = require_dist_node2();
     var import_universal_user_agent = require_dist_node();
-    var VERSION = "8.1.5";
-    var import_is_plain_object = require_is_plain_object();
+    var VERSION = "8.4.0";
+    function isPlainObject(value) {
+      if (typeof value !== "object" || value === null)
+        return false;
+      if (Object.prototype.toString.call(value) !== "[object Object]")
+        return false;
+      const proto = Object.getPrototypeOf(value);
+      if (proto === null)
+        return true;
+      const Ctor = Object.prototype.hasOwnProperty.call(proto, "constructor") && proto.constructor;
+      return typeof Ctor === "function" && Ctor instanceof Ctor && Function.prototype.call(Ctor) === Function.prototype.call(value);
+    }
     var import_request_error = require_dist_node4();
     function getBufferResponse(response) {
       return response.arrayBuffer();
     }
     function fetchWrapper(requestOptions) {
-      var _a, _b, _c;
+      var _a, _b, _c, _d;
       const log = requestOptions.request && requestOptions.request.log ? requestOptions.request.log : console;
       const parseSuccessResponseBody = ((_a = requestOptions.request) == null ? void 0 : _a.parseSuccessResponseBody) !== false;
-      if ((0, import_is_plain_object.isPlainObject)(requestOptions.body) || Array.isArray(requestOptions.body)) {
+      if (isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
         requestOptions.body = JSON.stringify(requestOptions.body);
       }
       let headers = {};
@@ -20713,8 +20722,9 @@ var require_dist_node5 = __commonJS({
       return fetch2(requestOptions.url, {
         method: requestOptions.method,
         body: requestOptions.body,
+        redirect: (_c = requestOptions.request) == null ? void 0 : _c.redirect,
         headers: requestOptions.headers,
-        signal: (_c = requestOptions.request) == null ? void 0 : _c.signal,
+        signal: (_d = requestOptions.request) == null ? void 0 : _d.signal,
         // duplex must be set if request.body is ReadableStream or Async Iterables.
         // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
         ...requestOptions.body && { duplex: "half" }
@@ -20811,11 +20821,17 @@ var require_dist_node5 = __commonJS({
     function toErrorMessage(data) {
       if (typeof data === "string")
         return data;
+      let suffix;
+      if ("documentation_url" in data) {
+        suffix = ` - ${data.documentation_url}`;
+      } else {
+        suffix = "";
+      }
       if ("message" in data) {
         if (Array.isArray(data.errors)) {
-          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
+          return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}${suffix}`;
         }
-        return data.message;
+        return `${data.message}${suffix}`;
       }
       return `Unknown error: ${JSON.stringify(data)}`;
     }
@@ -20880,7 +20896,7 @@ var require_dist_node6 = __commonJS({
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_request3 = require_dist_node5();
     var import_universal_user_agent = require_dist_node();
-    var VERSION = "7.0.2";
+    var VERSION = "7.1.0";
     var import_request2 = require_dist_node5();
     var import_request = require_dist_node5();
     function _buildMessageForResponseErrors(data) {
@@ -21090,7 +21106,12 @@ var require_dist_node8 = __commonJS({
     var import_request = require_dist_node5();
     var import_graphql = require_dist_node6();
     var import_auth_token = require_dist_node7();
-    var VERSION = "5.0.1";
+    var VERSION = "5.2.0";
+    var noop = () => {
+    };
+    var consoleWarn = console.warn.bind(console);
+    var consoleError = console.error.bind(console);
+    var userAgentTrail = `octokit-core.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`;
     var Octokit = class {
       static {
         this.VERSION = VERSION;
@@ -21151,10 +21172,7 @@ var require_dist_node8 = __commonJS({
             format: ""
           }
         };
-        requestDefaults.headers["user-agent"] = [
-          options.userAgent,
-          `octokit-core.js/${VERSION} ${(0, import_universal_user_agent.getUserAgent)()}`
-        ].filter(Boolean).join(" ");
+        requestDefaults.headers["user-agent"] = options.userAgent ? `${options.userAgent} ${userAgentTrail}` : userAgentTrail;
         if (options.baseUrl) {
           requestDefaults.baseUrl = options.baseUrl;
         }
@@ -21168,12 +21186,10 @@ var require_dist_node8 = __commonJS({
         this.graphql = (0, import_graphql.withCustomRequest)(this.request).defaults(requestDefaults);
         this.log = Object.assign(
           {
-            debug: () => {
-            },
-            info: () => {
-            },
-            warn: console.warn.bind(console),
-            error: console.error.bind(console)
+            debug: noop,
+            info: noop,
+            warn: consoleWarn,
+            error: consoleError
           },
           options.log
         );
@@ -21210,9 +21226,9 @@ var require_dist_node8 = __commonJS({
           this.auth = auth;
         }
         const classConstructor = this.constructor;
-        classConstructor.plugins.forEach((plugin) => {
-          Object.assign(this, plugin(this, options));
-        });
+        for (let i = 0; i < classConstructor.plugins.length; ++i) {
+          Object.assign(this, classConstructor.plugins[i](this, options));
+        }
       }
     };
   }
@@ -21245,7 +21261,7 @@ var require_dist_node9 = __commonJS({
       restEndpointMethods: () => restEndpointMethods
     });
     module2.exports = __toCommonJS2(dist_src_exports);
-    var VERSION = "10.1.5";
+    var VERSION = "10.4.1";
     var Endpoints = {
       actions: {
         addCustomLabelsToSelfHostedRunnerForOrg: [
@@ -21370,6 +21386,9 @@ var require_dist_node9 = __commonJS({
           "GET /repos/{owner}/{repo}/actions/permissions/selected-actions"
         ],
         getArtifact: ["GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}"],
+        getCustomOidcSubClaimForRepo: [
+          "GET /repos/{owner}/{repo}/actions/oidc/customization/sub"
+        ],
         getEnvironmentPublicKey: [
           "GET /repositories/{repository_id}/environments/{environment_name}/secrets/public-key"
         ],
@@ -21522,6 +21541,9 @@ var require_dist_node9 = __commonJS({
         setCustomLabelsForSelfHostedRunnerForRepo: [
           "PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels"
         ],
+        setCustomOidcSubClaimForRepo: [
+          "PUT /repos/{owner}/{repo}/actions/oidc/customization/sub"
+        ],
         setGithubActionsDefaultWorkflowPermissionsOrganization: [
           "PUT /orgs/{org}/actions/permissions/workflow"
         ],
@@ -21591,6 +21613,7 @@ var require_dist_node9 = __commonJS({
         listWatchersForRepo: ["GET /repos/{owner}/{repo}/subscribers"],
         markNotificationsAsRead: ["PUT /notifications"],
         markRepoNotificationsAsRead: ["PUT /repos/{owner}/{repo}/notifications"],
+        markThreadAsDone: ["DELETE /notifications/threads/{thread_id}"],
         markThreadAsRead: ["PATCH /notifications/threads/{thread_id}"],
         setRepoSubscription: ["PUT /repos/{owner}/{repo}/subscription"],
         setThreadSubscription: [
@@ -21867,10 +21890,10 @@ var require_dist_node9 = __commonJS({
         updateForAuthenticatedUser: ["PATCH /user/codespaces/{codespace_name}"]
       },
       copilot: {
-        addCopilotForBusinessSeatsForTeams: [
+        addCopilotSeatsForTeams: [
           "POST /orgs/{org}/copilot/billing/selected_teams"
         ],
-        addCopilotForBusinessSeatsForUsers: [
+        addCopilotSeatsForUsers: [
           "POST /orgs/{org}/copilot/billing/selected_users"
         ],
         cancelCopilotSeatAssignmentForTeams: [
@@ -22183,9 +22206,23 @@ var require_dist_node9 = __commonJS({
           }
         ]
       },
+      oidc: {
+        getOidcCustomSubTemplateForOrg: [
+          "GET /orgs/{org}/actions/oidc/customization/sub"
+        ],
+        updateOidcCustomSubTemplateForOrg: [
+          "PUT /orgs/{org}/actions/oidc/customization/sub"
+        ]
+      },
       orgs: {
         addSecurityManagerTeam: [
           "PUT /orgs/{org}/security-managers/teams/{team_slug}"
+        ],
+        assignTeamToOrgRole: [
+          "PUT /orgs/{org}/organization-roles/teams/{team_slug}/{role_id}"
+        ],
+        assignUserToOrgRole: [
+          "PUT /orgs/{org}/organization-roles/users/{username}/{role_id}"
         ],
         blockUser: ["PUT /orgs/{org}/blocks/{username}"],
         cancelInvitation: ["DELETE /orgs/{org}/invitations/{invitation_id}"],
@@ -22195,6 +22232,7 @@ var require_dist_node9 = __commonJS({
         convertMemberToOutsideCollaborator: [
           "PUT /orgs/{org}/outside_collaborators/{username}"
         ],
+        createCustomOrganizationRole: ["POST /orgs/{org}/organization-roles"],
         createInvitation: ["POST /orgs/{org}/invitations"],
         createOrUpdateCustomProperties: ["PATCH /orgs/{org}/properties/schema"],
         createOrUpdateCustomPropertiesValuesForRepos: [
@@ -22205,6 +22243,9 @@ var require_dist_node9 = __commonJS({
         ],
         createWebhook: ["POST /orgs/{org}/hooks"],
         delete: ["DELETE /orgs/{org}"],
+        deleteCustomOrganizationRole: [
+          "DELETE /orgs/{org}/organization-roles/{role_id}"
+        ],
         deleteWebhook: ["DELETE /orgs/{org}/hooks/{hook_id}"],
         enableOrDisableSecurityProductOnAllOrgRepos: [
           "POST /orgs/{org}/{security_product}/{enablement}"
@@ -22216,6 +22257,7 @@ var require_dist_node9 = __commonJS({
         ],
         getMembershipForAuthenticatedUser: ["GET /user/memberships/orgs/{org}"],
         getMembershipForUser: ["GET /orgs/{org}/memberships/{username}"],
+        getOrgRole: ["GET /orgs/{org}/organization-roles/{role_id}"],
         getWebhook: ["GET /orgs/{org}/hooks/{hook_id}"],
         getWebhookConfigForOrg: ["GET /orgs/{org}/hooks/{hook_id}/config"],
         getWebhookDelivery: [
@@ -22231,6 +22273,12 @@ var require_dist_node9 = __commonJS({
         listInvitationTeams: ["GET /orgs/{org}/invitations/{invitation_id}/teams"],
         listMembers: ["GET /orgs/{org}/members"],
         listMembershipsForAuthenticatedUser: ["GET /user/memberships/orgs"],
+        listOrgRoleTeams: ["GET /orgs/{org}/organization-roles/{role_id}/teams"],
+        listOrgRoleUsers: ["GET /orgs/{org}/organization-roles/{role_id}/users"],
+        listOrgRoles: ["GET /orgs/{org}/organization-roles"],
+        listOrganizationFineGrainedPermissions: [
+          "GET /orgs/{org}/organization-fine-grained-permissions"
+        ],
         listOutsideCollaborators: ["GET /orgs/{org}/outside_collaborators"],
         listPatGrantRepositories: [
           "GET /orgs/{org}/personal-access-tokens/{pat_id}/repositories"
@@ -22245,6 +22293,9 @@ var require_dist_node9 = __commonJS({
         listSecurityManagerTeams: ["GET /orgs/{org}/security-managers"],
         listWebhookDeliveries: ["GET /orgs/{org}/hooks/{hook_id}/deliveries"],
         listWebhooks: ["GET /orgs/{org}/hooks"],
+        patchCustomOrganizationRole: [
+          "PATCH /orgs/{org}/organization-roles/{role_id}"
+        ],
         pingWebhook: ["POST /orgs/{org}/hooks/{hook_id}/pings"],
         redeliverWebhookDelivery: [
           "POST /orgs/{org}/hooks/{hook_id}/deliveries/{delivery_id}/attempts"
@@ -22268,6 +22319,18 @@ var require_dist_node9 = __commonJS({
         ],
         reviewPatGrantRequestsInBulk: [
           "POST /orgs/{org}/personal-access-token-requests"
+        ],
+        revokeAllOrgRolesTeam: [
+          "DELETE /orgs/{org}/organization-roles/teams/{team_slug}"
+        ],
+        revokeAllOrgRolesUser: [
+          "DELETE /orgs/{org}/organization-roles/users/{username}"
+        ],
+        revokeOrgRoleTeam: [
+          "DELETE /orgs/{org}/organization-roles/teams/{team_slug}/{role_id}"
+        ],
+        revokeOrgRoleUser: [
+          "DELETE /orgs/{org}/organization-roles/users/{username}/{role_id}"
         ],
         setMembershipForUser: ["PUT /orgs/{org}/memberships/{username}"],
         setPublicMembershipForAuthenticatedUser: [
@@ -22559,6 +22622,9 @@ var require_dist_node9 = __commonJS({
           {},
           { mapToData: "users" }
         ],
+        cancelPagesDeployment: [
+          "POST /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}/cancel"
+        ],
         checkAutomatedSecurityFixes: [
           "GET /repos/{owner}/{repo}/automated-security-fixes"
         ],
@@ -22594,12 +22660,15 @@ var require_dist_node9 = __commonJS({
         createForAuthenticatedUser: ["POST /user/repos"],
         createFork: ["POST /repos/{owner}/{repo}/forks"],
         createInOrg: ["POST /orgs/{org}/repos"],
+        createOrUpdateCustomPropertiesValues: [
+          "PATCH /repos/{owner}/{repo}/properties/values"
+        ],
         createOrUpdateEnvironment: [
           "PUT /repos/{owner}/{repo}/environments/{environment_name}"
         ],
         createOrUpdateFileContents: ["PUT /repos/{owner}/{repo}/contents/{path}"],
         createOrgRuleset: ["POST /orgs/{org}/rulesets"],
-        createPagesDeployment: ["POST /repos/{owner}/{repo}/pages/deployment"],
+        createPagesDeployment: ["POST /repos/{owner}/{repo}/pages/deployments"],
         createPagesSite: ["POST /repos/{owner}/{repo}/pages"],
         createRelease: ["POST /repos/{owner}/{repo}/releases"],
         createRepoRuleset: ["POST /repos/{owner}/{repo}/rulesets"],
@@ -22752,6 +22821,9 @@ var require_dist_node9 = __commonJS({
         getOrgRulesets: ["GET /orgs/{org}/rulesets"],
         getPages: ["GET /repos/{owner}/{repo}/pages"],
         getPagesBuild: ["GET /repos/{owner}/{repo}/pages/builds/{build_id}"],
+        getPagesDeployment: [
+          "GET /repos/{owner}/{repo}/pages/deployments/{pages_deployment_id}"
+        ],
         getPagesHealthCheck: ["GET /repos/{owner}/{repo}/pages/health"],
         getParticipationStats: ["GET /repos/{owner}/{repo}/stats/participation"],
         getPullRequestReviewProtection: [
@@ -22962,6 +23034,9 @@ var require_dist_node9 = __commonJS({
         ]
       },
       securityAdvisories: {
+        createFork: [
+          "POST /repos/{owner}/{repo}/security-advisories/{ghsa_id}/forks"
+        ],
         createPrivateVulnerabilityReport: [
           "POST /repos/{owner}/{repo}/security-advisories/reports"
         ],
@@ -23344,7 +23419,7 @@ var require_dist_node10 = __commonJS({
       paginatingEndpoints: () => paginatingEndpoints
     });
     module2.exports = __toCommonJS2(dist_src_exports);
-    var VERSION = "9.1.4";
+    var VERSION = "9.2.1";
     function normalizePaginatedListResponse(response) {
       if (!response.data) {
         return {
@@ -23495,6 +23570,8 @@ var require_dist_node10 = __commonJS({
       "GET /orgs/{org}/members/{username}/codespaces",
       "GET /orgs/{org}/migrations",
       "GET /orgs/{org}/migrations/{migration_id}/repositories",
+      "GET /orgs/{org}/organization-roles/{role_id}/teams",
+      "GET /orgs/{org}/organization-roles/{role_id}/users",
       "GET /orgs/{org}/outside_collaborators",
       "GET /orgs/{org}/packages",
       "GET /orgs/{org}/packages/{package_type}/{package_name}/versions",
@@ -23972,10 +24049,7 @@ var require_dist_cjs2 = __commonJS({
       };
     }, "resolveHttpHandlerRuntimeConfig");
     var import_types5 = require_dist_cjs();
-    var Field = class {
-      static {
-        __name(this, "Field");
-      }
+    var _Field = class _Field {
       constructor({ name, kind = import_types5.FieldPosition.HEADER, values = [] }) {
         this.name = name;
         this.kind = kind;
@@ -24022,14 +24096,13 @@ var require_dist_cjs2 = __commonJS({
         return this.values;
       }
     };
-    var Fields = class {
+    __name(_Field, "Field");
+    var Field = _Field;
+    var _Fields = class _Fields {
       constructor({ fields = [], encoding = "utf-8" }) {
         this.entries = {};
         fields.forEach(this.setField.bind(this));
         this.encoding = encoding;
-      }
-      static {
-        __name(this, "Fields");
       }
       /**
        * Set entry for a {@link Field} name. The `name`
@@ -24070,10 +24143,9 @@ var require_dist_cjs2 = __commonJS({
         return Object.values(this.entries).filter((field) => field.kind === kind);
       }
     };
-    var HttpRequest7 = class _HttpRequest {
-      static {
-        __name(this, "HttpRequest");
-      }
+    __name(_Fields, "Fields");
+    var Fields = _Fields;
+    var _HttpRequest = class _HttpRequest2 {
       constructor(options) {
         this.method = options.method || "GET";
         this.hostname = options.hostname || "localhost";
@@ -24091,7 +24163,7 @@ var require_dist_cjs2 = __commonJS({
        * Note: this does not deep-clone the body.
        */
       static clone(request) {
-        const cloned = new _HttpRequest({
+        const cloned = new _HttpRequest2({
           ...request,
           headers: { ...request.headers }
         });
@@ -24120,9 +24192,11 @@ var require_dist_cjs2 = __commonJS({
        * asserts that IHttpRequest (interface) objects are of type HttpRequest (class).
        */
       clone() {
-        return _HttpRequest.clone(this);
+        return _HttpRequest2.clone(this);
       }
     };
+    __name(_HttpRequest, "HttpRequest");
+    var HttpRequest7 = _HttpRequest;
     function cloneQuery(query) {
       return Object.keys(query).reduce((carry, paramName) => {
         const param = query[paramName];
@@ -24133,10 +24207,7 @@ var require_dist_cjs2 = __commonJS({
       }, {});
     }
     __name(cloneQuery, "cloneQuery");
-    var HttpResponse2 = class {
-      static {
-        __name(this, "HttpResponse");
-      }
+    var _HttpResponse = class _HttpResponse {
       constructor(options) {
         this.statusCode = options.statusCode;
         this.reason = options.reason;
@@ -24150,6 +24221,8 @@ var require_dist_cjs2 = __commonJS({
         return typeof resp.statusCode === "number" && typeof resp.headers === "object";
       }
     };
+    __name(_HttpResponse, "HttpResponse");
+    var HttpResponse2 = _HttpResponse;
     function isValidHostname(hostname) {
       const hostPattern = /^[a-z0-9][a-z0-9\.\-]*[a-z0-9]$/;
       return hostPattern.test(hostname);
@@ -24190,9 +24263,10 @@ var require_dist_cjs3 = __commonJS({
     var import_protocol_http8 = require_dist_cjs2();
     function addExpectContinueMiddleware(options) {
       return (next) => async (args) => {
+        var _a, _b;
         const { request } = args;
         if (import_protocol_http8.HttpRequest.isInstance(request) && request.body && options.runtime === "node") {
-          if (options.requestHandler?.constructor?.name !== "FetchHttpHandler") {
+          if (((_b = (_a = options.requestHandler) == null ? void 0 : _a.constructor) == null ? void 0 : _b.name) !== "FetchHttpHandler") {
             request.headers = {
               ...request.headers,
               Expect: "100-continue"
@@ -24615,7 +24689,8 @@ var require_dist_cjs5 = __commonJS({
       }
     }, "deserializerMiddleware");
     var serializerMiddleware = /* @__PURE__ */ __name((options, serializer) => (next, context3) => async (args) => {
-      const endpoint = context3.endpointV2?.url && options.urlParser ? async () => options.urlParser(context3.endpointV2.url) : options.endpoint;
+      var _a;
+      const endpoint = ((_a = context3.endpointV2) == null ? void 0 : _a.url) && options.urlParser ? async () => options.urlParser(context3.endpointV2.url) : options.endpoint;
       if (!endpoint) {
         throw new Error("No valid endpoint provider available.");
       }
@@ -25195,7 +25270,7 @@ var require_dist_cjs12 = __commonJS({
           );
         }, timeoutInMs - offset);
         const doWithSocket = /* @__PURE__ */ __name((socket) => {
-          if (socket?.connecting) {
+          if (socket == null ? void 0 : socket.connecting) {
             socket.on("connect", () => {
               timing.clearTimeout(timeoutId);
             });
@@ -25236,7 +25311,7 @@ var require_dist_cjs12 = __commonJS({
       return timing.setTimeout(registerListener, deferTimeMs);
     }, "setSocketKeepAlive");
     var DEFER_EVENT_LISTENER_TIME3 = 3e3;
-    var setSocketTimeout = /* @__PURE__ */ __name((request, reject, timeoutInMs = DEFAULT_REQUEST_TIMEOUT) => {
+    var setSocketTimeout = /* @__PURE__ */ __name((request, reject, timeoutInMs = 0) => {
       const registerTimeout = /* @__PURE__ */ __name((offset) => {
         const timeout = timeoutInMs - offset;
         const onTimeout = /* @__PURE__ */ __name(() => {
@@ -25313,7 +25388,7 @@ var require_dist_cjs12 = __commonJS({
     }
     __name(writeBody, "writeBody");
     var DEFAULT_REQUEST_TIMEOUT = 0;
-    var NodeHttpHandler = class _NodeHttpHandler {
+    var _NodeHttpHandler = class _NodeHttpHandler2 {
       constructor(options) {
         this.socketWarningTimestamp = 0;
         this.metadata = { handlerProtocol: "http/1.1" };
@@ -25327,18 +25402,15 @@ var require_dist_cjs12 = __commonJS({
           }
         });
       }
-      static {
-        __name(this, "NodeHttpHandler");
-      }
       /**
        * @returns the input if it is an HttpHandler of any class,
        * or instantiates a new instance of this handler.
        */
       static create(instanceOrOptions) {
-        if (typeof instanceOrOptions?.handle === "function") {
+        if (typeof (instanceOrOptions == null ? void 0 : instanceOrOptions.handle) === "function") {
           return instanceOrOptions;
         }
-        return new _NodeHttpHandler(instanceOrOptions);
+        return new _NodeHttpHandler2(instanceOrOptions);
       }
       /**
        * @internal
@@ -25349,6 +25421,7 @@ var require_dist_cjs12 = __commonJS({
        * @returns timestamp of last emitted warning.
        */
       static checkSocketUsage(agent, socketWarningTimestamp, logger = console) {
+        var _a, _b, _c;
         const { sockets, requests, maxSockets } = agent;
         if (typeof maxSockets !== "number" || maxSockets === Infinity) {
           return socketWarningTimestamp;
@@ -25359,10 +25432,11 @@ var require_dist_cjs12 = __commonJS({
         }
         if (sockets && requests) {
           for (const origin in sockets) {
-            const socketsInUse = sockets[origin]?.length ?? 0;
-            const requestsEnqueued = requests[origin]?.length ?? 0;
+            const socketsInUse = ((_a = sockets[origin]) == null ? void 0 : _a.length) ?? 0;
+            const requestsEnqueued = ((_b = requests[origin]) == null ? void 0 : _b.length) ?? 0;
             if (socketsInUse >= maxSockets && requestsEnqueued >= 2 * maxSockets) {
-              logger?.warn?.(
+              (_c = logger == null ? void 0 : logger.warn) == null ? void 0 : _c.call(
+                logger,
                 `@smithy/node-http-handler:WARN - socket usage at capacity=${socketsInUse} and ${requestsEnqueued} additional requests are enqueued.
 See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html
 or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler config.`
@@ -25381,13 +25455,13 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
           connectionTimeout,
           requestTimeout: requestTimeout ?? socketTimeout,
           httpAgent: (() => {
-            if (httpAgent instanceof import_http.Agent || typeof httpAgent?.destroy === "function") {
+            if (httpAgent instanceof import_http.Agent || typeof (httpAgent == null ? void 0 : httpAgent.destroy) === "function") {
               return httpAgent;
             }
             return new import_http.Agent({ keepAlive, maxSockets, ...httpAgent });
           })(),
           httpsAgent: (() => {
-            if (httpsAgent instanceof import_https.Agent || typeof httpsAgent?.destroy === "function") {
+            if (httpsAgent instanceof import_https.Agent || typeof (httpsAgent == null ? void 0 : httpsAgent.destroy) === "function") {
               return httpsAgent;
             }
             return new import_https.Agent({ keepAlive, maxSockets, ...httpsAgent });
@@ -25396,8 +25470,9 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         };
       }
       destroy() {
-        this.config?.httpAgent?.destroy();
-        this.config?.httpsAgent?.destroy();
+        var _a, _b, _c, _d;
+        (_b = (_a = this.config) == null ? void 0 : _a.httpAgent) == null ? void 0 : _b.destroy();
+        (_d = (_c = this.config) == null ? void 0 : _c.httpsAgent) == null ? void 0 : _d.destroy();
       }
       async handle(request, { abortSignal } = {}) {
         if (!this.config) {
@@ -25419,7 +25494,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
           if (!this.config) {
             throw new Error("Node HTTP request handler config is not resolved");
           }
-          if (abortSignal?.aborted) {
+          if (abortSignal == null ? void 0 : abortSignal.aborted) {
             const abortError = new Error("Request aborted");
             abortError.name = "AbortError";
             reject(abortError);
@@ -25430,7 +25505,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
           timeouts.push(
             timing.setTimeout(
               () => {
-                this.socketWarningTimestamp = _NodeHttpHandler.checkSocketUsage(
+                this.socketWarningTimestamp = _NodeHttpHandler2.checkSocketUsage(
                   agent,
                   this.socketWarningTimestamp,
                   this.config.logger
@@ -25532,15 +25607,14 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         return this.config ?? {};
       }
     };
+    __name(_NodeHttpHandler, "NodeHttpHandler");
+    var NodeHttpHandler = _NodeHttpHandler;
     var import_http22 = require("http2");
     var import_http2 = __toESM2(require("http2"));
-    var NodeHttp2ConnectionPool = class {
+    var _NodeHttp2ConnectionPool = class _NodeHttp2ConnectionPool {
       constructor(sessions) {
         this.sessions = [];
         this.sessions = sessions ?? [];
-      }
-      static {
-        __name(this, "NodeHttp2ConnectionPool");
       }
       poll() {
         if (this.sessions.length > 0) {
@@ -25569,16 +25643,15 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         }
       }
     };
-    var NodeHttp2ConnectionManager = class {
+    __name(_NodeHttp2ConnectionPool, "NodeHttp2ConnectionPool");
+    var NodeHttp2ConnectionPool = _NodeHttp2ConnectionPool;
+    var _NodeHttp2ConnectionManager = class _NodeHttp2ConnectionManager {
       constructor(config) {
         this.sessionCache = /* @__PURE__ */ new Map();
         this.config = config;
         if (this.config.maxConcurrency && this.config.maxConcurrency <= 0) {
           throw new RangeError("maxConcurrency must be greater than zero.");
         }
-      }
-      static {
-        __name(this, "NodeHttp2ConnectionManager");
       }
       lease(requestContext, connectionConfiguration) {
         const url = this.getUrlString(requestContext);
@@ -25633,8 +25706,9 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         this.sessionCache.set(authority, existingConnectionPool);
       }
       release(requestContext, session) {
+        var _a;
         const cacheKey = this.getUrlString(requestContext);
-        this.sessionCache.get(cacheKey)?.offerLast(session);
+        (_a = this.sessionCache.get(cacheKey)) == null ? void 0 : _a.offerLast(session);
       }
       destroy() {
         for (const [key, connectionPool] of this.sessionCache) {
@@ -25660,7 +25734,9 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         return request.destination.toString();
       }
     };
-    var NodeHttp2Handler = class _NodeHttp2Handler {
+    __name(_NodeHttp2ConnectionManager, "NodeHttp2ConnectionManager");
+    var NodeHttp2ConnectionManager = _NodeHttp2ConnectionManager;
+    var _NodeHttp2Handler = class _NodeHttp2Handler2 {
       constructor(options) {
         this.metadata = { handlerProtocol: "h2" };
         this.connectionManager = new NodeHttp2ConnectionManager({});
@@ -25674,18 +25750,15 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
           }
         });
       }
-      static {
-        __name(this, "NodeHttp2Handler");
-      }
       /**
        * @returns the input if it is an HttpHandler of any class,
        * or instantiates a new instance of this handler.
        */
       static create(instanceOrOptions) {
-        if (typeof instanceOrOptions?.handle === "function") {
+        if (typeof (instanceOrOptions == null ? void 0 : instanceOrOptions.handle) === "function") {
           return instanceOrOptions;
         }
-        return new _NodeHttp2Handler(instanceOrOptions);
+        return new _NodeHttp2Handler2(instanceOrOptions);
       }
       destroy() {
         this.connectionManager.destroy();
@@ -25700,6 +25773,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         }
         const { requestTimeout, disableConcurrentStreams } = this.config;
         return new Promise((_resolve, _reject) => {
+          var _a;
           let fulfilled = false;
           let writeRequestBodyPromise = void 0;
           const resolve = /* @__PURE__ */ __name(async (arg) => {
@@ -25710,7 +25784,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
             await writeRequestBodyPromise;
             _reject(arg);
           }, "reject");
-          if (abortSignal?.aborted) {
+          if (abortSignal == null ? void 0 : abortSignal.aborted) {
             fulfilled = true;
             const abortError = new Error("Request aborted");
             abortError.name = "AbortError";
@@ -25727,7 +25801,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
           const authority = `${protocol}//${auth}${hostname}${port ? `:${port}` : ""}`;
           const requestContext = { destination: new URL(authority) };
           const session = this.connectionManager.lease(requestContext, {
-            requestTimeout: this.config?.sessionTimeout,
+            requestTimeout: (_a = this.config) == null ? void 0 : _a.sessionTimeout,
             disableConcurrentStreams: disableConcurrentStreams || false
           });
           const rejectWithDestroy = /* @__PURE__ */ __name((err) => {
@@ -25822,7 +25896,7 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
       }
       /**
        * Destroys a session.
-       * @param session - the session to destroy.
+       * @param session The session to destroy.
        */
       destroySession(session) {
         if (!session.destroyed) {
@@ -25830,19 +25904,20 @@ or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler conf
         }
       }
     };
-    var Collector = class extends import_stream.Writable {
+    __name(_NodeHttp2Handler, "NodeHttp2Handler");
+    var NodeHttp2Handler = _NodeHttp2Handler;
+    var _Collector = class _Collector extends import_stream.Writable {
       constructor() {
         super(...arguments);
         this.bufferedBytes = [];
-      }
-      static {
-        __name(this, "Collector");
       }
       _write(chunk, encoding, callback) {
         this.bufferedBytes.push(chunk);
         callback();
       }
     };
+    __name(_Collector, "Collector");
+    var Collector = _Collector;
     var streamCollector = /* @__PURE__ */ __name((stream) => {
       if (isReadableStreamInstance(stream)) {
         return collectReadableStream(stream);
@@ -25936,19 +26011,16 @@ var require_dist_cjs13 = __commonJS({
     var keepAliveSupport = {
       supported: void 0
     };
-    var FetchHttpHandler = class _FetchHttpHandler {
-      static {
-        __name(this, "FetchHttpHandler");
-      }
+    var _FetchHttpHandler = class _FetchHttpHandler2 {
       /**
        * @returns the input if it is an HttpHandler of any class,
        * or instantiates a new instance of this handler.
        */
       static create(instanceOrOptions) {
-        if (typeof instanceOrOptions?.handle === "function") {
+        if (typeof (instanceOrOptions == null ? void 0 : instanceOrOptions.handle) === "function") {
           return instanceOrOptions;
         }
-        return new _FetchHttpHandler(instanceOrOptions);
+        return new _FetchHttpHandler2(instanceOrOptions);
       }
       constructor(options) {
         if (typeof options === "function") {
@@ -25966,13 +26038,14 @@ var require_dist_cjs13 = __commonJS({
       destroy() {
       }
       async handle(request, { abortSignal } = {}) {
+        var _a;
         if (!this.config) {
           this.config = await this.configProvider;
         }
         const requestTimeoutInMs = this.config.requestTimeout;
         const keepAlive = this.config.keepAlive === true;
         const credentials = this.config.credentials;
-        if (abortSignal?.aborted) {
+        if (abortSignal == null ? void 0 : abortSignal.aborted) {
           const abortError = new Error("Request aborted");
           abortError.name = "AbortError";
           return Promise.reject(abortError);
@@ -26000,7 +26073,7 @@ var require_dist_cjs13 = __commonJS({
           method,
           credentials
         };
-        if (this.config?.cache) {
+        if ((_a = this.config) == null ? void 0 : _a.cache) {
           requestOptions.cache = this.config.cache;
         }
         if (body) {
@@ -26078,9 +26151,12 @@ var require_dist_cjs13 = __commonJS({
         return this.config ?? {};
       }
     };
+    __name(_FetchHttpHandler, "FetchHttpHandler");
+    var FetchHttpHandler = _FetchHttpHandler;
     var import_util_base64 = require_dist_cjs9();
     var streamCollector = /* @__PURE__ */ __name(async (stream) => {
-      if (typeof Blob === "function" && stream instanceof Blob || stream.constructor?.name === "Blob") {
+      var _a;
+      if (typeof Blob === "function" && stream instanceof Blob || ((_a = stream.constructor) == null ? void 0 : _a.name) === "Blob") {
         if (Blob.prototype.arrayBuffer !== void 0) {
           return new Uint8Array(await stream.arrayBuffer());
         }
@@ -26336,7 +26412,7 @@ var require_sdk_stream_mixin = __commonJS({
             throw new Error("The stream has been consumed by other callbacks.");
           }
           if (typeof stream_1.Readable.toWeb !== "function") {
-            throw new Error("Readable.toWeb() is not supported. Please ensure a polyfill is available.");
+            throw new Error("Readable.toWeb() is not supported. Please make sure you are using Node.js >= 17.0.0, or polyfill is available.");
           }
           transformed = true;
           return stream_1.Readable.toWeb(stream);
@@ -26653,10 +26729,7 @@ var require_dist_cjs15 = __commonJS({
       return Uint8ArrayBlobAdapter2.mutate((0, import_util_utf8.fromUtf8)(str2));
     }
     __name(transformFromString, "transformFromString");
-    var Uint8ArrayBlobAdapter2 = class _Uint8ArrayBlobAdapter extends Uint8Array {
-      static {
-        __name(this, "Uint8ArrayBlobAdapter");
-      }
+    var _Uint8ArrayBlobAdapter = class _Uint8ArrayBlobAdapter2 extends Uint8Array {
       /**
        * @param source - such as a string or Stream.
        * @returns a new Uint8ArrayBlobAdapter extending Uint8Array.
@@ -26674,7 +26747,7 @@ var require_dist_cjs15 = __commonJS({
        * @returns the same Uint8Array but with prototype switched to Uint8ArrayBlobAdapter.
        */
       static mutate(source) {
-        Object.setPrototypeOf(source, _Uint8ArrayBlobAdapter.prototype);
+        Object.setPrototypeOf(source, _Uint8ArrayBlobAdapter2.prototype);
         return source;
       }
       /**
@@ -26685,6 +26758,8 @@ var require_dist_cjs15 = __commonJS({
         return transformToString(this, encoding);
       }
     };
+    __name(_Uint8ArrayBlobAdapter, "Uint8ArrayBlobAdapter");
+    var Uint8ArrayBlobAdapter2 = _Uint8ArrayBlobAdapter;
     __reExport(src_exports, require_getAwsChunkedEncodingStream(), module2.exports);
     __reExport(src_exports, require_sdk_stream_mixin(), module2.exports);
     __reExport(src_exports, require_splitStream(), module2.exports);
@@ -27090,8 +27165,9 @@ var require_dist_cjs16 = __commonJS({
       memoize: () => memoize
     });
     module2.exports = __toCommonJS2(src_exports);
-    var ProviderError2 = class _ProviderError extends Error {
+    var _ProviderError = class _ProviderError2 extends Error {
       constructor(message, options = true) {
+        var _a;
         let logger;
         let tryNextLink = true;
         if (typeof options === "boolean") {
@@ -27104,11 +27180,8 @@ var require_dist_cjs16 = __commonJS({
         super(message);
         this.name = "ProviderError";
         this.tryNextLink = tryNextLink;
-        Object.setPrototypeOf(this, _ProviderError.prototype);
-        logger?.debug?.(`@smithy/property-provider ${tryNextLink ? "->" : "(!)"} ${message}`);
-      }
-      static {
-        __name(this, "ProviderError");
+        Object.setPrototypeOf(this, _ProviderError2.prototype);
+        (_a = logger == null ? void 0 : logger.debug) == null ? void 0 : _a.call(logger, `@smithy/property-provider ${tryNextLink ? "->" : "(!)"} ${message}`);
       }
       /**
        * @deprecated use new operator.
@@ -27117,32 +27190,32 @@ var require_dist_cjs16 = __commonJS({
         return Object.assign(new this(error2.message, options), error2);
       }
     };
-    var CredentialsProviderError = class _CredentialsProviderError extends ProviderError2 {
+    __name(_ProviderError, "ProviderError");
+    var ProviderError2 = _ProviderError;
+    var _CredentialsProviderError = class _CredentialsProviderError2 extends ProviderError2 {
       /**
        * @override
        */
       constructor(message, options = true) {
         super(message, options);
         this.name = "CredentialsProviderError";
-        Object.setPrototypeOf(this, _CredentialsProviderError.prototype);
-      }
-      static {
-        __name(this, "CredentialsProviderError");
+        Object.setPrototypeOf(this, _CredentialsProviderError2.prototype);
       }
     };
-    var TokenProviderError = class _TokenProviderError extends ProviderError2 {
+    __name(_CredentialsProviderError, "CredentialsProviderError");
+    var CredentialsProviderError = _CredentialsProviderError;
+    var _TokenProviderError = class _TokenProviderError2 extends ProviderError2 {
       /**
        * @override
        */
       constructor(message, options = true) {
         super(message, options);
         this.name = "TokenProviderError";
-        Object.setPrototypeOf(this, _TokenProviderError.prototype);
-      }
-      static {
-        __name(this, "TokenProviderError");
+        Object.setPrototypeOf(this, _TokenProviderError2.prototype);
       }
     };
+    __name(_TokenProviderError, "TokenProviderError");
+    var TokenProviderError = _TokenProviderError;
     var chain = /* @__PURE__ */ __name((...providers) => async () => {
       if (providers.length === 0) {
         throw new ProviderError2("No providers in chain");
@@ -27154,7 +27227,7 @@ var require_dist_cjs16 = __commonJS({
           return credentials;
         } catch (err) {
           lastProviderError = err;
-          if (err?.tryNextLink) {
+          if (err == null ? void 0 : err.tryNextLink) {
             continue;
           }
           throw err;
@@ -27183,14 +27256,14 @@ var require_dist_cjs16 = __commonJS({
       }, "coalesceProvider");
       if (isExpired === void 0) {
         return async (options) => {
-          if (!hasResult || options?.forceRefresh) {
+          if (!hasResult || (options == null ? void 0 : options.forceRefresh)) {
             resolved = await coalesceProvider();
           }
           return resolved;
         };
       }
       return async (options) => {
-        if (!hasResult || options?.forceRefresh) {
+        if (!hasResult || (options == null ? void 0 : options.forceRefresh)) {
           resolved = await coalesceProvider();
         }
         if (isConstant) {
@@ -27356,7 +27429,7 @@ var require_dist_cjs17 = __commonJS({
           continue;
         }
         const canonicalHeaderName = headerName.toLowerCase();
-        if (canonicalHeaderName in ALWAYS_UNSIGNABLE_HEADERS || unsignableHeaders?.has(canonicalHeaderName) || PROXY_HEADER_PATTERN.test(canonicalHeaderName) || SEC_HEADER_PATTERN.test(canonicalHeaderName)) {
+        if (canonicalHeaderName in ALWAYS_UNSIGNABLE_HEADERS || (unsignableHeaders == null ? void 0 : unsignableHeaders.has(canonicalHeaderName)) || PROXY_HEADER_PATTERN.test(canonicalHeaderName) || SEC_HEADER_PATTERN.test(canonicalHeaderName)) {
           if (!signableHeaders || signableHeaders && !signableHeaders.has(canonicalHeaderName)) {
             continue;
           }
@@ -27402,10 +27475,7 @@ var require_dist_cjs17 = __commonJS({
       return UNSIGNED_PAYLOAD;
     }, "getPayloadHash");
     var import_util_utf83 = require_dist_cjs8();
-    var HeaderFormatter = class {
-      static {
-        __name(this, "HeaderFormatter");
-      }
+    var _HeaderFormatter = class _HeaderFormatter {
       format(headers) {
         const chunks = [];
         for (const headerName of Object.keys(headers)) {
@@ -27491,16 +27561,15 @@ var require_dist_cjs17 = __commonJS({
         }
       }
     };
+    __name(_HeaderFormatter, "HeaderFormatter");
+    var HeaderFormatter = _HeaderFormatter;
     var UUID_PATTERN = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
-    var Int64 = class _Int64 {
+    var _Int64 = class _Int642 {
       constructor(bytes) {
         this.bytes = bytes;
         if (bytes.byteLength !== 8) {
           throw new Error("Int64 buffers must be exactly 8 bytes");
         }
-      }
-      static {
-        __name(this, "Int64");
       }
       static fromNumber(number) {
         if (number > 9223372036854776e3 || number < -9223372036854776e3) {
@@ -27513,7 +27582,7 @@ var require_dist_cjs17 = __commonJS({
         if (number < 0) {
           negate(bytes);
         }
-        return new _Int64(bytes);
+        return new _Int642(bytes);
       }
       /**
        * Called implicitly by infix arithmetic operators.
@@ -27530,6 +27599,8 @@ var require_dist_cjs17 = __commonJS({
         return String(this.valueOf());
       }
     };
+    __name(_Int64, "Int64");
+    var Int64 = _Int64;
     function negate(bytes) {
       for (let i = 0; i < 8; i++) {
         bytes[i] ^= 255;
@@ -27552,10 +27623,11 @@ var require_dist_cjs17 = __commonJS({
     }, "hasHeader");
     var import_protocol_http8 = require_dist_cjs2();
     var moveHeadersToQuery = /* @__PURE__ */ __name((request, options = {}) => {
+      var _a, _b;
       const { headers, query = {} } = import_protocol_http8.HttpRequest.clone(request);
       for (const name of Object.keys(headers)) {
         const lname = name.toLowerCase();
-        if (lname.slice(0, 6) === "x-amz-" && !options.unhoistableHeaders?.has(lname) || options.hoistableHeaders?.has(lname)) {
+        if (lname.slice(0, 6) === "x-amz-" && !((_a = options.unhoistableHeaders) == null ? void 0 : _a.has(lname)) || ((_b = options.hoistableHeaders) == null ? void 0 : _b.has(lname))) {
           query[name] = headers[name];
           delete headers[name];
         }
@@ -27588,7 +27660,7 @@ var require_dist_cjs17 = __commonJS({
       }
       return time;
     }, "toDate");
-    var SignatureV42 = class {
+    var _SignatureV4 = class _SignatureV4 {
       constructor({
         applyChecksum,
         credentials,
@@ -27604,9 +27676,6 @@ var require_dist_cjs17 = __commonJS({
         this.applyChecksum = typeof applyChecksum === "boolean" ? applyChecksum : true;
         this.regionProvider = (0, import_util_middleware3.normalizeProvider)(region);
         this.credentialProvider = (0, import_util_middleware3.normalizeProvider)(credentials);
-      }
-      static {
-        __name(this, "SignatureV4");
       }
       async presign(originalRequest, options = {}) {
         const {
@@ -27756,7 +27825,7 @@ ${(0, import_util_hex_encoding.toHex)(hashedRequest)}`;
         if (this.uriEscapePath) {
           const normalizedPathSegments = [];
           for (const pathSegment of path2.split("/")) {
-            if (pathSegment?.length === 0)
+            if ((pathSegment == null ? void 0 : pathSegment.length) === 0)
               continue;
             if (pathSegment === ".")
               continue;
@@ -27766,7 +27835,7 @@ ${(0, import_util_hex_encoding.toHex)(hashedRequest)}`;
               normalizedPathSegments.push(pathSegment);
             }
           }
-          const normalizedPath = `${path2?.startsWith("/") ? "/" : ""}${normalizedPathSegments.join("/")}${normalizedPathSegments.length > 0 && path2?.endsWith("/") ? "/" : ""}`;
+          const normalizedPath = `${(path2 == null ? void 0 : path2.startsWith("/")) ? "/" : ""}${normalizedPathSegments.join("/")}${normalizedPathSegments.length > 0 && (path2 == null ? void 0 : path2.endsWith("/")) ? "/" : ""}`;
           const doubleEncoded = (0, import_util_uri_escape.escapeUri)(normalizedPath);
           return doubleEncoded.replace(/%2F/g, "/");
         }
@@ -27789,6 +27858,8 @@ ${(0, import_util_hex_encoding.toHex)(hashedRequest)}`;
         }
       }
     };
+    __name(_SignatureV4, "SignatureV4");
+    var SignatureV42 = _SignatureV4;
     var formatDate = /* @__PURE__ */ __name((now) => {
       const longDate = iso8601(now).replace(/[\-:]/g, "");
       return {
@@ -27809,23 +27880,22 @@ var init_resolveAwsSdkSigV4Config = __esm({
     import_signature_v4 = __toESM(require_dist_cjs17());
     resolveAwsSdkSigV4Config = (config) => {
       let isUserSupplied = false;
-      let credentialsProvider;
+      let normalizedCreds;
       if (config.credentials) {
         isUserSupplied = true;
-        credentialsProvider = memoizeIdentityProvider(config.credentials, isIdentityExpired, doesIdentityRequireRefresh);
+        normalizedCreds = memoizeIdentityProvider(config.credentials, isIdentityExpired, doesIdentityRequireRefresh);
       }
-      if (!credentialsProvider) {
+      if (!normalizedCreds) {
         if (config.credentialDefaultProvider) {
-          credentialsProvider = normalizeProvider(config.credentialDefaultProvider(Object.assign({}, config, {
+          normalizedCreds = normalizeProvider(config.credentialDefaultProvider(Object.assign({}, config, {
             parentClientConfig: config
           })));
         } else {
-          credentialsProvider = async () => {
+          normalizedCreds = async () => {
             throw new Error("`credentials` is missing");
           };
         }
       }
-      const boundCredentialsProvider = async () => credentialsProvider({ callerClientConfig: config });
       const { signingEscapePath = true, systemClockOffset = config.systemClockOffset || 0, sha256 } = config;
       let signer;
       if (config.signer) {
@@ -27843,7 +27913,7 @@ var init_resolveAwsSdkSigV4Config = __esm({
           config.signingName = config.signingName || signingService || config.serviceId;
           const params = {
             ...config,
-            credentials: boundCredentialsProvider,
+            credentials: normalizedCreds,
             region: config.signingRegion,
             service: config.signingName,
             sha256,
@@ -27866,7 +27936,7 @@ var init_resolveAwsSdkSigV4Config = __esm({
           config.signingName = config.signingName || signingService || config.serviceId;
           const params = {
             ...config,
-            credentials: boundCredentialsProvider,
+            credentials: normalizedCreds,
             region: config.signingRegion,
             service: config.signingName,
             sha256,
@@ -27880,7 +27950,7 @@ var init_resolveAwsSdkSigV4Config = __esm({
         ...config,
         systemClockOffset,
         signingEscapePath,
-        credentials: isUserSupplied ? async () => boundCredentialsProvider().then((creds) => setCredentialFeature(creds, "CREDENTIALS_CODE", "e")) : boundCredentialsProvider,
+        credentials: isUserSupplied ? async () => normalizedCreds().then((creds) => setCredentialFeature(creds, "CREDENTIALS_CODE", "e")) : normalizedCreds,
         signer
       };
     };
@@ -28048,13 +28118,14 @@ var require_dist_cjs18 = __commonJS({
         return isRemoved;
       }, "removeByReference");
       const cloneTo = /* @__PURE__ */ __name((toStack) => {
+        var _a;
         absoluteEntries.forEach((entry) => {
           toStack.add(entry.middleware, { ...entry });
         });
         relativeEntries.forEach((entry) => {
           toStack.addRelativeTo(entry.middleware, { ...entry });
         });
-        toStack.identifyOnResolve?.(stack.identifyOnResolve());
+        (_a = toStack.identifyOnResolve) == null ? void 0 : _a.call(toStack, stack.identifyOnResolve());
         return toStack;
       }, "cloneTo");
       const expandRelativeMiddlewareList = /* @__PURE__ */ __name((from) => {
@@ -28146,7 +28217,10 @@ var require_dist_cjs18 = __commonJS({
                 throw new Error(`Duplicate middleware name '${getMiddlewareNameWithAliases(name, _aliases)}'`);
               for (const alias of aliases) {
                 const toOverrideIndex = absoluteEntries.findIndex(
-                  (entry2) => entry2.name === alias || entry2.aliases?.some((a) => a === alias)
+                  (entry2) => {
+                    var _a;
+                    return entry2.name === alias || ((_a = entry2.aliases) == null ? void 0 : _a.some((a) => a === alias));
+                  }
                 );
                 if (toOverrideIndex === -1) {
                   continue;
@@ -28179,7 +28253,10 @@ var require_dist_cjs18 = __commonJS({
                 throw new Error(`Duplicate middleware name '${getMiddlewareNameWithAliases(name, _aliases)}'`);
               for (const alias of aliases) {
                 const toOverrideIndex = relativeEntries.findIndex(
-                  (entry2) => entry2.name === alias || entry2.aliases?.some((a) => a === alias)
+                  (entry2) => {
+                    var _a;
+                    return entry2.name === alias || ((_a = entry2.aliases) == null ? void 0 : _a.some((a) => a === alias));
+                  }
                 );
                 if (toOverrideIndex === -1) {
                   continue;
@@ -28228,10 +28305,11 @@ var require_dist_cjs18 = __commonJS({
           return isRemoved;
         },
         concat: (from) => {
+          var _a;
           const cloned = cloneTo(constructStack());
           cloned.use(from);
           cloned.identifyOnResolve(
-            identifyOnResolve || cloned.identifyOnResolve() || (from.identifyOnResolve?.() ?? false)
+            identifyOnResolve || cloned.identifyOnResolve() || (((_a = from.identifyOnResolve) == null ? void 0 : _a.call(from)) ?? false)
           );
           return cloned;
         },
@@ -28361,13 +28439,10 @@ var require_dist_cjs19 = __commonJS({
     });
     module2.exports = __toCommonJS2(src_exports);
     var import_middleware_stack = require_dist_cjs18();
-    var Client = class {
+    var _Client = class _Client {
       constructor(config) {
         this.config = config;
         this.middlewareStack = (0, import_middleware_stack.constructStack)();
-      }
-      static {
-        __name(this, "Client");
       }
       send(command, optionsOrCb, cb) {
         const options = typeof optionsOrCb !== "function" ? optionsOrCb : void 0;
@@ -28404,18 +28479,18 @@ var require_dist_cjs19 = __commonJS({
         }
       }
       destroy() {
-        this.config?.requestHandler?.destroy?.();
+        var _a, _b, _c;
+        (_c = (_b = (_a = this.config) == null ? void 0 : _a.requestHandler) == null ? void 0 : _b.destroy) == null ? void 0 : _c.call(_b);
         delete this.handlers;
       }
     };
+    __name(_Client, "Client");
+    var Client = _Client;
     var import_protocols2 = (init_protocols(), __toCommonJS(protocols_exports));
     var import_types5 = require_dist_cjs();
-    var Command = class {
+    var _Command = class _Command {
       constructor() {
         this.middlewareStack = (0, import_middleware_stack.constructStack)();
-      }
-      static {
-        __name(this, "Command");
       }
       /**
        * Factory for Command ClassBuilder.
@@ -28461,7 +28536,9 @@ var require_dist_cjs19 = __commonJS({
         );
       }
     };
-    var ClassBuilder = class {
+    __name(_Command, "Command");
+    var Command = _Command;
+    var _ClassBuilder = class _ClassBuilder {
       constructor() {
         this._init = () => {
         };
@@ -28475,9 +28552,6 @@ var require_dist_cjs19 = __commonJS({
         this._outputFilterSensitiveLog = (_) => _;
         this._serializer = null;
         this._deserializer = null;
-      }
-      static {
-        __name(this, "ClassBuilder");
       }
       /**
        * Optional init callback.
@@ -28551,9 +28625,10 @@ var require_dist_cjs19 = __commonJS({
        * @returns a Command class with the classBuilder properties.
        */
       build() {
+        var _a;
         const closure = this;
         let CommandRef;
-        return CommandRef = class extends Command {
+        return CommandRef = (_a = class extends Command {
           /**
            * @public
            */
@@ -28563,9 +28638,6 @@ var require_dist_cjs19 = __commonJS({
             this.deserialize = closure._deserializer;
             this.input = input ?? {};
             closure._init(this);
-          }
-          static {
-            __name(this, "CommandRef");
           }
           /**
            * @public
@@ -28588,9 +28660,11 @@ var require_dist_cjs19 = __commonJS({
               additionalContext: closure._additionalContext
             });
           }
-        };
+        }, __name(_a, "CommandRef"), _a);
       }
     };
+    __name(_ClassBuilder, "ClassBuilder");
+    var ClassBuilder = _ClassBuilder;
     var SENSITIVE_STRING = "***SensitiveInformation***";
     var createAggregatedClient = /* @__PURE__ */ __name((commands, Client2) => {
       for (const command of Object.keys(commands)) {
@@ -29061,13 +29135,10 @@ var require_dist_cjs19 = __commonJS({
       }
       return value.slice(idx);
     }, "stripLeadingZeroes");
-    var ServiceException = class _ServiceException extends Error {
-      static {
-        __name(this, "ServiceException");
-      }
+    var _ServiceException = class _ServiceException2 extends Error {
       constructor(options) {
         super(options.message);
-        Object.setPrototypeOf(this, _ServiceException.prototype);
+        Object.setPrototypeOf(this, _ServiceException2.prototype);
         this.name = options.name;
         this.$fault = options.$fault;
         this.$metadata = options.$metadata;
@@ -29082,6 +29153,8 @@ var require_dist_cjs19 = __commonJS({
         return Boolean(candidate.$fault) && Boolean(candidate.$metadata) && (candidate.$fault === "client" || candidate.$fault === "server");
       }
     };
+    __name(_ServiceException, "ServiceException");
+    var ServiceException = _ServiceException;
     var decorateServiceException = /* @__PURE__ */ __name((exception2, additions = {}) => {
       Object.entries(additions).filter(([, v]) => v !== void 0).forEach(([k, v]) => {
         if (exception2[k] == void 0 || exception2[k] === "") {
@@ -29097,7 +29170,7 @@ var require_dist_cjs19 = __commonJS({
       const $metadata = deserializeMetadata(output);
       const statusCode = $metadata.httpStatusCode ? $metadata.httpStatusCode + "" : void 0;
       const response = new exceptionCtor({
-        name: parsedBody?.code || parsedBody?.Code || errorCode || statusCode || "UnknownError",
+        name: (parsedBody == null ? void 0 : parsedBody.code) || (parsedBody == null ? void 0 : parsedBody.Code) || errorCode || statusCode || "UnknownError",
         $fault: "client",
         $metadata
       });
@@ -29242,10 +29315,7 @@ var require_dist_cjs19 = __commonJS({
       return LazyJsonString(JSON.stringify(object));
     };
     LazyJsonString.fromObject = LazyJsonString.from;
-    var NoOpLogger = class {
-      static {
-        __name(this, "NoOpLogger");
-      }
+    var _NoOpLogger = class _NoOpLogger {
       trace() {
       }
       debug() {
@@ -29257,6 +29327,8 @@ var require_dist_cjs19 = __commonJS({
       error() {
       }
     };
+    __name(_NoOpLogger, "NoOpLogger");
+    var NoOpLogger = _NoOpLogger;
     function map2(arg0, arg1, arg2) {
       let target;
       let filter;
@@ -31319,6 +31391,7 @@ __export(tslib_es6_exports, {
   __propKey: () => __propKey,
   __read: () => __read,
   __rest: () => __rest,
+  __rewriteRelativeImportExtension: () => __rewriteRelativeImportExtension,
   __runInitializers: () => __runInitializers,
   __setFunctionName: () => __setFunctionName,
   __spread: () => __spread,
@@ -31438,8 +31511,8 @@ function __generator(thisArg, body) {
   var _ = { label: 0, sent: function() {
     if (t[0] & 1) throw t[1];
     return t[1];
-  }, trys: [], ops: [] }, f, y, t, g;
-  return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
+  }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+  return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() {
     return this;
   }), g;
   function verb(n) {
@@ -31561,15 +31634,23 @@ function __await(v) {
 function __asyncGenerator(thisArg, _arguments, generator) {
   if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
   var g = generator.apply(thisArg, _arguments || []), i, q = [];
-  return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function() {
+  return i = Object.create((typeof AsyncIterator === "function" ? AsyncIterator : Object).prototype), verb("next"), verb("throw"), verb("return", awaitReturn), i[Symbol.asyncIterator] = function() {
     return this;
   }, i;
-  function verb(n) {
-    if (g[n]) i[n] = function(v) {
-      return new Promise(function(a, b) {
-        q.push([n, v, a, b]) > 1 || resume(n, v);
-      });
+  function awaitReturn(f) {
+    return function(v) {
+      return Promise.resolve(v).then(f, reject);
     };
+  }
+  function verb(n, f) {
+    if (g[n]) {
+      i[n] = function(v) {
+        return new Promise(function(a, b) {
+          q.push([n, v, a, b]) > 1 || resume(n, v);
+        });
+      };
+      if (f) i[n] = f(i[n]);
+    }
   }
   function resume(n, v) {
     try {
@@ -31635,7 +31716,7 @@ function __importStar(mod) {
   if (mod && mod.__esModule) return mod;
   var result = {};
   if (mod != null) {
-    for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
   }
   __setModuleDefault(result, mod);
   return result;
@@ -31661,7 +31742,7 @@ function __classPrivateFieldIn(state2, receiver) {
 function __addDisposableResource(env, value, async) {
   if (value !== null && value !== void 0) {
     if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-    var dispose;
+    var dispose, inner;
     if (async) {
       if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
       dispose = value[Symbol.asyncDispose];
@@ -31669,8 +31750,16 @@ function __addDisposableResource(env, value, async) {
     if (dispose === void 0) {
       if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
       dispose = value[Symbol.dispose];
+      if (async) inner = dispose;
     }
     if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
+    if (inner) dispose = function() {
+      try {
+        inner.call(this);
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
     env.stack.push({ value, dispose, async });
   } else if (async) {
     env.stack.push({ async: true });
@@ -31682,24 +31771,36 @@ function __disposeResources(env) {
     env.error = env.hasError ? new _SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
     env.hasError = true;
   }
+  var r, s = 0;
   function next() {
-    while (env.stack.length) {
-      var rec = env.stack.pop();
+    while (r = env.stack.pop()) {
       try {
-        var result = rec.dispose && rec.dispose.call(rec.value);
-        if (rec.async) return Promise.resolve(result).then(next, function(e) {
-          fail(e);
-          return next();
-        });
+        if (!r.async && s === 1) return s = 0, env.stack.push(r), Promise.resolve().then(next);
+        if (r.dispose) {
+          var result = r.dispose.call(r.value);
+          if (r.async) return s |= 2, Promise.resolve(result).then(next, function(e) {
+            fail(e);
+            return next();
+          });
+        } else s |= 1;
       } catch (e) {
         fail(e);
       }
     }
+    if (s === 1) return env.hasError ? Promise.reject(env.error) : Promise.resolve();
     if (env.hasError) throw env.error;
   }
   return next();
 }
-var extendStatics, __assign, __createBinding, __setModuleDefault, _SuppressedError, tslib_es6_default;
+function __rewriteRelativeImportExtension(path2, preserveJsx) {
+  if (typeof path2 === "string" && /^\.\.?\//.test(path2)) {
+    return path2.replace(/\.(tsx)$|((?:\.d)?)((?:\.[^./]+?)?)\.([cm]?)ts$/i, function(m, tsx, d, ext, cm) {
+      return tsx ? preserveJsx ? ".jsx" : ".js" : d && (!ext || !cm) ? m : d + ext + "." + cm.toLowerCase() + "js";
+    });
+  }
+  return path2;
+}
+var extendStatics, __assign, __createBinding, __setModuleDefault, ownKeys, _SuppressedError, tslib_es6_default;
 var init_tslib_es6 = __esm({
   "node_modules/tslib/tslib.es6.mjs"() {
     extendStatics = function(d, b) {
@@ -31738,6 +31839,14 @@ var init_tslib_es6 = __esm({
     } : function(o, v) {
       o["default"] = v;
     };
+    ownKeys = function(o) {
+      ownKeys = Object.getOwnPropertyNames || function(o2) {
+        var ar = [];
+        for (var k in o2) if (Object.prototype.hasOwnProperty.call(o2, k)) ar[ar.length] = k;
+        return ar;
+      };
+      return ownKeys(o);
+    };
     _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function(error2, suppressed, message) {
       var e = new Error(message);
       return e.name = "SuppressedError", e.error = error2, e.suppressed = suppressed, e;
@@ -31748,6 +31857,10 @@ var init_tslib_es6 = __esm({
       __rest,
       __decorate,
       __param,
+      __esDecorate,
+      __runInitializers,
+      __propKey,
+      __setFunctionName,
       __metadata,
       __awaiter,
       __generator,
@@ -31769,7 +31882,8 @@ var init_tslib_es6 = __esm({
       __classPrivateFieldSet,
       __classPrivateFieldIn,
       __addDisposableResource,
-      __disposeResources
+      __disposeResources,
+      __rewriteRelativeImportExtension
     };
   }
 });
@@ -32711,7 +32825,9 @@ var require_getCrc32ChecksumAlgorithmFunction = __commonJS({
     var util_1 = require_main2();
     var zlib = tslib_1.__importStar(require("zlib"));
     var NodeCrc32 = class {
-      checksum = 0;
+      constructor() {
+        this.checksum = 0;
+      }
       update(data) {
         this.checksum = zlib.crc32(data, this.checksum);
       }
@@ -32928,35 +33044,32 @@ var require_dist_cjs23 = __commonJS({
       }
       return false;
     }, "hasHeader");
-    var hasHeaderWithPrefix = /* @__PURE__ */ __name((headerPrefix, headers) => {
-      const soughtHeaderPrefix = headerPrefix.toLowerCase();
-      for (const headerName of Object.keys(headers)) {
-        if (headerName.toLowerCase().startsWith(soughtHeaderPrefix)) {
-          return true;
-        }
-      }
-      return false;
-    }, "hasHeaderWithPrefix");
     var import_is_array_buffer = require_dist_cjs6();
     var isStreaming = /* @__PURE__ */ __name((body) => body !== void 0 && typeof body !== "string" && !ArrayBuffer.isView(body) && !(0, import_is_array_buffer.isArrayBuffer)(body), "isStreaming");
     var import_crc32c = require_main3();
     var import_getCrc32ChecksumAlgorithmFunction = require_getCrc32ChecksumAlgorithmFunction();
-    var selectChecksumAlgorithmFunction = /* @__PURE__ */ __name((checksumAlgorithm, config) => {
-      switch (checksumAlgorithm) {
-        case "MD5":
-          return config.md5;
-        case "CRC32":
-          return (0, import_getCrc32ChecksumAlgorithmFunction.getCrc32ChecksumAlgorithmFunction)();
-        case "CRC32C":
-          return import_crc32c.AwsCrc32c;
-        case "SHA1":
-          return config.sha1;
-        case "SHA256":
-          return config.sha256;
-        default:
-          throw new Error(`Unsupported checksum algorithm: ${checksumAlgorithm}`);
-      }
-    }, "selectChecksumAlgorithmFunction");
+    var selectChecksumAlgorithmFunction = /* @__PURE__ */ __name((checksumAlgorithm, config) => ({
+      [
+        "MD5"
+        /* MD5 */
+      ]: config.md5,
+      [
+        "CRC32"
+        /* CRC32 */
+      ]: (0, import_getCrc32ChecksumAlgorithmFunction.getCrc32ChecksumAlgorithmFunction)(),
+      [
+        "CRC32C"
+        /* CRC32C */
+      ]: import_crc32c.AwsCrc32c,
+      [
+        "SHA1"
+        /* SHA1 */
+      ]: config.sha1,
+      [
+        "SHA256"
+        /* SHA256 */
+      ]: config.sha256
+    })[checksumAlgorithm], "selectChecksumAlgorithmFunction");
     var import_util_utf8 = require_dist_cjs8();
     var stringHasher = /* @__PURE__ */ __name((checksumAlgorithmFn, body) => {
       const hash = new checksumAlgorithmFn();
@@ -32973,9 +33086,6 @@ var require_dist_cjs23 = __commonJS({
       if (!import_protocol_http8.HttpRequest.isInstance(args.request)) {
         return next(args);
       }
-      if (hasHeaderWithPrefix("x-amz-checksum-", args.request.headers)) {
-        return next(args);
-      }
       const { request, input } = args;
       const { body: requestBody, headers } = request;
       const { base64Encoder, streamHasher } = config;
@@ -32984,7 +33094,7 @@ var require_dist_cjs23 = __commonJS({
         input,
         {
           requestChecksumRequired,
-          requestAlgorithmMember: requestAlgorithmMember?.name
+          requestAlgorithmMember
         },
         !!context3.isS3ExpressBucket
       );
@@ -33257,6 +33367,7 @@ var require_dist_cjs25 = __commonJS({
     });
     module2.exports = __toCommonJS2(src_exports);
     var loggerMiddleware = /* @__PURE__ */ __name(() => (next, context3) => async (args) => {
+      var _a, _b;
       try {
         const response = await next(args);
         const { clientName, commandName, logger, dynamoDbDocumentClientOptions = {} } = context3;
@@ -33264,7 +33375,7 @@ var require_dist_cjs25 = __commonJS({
         const inputFilterSensitiveLog = overrideInputFilterSensitiveLog ?? context3.inputFilterSensitiveLog;
         const outputFilterSensitiveLog = overrideOutputFilterSensitiveLog ?? context3.outputFilterSensitiveLog;
         const { $metadata, ...outputWithoutMetadata } = response.output;
-        logger?.info?.({
+        (_a = logger == null ? void 0 : logger.info) == null ? void 0 : _a.call(logger, {
           clientName,
           commandName,
           input: inputFilterSensitiveLog(args.input),
@@ -33276,7 +33387,7 @@ var require_dist_cjs25 = __commonJS({
         const { clientName, commandName, logger, dynamoDbDocumentClientOptions = {} } = context3;
         const { overrideInputFilterSensitiveLog } = dynamoDbDocumentClientOptions;
         const inputFilterSensitiveLog = overrideInputFilterSensitiveLog ?? context3.inputFilterSensitiveLog;
-        logger?.error?.({
+        (_b = logger == null ? void 0 : logger.error) == null ? void 0 : _b.call(logger, {
           clientName,
           commandName,
           input: inputFilterSensitiveLog(args.input),
@@ -33539,11 +33650,12 @@ var require_dist_cjs29 = __commonJS({
     var CONTENT_LENGTH_HEADER = "content-length";
     function checkContentLengthHeader() {
       return (next, context3) => async (args) => {
+        var _a;
         const { request } = args;
         if (import_protocol_http8.HttpRequest.isInstance(request)) {
           if (!(CONTENT_LENGTH_HEADER in request.headers)) {
             const message = `Are you using a Stream of unknown length as the Body of a PutObject request? Consider using Upload instead from @aws-sdk/lib-storage.`;
-            if (typeof context3?.logger?.warn === "function" && !(context3.logger instanceof import_smithy_client4.NoOpLogger)) {
+            if (typeof ((_a = context3 == null ? void 0 : context3.logger) == null ? void 0 : _a.warn) === "function" && !(context3.logger instanceof import_smithy_client4.NoOpLogger)) {
               context3.logger.warn(message);
             } else {
               console.warn(message);
@@ -33608,15 +33720,16 @@ var require_dist_cjs29 = __commonJS({
     };
     function regionRedirectMiddleware(clientConfig) {
       return (next, context3) => async (args) => {
+        var _a, _b, _c;
         try {
           return await next(args);
         } catch (err) {
           if (clientConfig.followRegionRedirects) {
-            if (err?.$metadata?.httpStatusCode === 301 || // err.name === "PermanentRedirect" && --> removing the error name check, as that allows for HEAD operations (which have the 301 status code, but not the same error name) to be covered for region redirection as well
-            err?.$metadata?.httpStatusCode === 400 && err?.name === "IllegalLocationConstraintException") {
+            if (((_a = err == null ? void 0 : err.$metadata) == null ? void 0 : _a.httpStatusCode) === 301 || // err.name === "PermanentRedirect" && --> removing the error name check, as that allows for HEAD operations (which have the 301 status code, but not the same error name) to be covered for region redirection as well
+            ((_b = err == null ? void 0 : err.$metadata) == null ? void 0 : _b.httpStatusCode) === 400 && (err == null ? void 0 : err.name) === "IllegalLocationConstraintException") {
               try {
                 const actualRegion = err.$response.headers["x-amz-bucket-region"];
-                context3.logger?.debug(`Redirecting from ${await clientConfig.region()} to ${actualRegion}`);
+                (_c = context3.logger) == null ? void 0 : _c.debug(`Redirecting from ${await clientConfig.region()} to ${actualRegion}`);
                 context3.__s3RegionRedirect = actualRegion;
               } catch (e) {
                 throw new Error("Region redirect failed: " + e);
@@ -33643,6 +33756,7 @@ var require_dist_cjs29 = __commonJS({
     }), "getRegionRedirectMiddlewarePlugin");
     var s3ExpiresMiddleware = /* @__PURE__ */ __name((config) => {
       return (next, context3) => async (args) => {
+        var _a;
         const result = await next(args);
         const { response } = result;
         if (import_protocol_http8.HttpResponse.isInstance(response)) {
@@ -33651,7 +33765,7 @@ var require_dist_cjs29 = __commonJS({
             try {
               (0, import_smithy_client4.parseRfc7231DateTime)(response.headers.expires);
             } catch (e) {
-              context3.logger?.warn(
+              (_a = context3.logger) == null ? void 0 : _a.warn(
                 `AWS SDK Warning for ${context3.clientName}::${context3.commandName} response parsing (${response.headers.expires}): ${e}`
               );
               delete response.headers.expires;
@@ -33673,15 +33787,11 @@ var require_dist_cjs29 = __commonJS({
         clientStack.addRelativeTo(s3ExpiresMiddleware(clientConfig), s3ExpiresMiddlewareOptions);
       }
     }), "getS3ExpiresMiddlewarePlugin");
-    var S3ExpressIdentityCache = class _S3ExpressIdentityCache {
+    var _S3ExpressIdentityCache = class _S3ExpressIdentityCache2 {
       constructor(data = {}) {
         this.data = data;
+        this.lastPurgeTime = Date.now();
       }
-      static {
-        __name(this, "S3ExpressIdentityCache");
-      }
-      lastPurgeTime = Date.now();
-      static EXPIRED_CREDENTIAL_PURGE_INTERVAL_MS = 3e4;
       get(key) {
         const entry = this.data[key];
         if (!entry) {
@@ -33698,7 +33808,7 @@ var require_dist_cjs29 = __commonJS({
       }
       async purgeExpired() {
         const now = Date.now();
-        if (this.lastPurgeTime + _S3ExpressIdentityCache.EXPIRED_CREDENTIAL_PURGE_INTERVAL_MS > now) {
+        if (this.lastPurgeTime + _S3ExpressIdentityCache2.EXPIRED_CREDENTIAL_PURGE_INTERVAL_MS > now) {
           return;
         }
         for (const key in this.data) {
@@ -33714,7 +33824,10 @@ var require_dist_cjs29 = __commonJS({
         }
       }
     };
-    var S3ExpressIdentityCacheEntry = class {
+    __name(_S3ExpressIdentityCache, "S3ExpressIdentityCache");
+    _S3ExpressIdentityCache.EXPIRED_CREDENTIAL_PURGE_INTERVAL_MS = 3e4;
+    var S3ExpressIdentityCache = _S3ExpressIdentityCache;
+    var _S3ExpressIdentityCacheEntry = class _S3ExpressIdentityCacheEntry {
       /**
        * @param identity - stored identity.
        * @param accessed - timestamp of last access in epoch ms.
@@ -33725,34 +33838,30 @@ var require_dist_cjs29 = __commonJS({
         this.isRefreshing = isRefreshing;
         this.accessed = accessed;
       }
-      static {
-        __name(this, "S3ExpressIdentityCacheEntry");
-      }
       get identity() {
         this.accessed = Date.now();
         return this._identity;
       }
     };
-    var S3ExpressIdentityProviderImpl = class _S3ExpressIdentityProviderImpl {
+    __name(_S3ExpressIdentityCacheEntry, "S3ExpressIdentityCacheEntry");
+    var S3ExpressIdentityCacheEntry = _S3ExpressIdentityCacheEntry;
+    var _S3ExpressIdentityProviderImpl = class _S3ExpressIdentityProviderImpl2 {
       constructor(createSessionFn, cache = new S3ExpressIdentityCache()) {
         this.createSessionFn = createSessionFn;
         this.cache = cache;
       }
-      static {
-        __name(this, "S3ExpressIdentityProviderImpl");
-      }
-      static REFRESH_WINDOW_MS = 6e4;
       async getS3ExpressIdentity(awsIdentity, identityProperties) {
         const key = identityProperties.Bucket;
         const { cache } = this;
         const entry = cache.get(key);
         if (entry) {
           return entry.identity.then((identity) => {
-            const isExpired = (identity.expiration?.getTime() ?? 0) < Date.now();
+            var _a, _b;
+            const isExpired = (((_a = identity.expiration) == null ? void 0 : _a.getTime()) ?? 0) < Date.now();
             if (isExpired) {
               return cache.set(key, new S3ExpressIdentityCacheEntry(this.getIdentity(key))).identity;
             }
-            const isExpiringSoon = (identity.expiration?.getTime() ?? 0) < Date.now() + _S3ExpressIdentityProviderImpl.REFRESH_WINDOW_MS;
+            const isExpiringSoon = (((_b = identity.expiration) == null ? void 0 : _b.getTime()) ?? 0) < Date.now() + _S3ExpressIdentityProviderImpl2.REFRESH_WINDOW_MS;
             if (isExpiringSoon && !entry.isRefreshing) {
               entry.isRefreshing = true;
               this.getIdentity(key).then((id) => {
@@ -33765,11 +33874,12 @@ var require_dist_cjs29 = __commonJS({
         return cache.set(key, new S3ExpressIdentityCacheEntry(this.getIdentity(key))).identity;
       }
       async getIdentity(key) {
+        var _a, _b;
         await this.cache.purgeExpired().catch((error2) => {
           console.warn("Error while clearing expired entries in S3ExpressIdentityCache: \n" + error2);
         });
         const session = await this.createSessionFn(key);
-        if (!session.Credentials?.AccessKeyId || !session.Credentials?.SecretAccessKey) {
+        if (!((_a = session.Credentials) == null ? void 0 : _a.AccessKeyId) || !((_b = session.Credentials) == null ? void 0 : _b.SecretAccessKey)) {
           throw new Error("s3#createSession response credential missing AccessKeyId or SecretAccessKey.");
         }
         const identity = {
@@ -33781,6 +33891,9 @@ var require_dist_cjs29 = __commonJS({
         return identity;
       }
     };
+    __name(_S3ExpressIdentityProviderImpl, "S3ExpressIdentityProviderImpl");
+    _S3ExpressIdentityProviderImpl.REFRESH_WINDOW_MS = 6e4;
+    var S3ExpressIdentityProviderImpl = _S3ExpressIdentityProviderImpl;
     var import_signature_v42 = require_dist_cjs17();
     var import_util_config_provider = require_dist_cjs27();
     var S3_EXPRESS_BUCKET_TYPE = "Directory";
@@ -33795,10 +33908,7 @@ var require_dist_cjs29 = __commonJS({
       configFileSelector: (profile) => (0, import_util_config_provider.booleanSelector)(profile, NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_INI_NAME, import_util_config_provider.SelectorType.CONFIG),
       default: false
     };
-    var SignatureV4S3Express = class extends import_signature_v42.SignatureV4 {
-      static {
-        __name(this, "SignatureV4S3Express");
-      }
+    var _SignatureV4S3Express = class _SignatureV4S3Express extends import_signature_v42.SignatureV4 {
       /**
        * Signs with alternate provided credentials instead of those provided in the
        * constructor.
@@ -33827,6 +33937,8 @@ var require_dist_cjs29 = __commonJS({
         return this.presign(requestToSign, options);
       }
     };
+    __name(_SignatureV4S3Express, "SignatureV4S3Express");
+    var SignatureV4S3Express = _SignatureV4S3Express;
     function getCredentialsWithoutSessionToken(credentials) {
       const credentialsWithoutSessionToken = {
         accessKeyId: credentials.accessKeyId,
@@ -33852,10 +33964,11 @@ var require_dist_cjs29 = __commonJS({
     var import_core4 = (init_dist_es2(), __toCommonJS(dist_es_exports2));
     var s3ExpressMiddleware = /* @__PURE__ */ __name((options) => {
       return (next, context3) => async (args) => {
+        var _a, _b, _c, _d, _e;
         if (context3.endpointV2) {
           const endpoint = context3.endpointV2;
-          const isS3ExpressAuth = endpoint.properties?.authSchemes?.[0]?.name === S3_EXPRESS_AUTH_SCHEME;
-          const isS3ExpressBucket = endpoint.properties?.backend === S3_EXPRESS_BACKEND || endpoint.properties?.bucketType === S3_EXPRESS_BUCKET_TYPE;
+          const isS3ExpressAuth = ((_c = (_b = (_a = endpoint.properties) == null ? void 0 : _a.authSchemes) == null ? void 0 : _b[0]) == null ? void 0 : _c.name) === S3_EXPRESS_AUTH_SCHEME;
+          const isS3ExpressBucket = ((_d = endpoint.properties) == null ? void 0 : _d.backend) === S3_EXPRESS_BACKEND || ((_e = endpoint.properties) == null ? void 0 : _e.bucketType) === S3_EXPRESS_BUCKET_TYPE;
           if (isS3ExpressBucket) {
             (0, import_core4.setFeature)(context3, "S3_EXPRESS_BUCKET", "J");
             context3.isS3ExpressBucket = true;
@@ -33983,7 +34096,7 @@ var require_dist_cjs29 = __commonJS({
       if (statusCode < 200 || statusCode >= 300) {
         return result;
       }
-      const isSplittableStream = typeof sourceBody?.stream === "function" || typeof sourceBody?.pipe === "function" || typeof sourceBody?.tee === "function";
+      const isSplittableStream = typeof (sourceBody == null ? void 0 : sourceBody.stream) === "function" || typeof (sourceBody == null ? void 0 : sourceBody.pipe) === "function" || typeof (sourceBody == null ? void 0 : sourceBody.tee) === "function";
       if (!isSplittableStream) {
         return result;
       }
@@ -33998,7 +34111,7 @@ var require_dist_cjs29 = __commonJS({
           return (0, import_util_stream2.headStream)(stream, MAX_BYTES_TO_INSPECT);
         }
       });
-      if (typeof bodyCopy?.destroy === "function") {
+      if (typeof (bodyCopy == null ? void 0 : bodyCopy.destroy) === "function") {
         bodyCopy.destroy();
       }
       const bodyStringTail = config.utf8Encoder(bodyBytes.subarray(bodyBytes.length - 16));
@@ -34033,6 +34146,7 @@ var require_dist_cjs29 = __commonJS({
     var import_util_arn_parser = require_dist_cjs28();
     function bucketEndpointMiddleware(options) {
       return (next, context3) => async (args) => {
+        var _a, _b, _c, _d;
         if (options.bucketEndpoint) {
           const endpoint = context3.endpointV2;
           if (endpoint) {
@@ -34046,10 +34160,10 @@ var require_dist_cjs29 = __commonJS({
                 };
               } catch (e) {
                 const warning = `@aws-sdk/middleware-sdk-s3: bucketEndpoint=true was set but Bucket=${bucket} could not be parsed as URL.`;
-                if (context3.logger?.constructor?.name === "NoOpLogger") {
+                if (((_b = (_a = context3.logger) == null ? void 0 : _a.constructor) == null ? void 0 : _b.name) === "NoOpLogger") {
                   console.warn(warning);
                 } else {
-                  context3.logger?.warn?.(warning);
+                  (_d = (_c = context3.logger) == null ? void 0 : _c.warn) == null ? void 0 : _d.call(_c, warning);
                 }
                 throw e;
               }
@@ -34126,7 +34240,7 @@ var require_dist_cjs30 = __commonJS({
       resolveEndpoint: () => resolveEndpoint2
     });
     module2.exports = __toCommonJS2(src_exports);
-    var EndpointCache = class {
+    var _EndpointCache = class _EndpointCache {
       /**
        * @param [size] - desired average maximum capacity. A buffer of 10 additional keys will be allowed
        *                 before keys are dropped.
@@ -34142,9 +34256,6 @@ var require_dist_cjs30 = __commonJS({
         if (params) {
           this.parameters = params;
         }
-      }
-      static {
-        __name(this, "EndpointCache");
       }
       /**
        * @param endpointParams - query for endpoint.
@@ -34194,6 +34305,8 @@ var require_dist_cjs30 = __commonJS({
         return buffer;
       }
     };
+    __name(_EndpointCache, "EndpointCache");
+    var EndpointCache = _EndpointCache;
     var IP_V4_REGEX = new RegExp(
       `^(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}$`
     );
@@ -34226,15 +34339,14 @@ var require_dist_cjs30 = __commonJS({
       return JSON.stringify(input, null, 2);
     }
     __name(toDebugString, "toDebugString");
-    var EndpointError2 = class extends Error {
-      static {
-        __name(this, "EndpointError");
-      }
+    var _EndpointError = class _EndpointError extends Error {
       constructor(message) {
         super(message);
         this.name = "EndpointError";
       }
     };
+    __name(_EndpointError, "EndpointError");
+    var EndpointError2 = _EndpointError;
     var booleanEquals = /* @__PURE__ */ __name((value1, value2) => value1 === value2, "booleanEquals");
     var getAttrPathList = /* @__PURE__ */ __name((path2) => {
       const parts = path2.split(".");
@@ -34399,17 +34511,19 @@ var require_dist_cjs30 = __commonJS({
       return endpointFunctions[fn](...evaluatedArgs);
     }, "callFunction");
     var evaluateCondition = /* @__PURE__ */ __name(({ assign, ...fnArgs }, options) => {
+      var _a, _b;
       if (assign && assign in options.referenceRecord) {
         throw new EndpointError2(`'${assign}' is already defined in Reference Record.`);
       }
       const value = callFunction(fnArgs, options);
-      options.logger?.debug?.(`${debugId} evaluateCondition: ${toDebugString(fnArgs)} = ${toDebugString(value)}`);
+      (_b = (_a = options.logger) == null ? void 0 : _a.debug) == null ? void 0 : _b.call(_a, `${debugId} evaluateCondition: ${toDebugString(fnArgs)} = ${toDebugString(value)}`);
       return {
         result: value === "" ? true : !!value,
         ...assign != null && { toAssign: { name: assign, value } }
       };
     }, "evaluateCondition");
     var evaluateConditions = /* @__PURE__ */ __name((conditions = [], options) => {
+      var _a, _b;
       const conditionsReferenceRecord = {};
       for (const condition of conditions) {
         const { result, toAssign } = evaluateCondition(condition, {
@@ -34424,7 +34538,7 @@ var require_dist_cjs30 = __commonJS({
         }
         if (toAssign) {
           conditionsReferenceRecord[toAssign.name] = toAssign.value;
-          options.logger?.debug?.(`${debugId} assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`);
+          (_b = (_a = options.logger) == null ? void 0 : _a.debug) == null ? void 0 : _b.call(_a, `${debugId} assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`);
         }
       }
       return { result: true, referenceRecord: conditionsReferenceRecord };
@@ -34480,6 +34594,7 @@ var require_dist_cjs30 = __commonJS({
       throw new EndpointError2(`Endpoint URL must be a string, got ${typeof expression}`);
     }, "getEndpointUrl");
     var evaluateEndpointRule = /* @__PURE__ */ __name((endpointRule, options) => {
+      var _a, _b;
       const { conditions, endpoint } = endpointRule;
       const { result, referenceRecord } = evaluateConditions(conditions, options);
       if (!result) {
@@ -34490,7 +34605,7 @@ var require_dist_cjs30 = __commonJS({
         referenceRecord: { ...options.referenceRecord, ...referenceRecord }
       };
       const { url, properties, headers } = endpoint;
-      options.logger?.debug?.(`${debugId} Resolving endpoint from template: ${toDebugString(endpoint)}`);
+      (_b = (_a = options.logger) == null ? void 0 : _a.debug) == null ? void 0 : _b.call(_a, `${debugId} Resolving endpoint from template: ${toDebugString(endpoint)}`);
       return {
         ...headers != void 0 && {
           headers: getEndpointHeaders(headers, endpointRuleOptions)
@@ -34546,9 +34661,10 @@ var require_dist_cjs30 = __commonJS({
       throw new EndpointError2(`Rules evaluation failed`);
     }, "evaluateRules");
     var resolveEndpoint2 = /* @__PURE__ */ __name((ruleSetObject, options) => {
+      var _a, _b, _c, _d;
       const { endpointParams, logger } = options;
       const { parameters, rules } = ruleSetObject;
-      options.logger?.debug?.(`${debugId} Initial EndpointParams: ${toDebugString(endpointParams)}`);
+      (_b = (_a = options.logger) == null ? void 0 : _a.debug) == null ? void 0 : _b.call(_a, `${debugId} Initial EndpointParams: ${toDebugString(endpointParams)}`);
       const paramsWithDefault = Object.entries(parameters).filter(([, v]) => v.default != null).map(([k, v]) => [k, v.default]);
       if (paramsWithDefault.length > 0) {
         for (const [paramKey, paramDefaultValue] of paramsWithDefault) {
@@ -34562,7 +34678,7 @@ var require_dist_cjs30 = __commonJS({
         }
       }
       const endpoint = evaluateRules(rules, { endpointParams, logger, referenceRecord: {} });
-      options.logger?.debug?.(`${debugId} Resolved endpoint: ${toDebugString(endpoint)}`);
+      (_d = (_c = options.logger) == null ? void 0 : _c.debug) == null ? void 0 : _d.call(_c, `${debugId} Resolved endpoint: ${toDebugString(endpoint)}`);
       return endpoint;
     }, "resolveEndpoint");
   }
@@ -34983,13 +35099,14 @@ var require_dist_cjs32 = __commonJS({
         ...input,
         customUserAgent: typeof input.customUserAgent === "string" ? [[input.customUserAgent]] : input.customUserAgent,
         userAgentAppId: async () => {
+          var _a, _b;
           const appId = await normalizedAppIdProvider();
           if (!isValidUserAgentAppId(appId)) {
-            const logger = input.logger?.constructor?.name === "NoOpLogger" || !input.logger ? console : input.logger;
+            const logger = ((_b = (_a = input.logger) == null ? void 0 : _a.constructor) == null ? void 0 : _b.name) === "NoOpLogger" || !input.logger ? console : input.logger;
             if (typeof appId !== "string") {
-              logger?.warn("userAgentAppId must be a string or undefined.");
+              logger == null ? void 0 : logger.warn("userAgentAppId must be a string or undefined.");
             } else if (appId.length > 50) {
-              logger?.warn("The provided userAgentAppId exceeds the maximum length of 50 characters.");
+              logger == null ? void 0 : logger.warn("The provided userAgentAppId exceeds the maximum length of 50 characters.");
             }
           }
           return appId;
@@ -35002,14 +35119,15 @@ var require_dist_cjs32 = __commonJS({
     var import_core22 = (init_dist_es2(), __toCommonJS(dist_es_exports2));
     var ACCOUNT_ID_ENDPOINT_REGEX = /\d{12}\.ddb/;
     async function checkFeatures(context3, config, args) {
+      var _a, _b, _c, _d, _e, _f, _g;
       const request = args.request;
-      if (request?.headers?.["smithy-protocol"] === "rpc-v2-cbor") {
+      if (((_a = request == null ? void 0 : request.headers) == null ? void 0 : _a["smithy-protocol"]) === "rpc-v2-cbor") {
         (0, import_core22.setFeature)(context3, "PROTOCOL_RPC_V2_CBOR", "M");
       }
       if (typeof config.retryStrategy === "function") {
         const retryStrategy = await config.retryStrategy();
         if (typeof retryStrategy.acquireInitialRetryToken === "function") {
-          if (retryStrategy.constructor?.name?.includes("Adaptive")) {
+          if ((_c = (_b = retryStrategy.constructor) == null ? void 0 : _b.name) == null ? void 0 : _c.includes("Adaptive")) {
             (0, import_core22.setFeature)(context3, "RETRY_MODE_ADAPTIVE", "F");
           } else {
             (0, import_core22.setFeature)(context3, "RETRY_MODE_STANDARD", "E");
@@ -35020,10 +35138,10 @@ var require_dist_cjs32 = __commonJS({
       }
       if (typeof config.accountIdEndpointMode === "function") {
         const endpointV2 = context3.endpointV2;
-        if (String(endpointV2?.url?.hostname).match(ACCOUNT_ID_ENDPOINT_REGEX)) {
+        if (String((_d = endpointV2 == null ? void 0 : endpointV2.url) == null ? void 0 : _d.hostname).match(ACCOUNT_ID_ENDPOINT_REGEX)) {
           (0, import_core22.setFeature)(context3, "ACCOUNT_ID_ENDPOINT", "O");
         }
-        switch (await config.accountIdEndpointMode?.()) {
+        switch (await ((_e = config.accountIdEndpointMode) == null ? void 0 : _e.call(config))) {
           case "disabled":
             (0, import_core22.setFeature)(context3, "ACCOUNT_ID_MODE_DISABLED", "Q");
             break;
@@ -35035,8 +35153,8 @@ var require_dist_cjs32 = __commonJS({
             break;
         }
       }
-      const identity = context3.__smithy_context?.selectedHttpAuthScheme?.identity;
-      if (identity?.$source) {
+      const identity = (_g = (_f = context3.__smithy_context) == null ? void 0 : _f.selectedHttpAuthScheme) == null ? void 0 : _g.identity;
+      if (identity == null ? void 0 : identity.$source) {
         const credentials = identity;
         if (credentials.accountId) {
           (0, import_core22.setFeature)(context3, "RESOLVED_ACCOUNT_ID", "T");
@@ -35073,21 +35191,22 @@ var require_dist_cjs32 = __commonJS({
     }
     __name(encodeFeatures, "encodeFeatures");
     var userAgentMiddleware = /* @__PURE__ */ __name((options) => (next, context3) => async (args) => {
+      var _a, _b, _c, _d;
       const { request } = args;
       if (!import_protocol_http8.HttpRequest.isInstance(request)) {
         return next(args);
       }
       const { headers } = request;
-      const userAgent = context3?.userAgent?.map(escapeUserAgent) || [];
+      const userAgent = ((_a = context3 == null ? void 0 : context3.userAgent) == null ? void 0 : _a.map(escapeUserAgent)) || [];
       const defaultUserAgent = (await options.defaultUserAgentProvider()).map(escapeUserAgent);
       await checkFeatures(context3, options, args);
       const awsContext = context3;
       defaultUserAgent.push(
         `m/${encodeFeatures(
-          Object.assign({}, context3.__smithy_context?.features, awsContext.__aws_sdk_context?.features)
+          Object.assign({}, (_b = context3.__smithy_context) == null ? void 0 : _b.features, (_c = awsContext.__aws_sdk_context) == null ? void 0 : _c.features)
         )}`
       );
-      const customUserAgent = options?.customUserAgent?.map(escapeUserAgent) || [];
+      const customUserAgent = ((_d = options == null ? void 0 : options.customUserAgent) == null ? void 0 : _d.map(escapeUserAgent)) || [];
       const appId = await options.userAgentAppId();
       if (appId) {
         defaultUserAgent.push(escapeUserAgent([`app/${appId}`]));
@@ -35112,8 +35231,9 @@ var require_dist_cjs32 = __commonJS({
       });
     }, "userAgentMiddleware");
     var escapeUserAgent = /* @__PURE__ */ __name((userAgentPair) => {
+      var _a;
       const name = userAgentPair[0].split(UA_NAME_SEPARATOR).map((part) => part.replace(UA_NAME_ESCAPE_REGEX, UA_ESCAPE_CHAR)).join(UA_NAME_SEPARATOR);
-      const version2 = userAgentPair[1]?.replace(UA_VALUE_ESCAPE_REGEX, UA_ESCAPE_CHAR);
+      const version2 = (_a = userAgentPair[1]) == null ? void 0 : _a.replace(UA_VALUE_ESCAPE_REGEX, UA_ESCAPE_CHAR);
       const prefixSeparatorIndex = name.indexOf(UA_NAME_SEPARATOR);
       const prefix = name.substring(0, prefixSeparatorIndex);
       let uaName = name.substring(prefixSeparatorIndex + 1);
@@ -35278,9 +35398,12 @@ var require_dist_cjs33 = __commonJS({
         }
       };
     }, "resolveRegionConfig");
-    var getHostnameFromVariants = /* @__PURE__ */ __name((variants = [], { useFipsEndpoint, useDualstackEndpoint }) => variants.find(
-      ({ tags }) => useFipsEndpoint === tags.includes("fips") && useDualstackEndpoint === tags.includes("dualstack")
-    )?.hostname, "getHostnameFromVariants");
+    var getHostnameFromVariants = /* @__PURE__ */ __name((variants = [], { useFipsEndpoint, useDualstackEndpoint }) => {
+      var _a;
+      return (_a = variants.find(
+        ({ tags }) => useFipsEndpoint === tags.includes("fips") && useDualstackEndpoint === tags.includes("dualstack")
+      )) == null ? void 0 : _a.hostname;
+    }, "getHostnameFromVariants");
     var getResolvedHostname = /* @__PURE__ */ __name((resolvedRegion, { regionHostname, partitionHostname }) => regionHostname ? regionHostname : partitionHostname ? partitionHostname.replace("{region}", resolvedRegion) : void 0, "getResolvedHostname");
     var getResolvedPartition = /* @__PURE__ */ __name((region, { partitionHash }) => Object.keys(partitionHash || {}).find((key) => partitionHash[key].regions.includes(region)) ?? "aws", "getResolvedPartition");
     var getResolvedSigningRegion = /* @__PURE__ */ __name((hostname, { signingRegion, regionRegex, useFipsEndpoint }) => {
@@ -35301,17 +35424,18 @@ var require_dist_cjs33 = __commonJS({
       regionHash,
       partitionHash
     }) => {
+      var _a, _b, _c, _d, _e;
       const partition = getResolvedPartition(region, { partitionHash });
-      const resolvedRegion = region in regionHash ? region : partitionHash[partition]?.endpoint ?? region;
+      const resolvedRegion = region in regionHash ? region : ((_a = partitionHash[partition]) == null ? void 0 : _a.endpoint) ?? region;
       const hostnameOptions = { useFipsEndpoint, useDualstackEndpoint };
-      const regionHostname = getHostnameFromVariants(regionHash[resolvedRegion]?.variants, hostnameOptions);
-      const partitionHostname = getHostnameFromVariants(partitionHash[partition]?.variants, hostnameOptions);
+      const regionHostname = getHostnameFromVariants((_b = regionHash[resolvedRegion]) == null ? void 0 : _b.variants, hostnameOptions);
+      const partitionHostname = getHostnameFromVariants((_c = partitionHash[partition]) == null ? void 0 : _c.variants, hostnameOptions);
       const hostname = getResolvedHostname(resolvedRegion, { regionHostname, partitionHostname });
       if (hostname === void 0) {
         throw new Error(`Endpoint resolution failed for: ${{ resolvedRegion, useFipsEndpoint, useDualstackEndpoint }}`);
       }
       const signingRegion = getResolvedSigningRegion(hostname, {
-        signingRegion: regionHash[resolvedRegion]?.signingRegion,
+        signingRegion: (_d = regionHash[resolvedRegion]) == null ? void 0 : _d.signingRegion,
         regionRegex: partitionHash[partition].regionRegex,
         useFipsEndpoint
       });
@@ -35320,7 +35444,7 @@ var require_dist_cjs33 = __commonJS({
         signingService,
         hostname,
         ...signingRegion && { signingRegion },
-        ...regionHash[resolvedRegion]?.signingService && {
+        ...((_e = regionHash[resolvedRegion]) == null ? void 0 : _e.signingService) && {
           signingService: regionHash[resolvedRegion].signingService
         }
       };
@@ -35841,11 +35965,21 @@ var require_dist_cjs36 = __commonJS({
     var NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "ECONNREFUSED", "EPIPE", "ETIMEDOUT"];
     var isRetryableByTrait = /* @__PURE__ */ __name((error2) => error2.$retryable !== void 0, "isRetryableByTrait");
     var isClockSkewError = /* @__PURE__ */ __name((error2) => CLOCK_SKEW_ERROR_CODES.includes(error2.name), "isClockSkewError");
-    var isClockSkewCorrectedError = /* @__PURE__ */ __name((error2) => error2.$metadata?.clockSkewCorrected, "isClockSkewCorrectedError");
-    var isThrottlingError = /* @__PURE__ */ __name((error2) => error2.$metadata?.httpStatusCode === 429 || THROTTLING_ERROR_CODES.includes(error2.name) || error2.$retryable?.throttling == true, "isThrottlingError");
-    var isTransientError = /* @__PURE__ */ __name((error2, depth = 0) => isClockSkewCorrectedError(error2) || TRANSIENT_ERROR_CODES.includes(error2.name) || NODEJS_TIMEOUT_ERROR_CODES.includes(error2?.code || "") || TRANSIENT_ERROR_STATUS_CODES.includes(error2.$metadata?.httpStatusCode || 0) || error2.cause !== void 0 && depth <= 10 && isTransientError(error2.cause, depth + 1), "isTransientError");
+    var isClockSkewCorrectedError = /* @__PURE__ */ __name((error2) => {
+      var _a;
+      return (_a = error2.$metadata) == null ? void 0 : _a.clockSkewCorrected;
+    }, "isClockSkewCorrectedError");
+    var isThrottlingError = /* @__PURE__ */ __name((error2) => {
+      var _a, _b;
+      return ((_a = error2.$metadata) == null ? void 0 : _a.httpStatusCode) === 429 || THROTTLING_ERROR_CODES.includes(error2.name) || ((_b = error2.$retryable) == null ? void 0 : _b.throttling) == true;
+    }, "isThrottlingError");
+    var isTransientError = /* @__PURE__ */ __name((error2, depth = 0) => {
+      var _a;
+      return isClockSkewCorrectedError(error2) || TRANSIENT_ERROR_CODES.includes(error2.name) || NODEJS_TIMEOUT_ERROR_CODES.includes((error2 == null ? void 0 : error2.code) || "") || TRANSIENT_ERROR_STATUS_CODES.includes(((_a = error2.$metadata) == null ? void 0 : _a.httpStatusCode) || 0) || error2.cause !== void 0 && depth <= 10 && isTransientError(error2.cause, depth + 1);
+    }, "isTransientError");
     var isServerError = /* @__PURE__ */ __name((error2) => {
-      if (error2.$metadata?.httpStatusCode !== void 0) {
+      var _a;
+      if (((_a = error2.$metadata) == null ? void 0 : _a.httpStatusCode) !== void 0) {
         const statusCode = error2.$metadata.httpStatusCode;
         if (500 <= statusCode && statusCode <= 599 && !isTransientError(error2)) {
           return true;
@@ -35906,7 +36040,7 @@ var require_dist_cjs37 = __commonJS({
     var DEFAULT_MAX_ATTEMPTS = 3;
     var DEFAULT_RETRY_MODE = "standard";
     var import_service_error_classification = require_dist_cjs36();
-    var DefaultRateLimiter = class _DefaultRateLimiter {
+    var _DefaultRateLimiter = class _DefaultRateLimiter2 {
       constructor(options) {
         this.currentCapacity = 0;
         this.enabled = false;
@@ -35915,22 +36049,16 @@ var require_dist_cjs37 = __commonJS({
         this.requestCount = 0;
         this.lastTimestamp = 0;
         this.timeWindow = 0;
-        this.beta = options?.beta ?? 0.7;
-        this.minCapacity = options?.minCapacity ?? 1;
-        this.minFillRate = options?.minFillRate ?? 0.5;
-        this.scaleConstant = options?.scaleConstant ?? 0.4;
-        this.smooth = options?.smooth ?? 0.8;
+        this.beta = (options == null ? void 0 : options.beta) ?? 0.7;
+        this.minCapacity = (options == null ? void 0 : options.minCapacity) ?? 1;
+        this.minFillRate = (options == null ? void 0 : options.minFillRate) ?? 0.5;
+        this.scaleConstant = (options == null ? void 0 : options.scaleConstant) ?? 0.4;
+        this.smooth = (options == null ? void 0 : options.smooth) ?? 0.8;
         const currentTimeInSeconds = this.getCurrentTimeInSeconds();
         this.lastThrottleTime = currentTimeInSeconds;
         this.lastTxRateBucket = Math.floor(this.getCurrentTimeInSeconds());
         this.fillRate = this.minFillRate;
         this.maxCapacity = this.minCapacity;
-      }
-      static {
-        __name(this, "DefaultRateLimiter");
-      }
-      static {
-        this.setTimeoutFn = setTimeout;
       }
       getCurrentTimeInSeconds() {
         return Date.now() / 1e3;
@@ -35945,7 +36073,7 @@ var require_dist_cjs37 = __commonJS({
         this.refillTokenBucket();
         if (amount > this.currentCapacity) {
           const delay = (amount - this.currentCapacity) / this.fillRate * 1e3;
-          await new Promise((resolve) => _DefaultRateLimiter.setTimeoutFn(resolve, delay));
+          await new Promise((resolve) => _DefaultRateLimiter2.setTimeoutFn(resolve, delay));
         }
         this.currentCapacity = this.currentCapacity - amount;
       }
@@ -36011,6 +36139,9 @@ var require_dist_cjs37 = __commonJS({
         return parseFloat(num.toFixed(8));
       }
     };
+    __name(_DefaultRateLimiter, "DefaultRateLimiter");
+    _DefaultRateLimiter.setTimeoutFn = setTimeout;
+    var DefaultRateLimiter = _DefaultRateLimiter;
     var DEFAULT_RETRY_DELAY_BASE = 100;
     var MAXIMUM_RETRY_DELAY = 20 * 1e3;
     var THROTTLING_RETRY_DELAY_BASE = 500;
@@ -36047,16 +36178,13 @@ var require_dist_cjs37 = __commonJS({
         getRetryCost
       };
     }, "createDefaultRetryToken");
-    var StandardRetryStrategy = class {
+    var _StandardRetryStrategy = class _StandardRetryStrategy {
       constructor(maxAttempts) {
         this.maxAttempts = maxAttempts;
         this.mode = "standard";
         this.capacity = INITIAL_RETRY_TOKENS;
         this.retryBackoffStrategy = getDefaultRetryBackoffStrategy();
         this.maxAttemptsProvider = typeof maxAttempts === "function" ? maxAttempts : async () => maxAttempts;
-      }
-      static {
-        __name(this, "StandardRetryStrategy");
       }
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       async acquireInitialRetryToken(retryTokenScope) {
@@ -36114,16 +36242,15 @@ var require_dist_cjs37 = __commonJS({
         return errorType === "THROTTLING" || errorType === "TRANSIENT";
       }
     };
-    var AdaptiveRetryStrategy = class {
+    __name(_StandardRetryStrategy, "StandardRetryStrategy");
+    var StandardRetryStrategy = _StandardRetryStrategy;
+    var _AdaptiveRetryStrategy = class _AdaptiveRetryStrategy {
       constructor(maxAttemptsProvider, options) {
         this.maxAttemptsProvider = maxAttemptsProvider;
         this.mode = "adaptive";
         const { rateLimiter } = options ?? {};
         this.rateLimiter = rateLimiter ?? new DefaultRateLimiter();
         this.standardRetryStrategy = new StandardRetryStrategy(maxAttemptsProvider);
-      }
-      static {
-        __name(this, "AdaptiveRetryStrategy");
       }
       async acquireInitialRetryToken(retryTokenScope) {
         await this.rateLimiter.getSendToken();
@@ -36138,10 +36265,9 @@ var require_dist_cjs37 = __commonJS({
         this.standardRetryStrategy.recordSuccess(token);
       }
     };
-    var ConfiguredRetryStrategy = class extends StandardRetryStrategy {
-      static {
-        __name(this, "ConfiguredRetryStrategy");
-      }
+    __name(_AdaptiveRetryStrategy, "AdaptiveRetryStrategy");
+    var AdaptiveRetryStrategy = _AdaptiveRetryStrategy;
+    var _ConfiguredRetryStrategy = class _ConfiguredRetryStrategy extends StandardRetryStrategy {
       /**
        * @param maxAttempts - the maximum number of retry attempts allowed.
        *                      e.g., if set to 3, then 4 total requests are possible.
@@ -36175,6 +36301,8 @@ var require_dist_cjs37 = __commonJS({
         return token;
       }
     };
+    __name(_ConfiguredRetryStrategy, "ConfiguredRetryStrategy");
+    var ConfiguredRetryStrategy = _ConfiguredRetryStrategy;
   }
 });
 
@@ -36238,9 +36366,9 @@ var require_dist_cjs38 = __commonJS({
     var import_util_retry = require_dist_cjs37();
     var getDefaultRetryQuota = /* @__PURE__ */ __name((initialRetryTokens, options) => {
       const MAX_CAPACITY = initialRetryTokens;
-      const noRetryIncrement = options?.noRetryIncrement ?? import_util_retry.NO_RETRY_INCREMENT;
-      const retryCost = options?.retryCost ?? import_util_retry.RETRY_COST;
-      const timeoutRetryCost = options?.timeoutRetryCost ?? import_util_retry.TIMEOUT_RETRY_COST;
+      const noRetryIncrement = (options == null ? void 0 : options.noRetryIncrement) ?? import_util_retry.NO_RETRY_INCREMENT;
+      const retryCost = (options == null ? void 0 : options.retryCost) ?? import_util_retry.RETRY_COST;
+      const timeoutRetryCost = (options == null ? void 0 : options.timeoutRetryCost) ?? import_util_retry.TIMEOUT_RETRY_COST;
       let availableCapacity = initialRetryTokens;
       const getCapacityAmount = /* @__PURE__ */ __name((error2) => error2.name === "TimeoutError" ? timeoutRetryCost : retryCost, "getCapacityAmount");
       const hasRetryTokens = /* @__PURE__ */ __name((error2) => getCapacityAmount(error2) <= availableCapacity, "hasRetryTokens");
@@ -36279,16 +36407,13 @@ var require_dist_cjs38 = __commonJS({
         return new Error(error2);
       return new Error(`AWS SDK error wrapper for ${error2}`);
     }, "asSdkError");
-    var StandardRetryStrategy = class {
+    var _StandardRetryStrategy = class _StandardRetryStrategy {
       constructor(maxAttemptsProvider, options) {
         this.maxAttemptsProvider = maxAttemptsProvider;
         this.mode = import_util_retry.RETRY_MODES.STANDARD;
-        this.retryDecider = options?.retryDecider ?? defaultRetryDecider;
-        this.delayDecider = options?.delayDecider ?? defaultDelayDecider;
-        this.retryQuota = options?.retryQuota ?? getDefaultRetryQuota(import_util_retry.INITIAL_RETRY_TOKENS);
-      }
-      static {
-        __name(this, "StandardRetryStrategy");
+        this.retryDecider = (options == null ? void 0 : options.retryDecider) ?? defaultRetryDecider;
+        this.delayDecider = (options == null ? void 0 : options.delayDecider) ?? defaultDelayDecider;
+        this.retryQuota = (options == null ? void 0 : options.retryQuota) ?? getDefaultRetryQuota(import_util_retry.INITIAL_RETRY_TOKENS);
       }
       shouldRetry(error2, attempts, maxAttempts) {
         return attempts < maxAttempts && this.retryDecider(error2) && this.retryQuota.hasRetryTokens(error2);
@@ -36316,11 +36441,11 @@ var require_dist_cjs38 = __commonJS({
             if (import_protocol_http8.HttpRequest.isInstance(request)) {
               request.headers[import_util_retry.REQUEST_HEADER] = `attempt=${attempts + 1}; max=${maxAttempts}`;
             }
-            if (options?.beforeRequest) {
+            if (options == null ? void 0 : options.beforeRequest) {
               await options.beforeRequest();
             }
             const { response, output } = await next(args);
-            if (options?.afterRequest) {
+            if (options == null ? void 0 : options.afterRequest) {
               options.afterRequest(response);
             }
             this.retryQuota.releaseRetryTokens(retryTokenAmount);
@@ -36352,6 +36477,8 @@ var require_dist_cjs38 = __commonJS({
         }
       }
     };
+    __name(_StandardRetryStrategy, "StandardRetryStrategy");
+    var StandardRetryStrategy = _StandardRetryStrategy;
     var getDelayFromRetryAfterHeader = /* @__PURE__ */ __name((response) => {
       if (!import_protocol_http8.HttpResponse.isInstance(response))
         return;
@@ -36365,10 +36492,7 @@ var require_dist_cjs38 = __commonJS({
       const retryAfterDate = new Date(retryAfter);
       return retryAfterDate.getTime() - Date.now();
     }, "getDelayFromRetryAfterHeader");
-    var AdaptiveRetryStrategy = class extends StandardRetryStrategy {
-      static {
-        __name(this, "AdaptiveRetryStrategy");
-      }
+    var _AdaptiveRetryStrategy = class _AdaptiveRetryStrategy extends StandardRetryStrategy {
       constructor(maxAttemptsProvider, options) {
         const { rateLimiter, ...superOptions } = options ?? {};
         super(maxAttemptsProvider, superOptions);
@@ -36386,6 +36510,8 @@ var require_dist_cjs38 = __commonJS({
         });
       }
     };
+    __name(_AdaptiveRetryStrategy, "AdaptiveRetryStrategy");
+    var AdaptiveRetryStrategy = _AdaptiveRetryStrategy;
     var import_util_middleware3 = require_dist_cjs4();
     var ENV_MAX_ATTEMPTS = "AWS_MAX_ATTEMPTS";
     var CONFIG_MAX_ATTEMPTS = "max_attempts";
@@ -36460,6 +36586,7 @@ var require_dist_cjs38 = __commonJS({
     var import_smithy_client4 = require_dist_cjs19();
     var import_isStreamingPayload = require_isStreamingPayload();
     var retryMiddleware = /* @__PURE__ */ __name((options) => (next, context3) => async (args) => {
+      var _a;
       let retryStrategy = await options.retryStrategy();
       const maxAttempts = await options.maxAttempts();
       if (isRetryStrategyV2(retryStrategy)) {
@@ -36487,7 +36614,7 @@ var require_dist_cjs38 = __commonJS({
             const retryErrorInfo = getRetryErrorInfo(e);
             lastError = asSdkError(e);
             if (isRequest && (0, import_isStreamingPayload.isStreamingPayload)(request)) {
-              (context3.logger instanceof import_smithy_client4.NoOpLogger ? console : context3.logger)?.warn(
+              (_a = context3.logger instanceof import_smithy_client4.NoOpLogger ? console : context3.logger) == null ? void 0 : _a.warn(
                 "An error was encountered in a non-retryable streaming request."
               );
               throw lastError;
@@ -36510,7 +36637,7 @@ var require_dist_cjs38 = __commonJS({
         }
       } else {
         retryStrategy = retryStrategy;
-        if (retryStrategy?.mode)
+        if (retryStrategy == null ? void 0 : retryStrategy.mode)
           context3.userAgent = [...context3.userAgent || [], ["cfg/retry-mode", retryStrategy.mode]];
         return retryStrategy.retry(next, args);
       }
@@ -36596,13 +36723,7 @@ var require_dist_cjs39 = __commonJS({
     var signatureV4CrtContainer = {
       CrtSignerV4: null
     };
-    var SignatureV4MultiRegion = class {
-      static {
-        __name(this, "SignatureV4MultiRegion");
-      }
-      sigv4aSigner;
-      sigv4Signer;
-      signerOptions;
+    var _SignatureV4MultiRegion = class _SignatureV4MultiRegion {
       constructor(options) {
         this.sigv4Signer = new import_middleware_sdk_s3.SignatureV4S3Express(options);
         this.signerOptions = options;
@@ -36662,6 +36783,8 @@ For more information please go to https://github.com/aws/aws-sdk-js-v3#functiona
         return this.sigv4aSigner;
       }
     };
+    __name(_SignatureV4MultiRegion, "SignatureV4MultiRegion");
+    var SignatureV4MultiRegion = _SignatureV4MultiRegion;
   }
 });
 
@@ -37188,7 +37311,7 @@ var require_dist_cjs44 = __commonJS({
     });
     module2.exports = __toCommonJS2(src_exports);
     var resolveParamsForS3 = /* @__PURE__ */ __name(async (endpointParams) => {
-      const bucket = endpointParams?.Bucket || "";
+      const bucket = (endpointParams == null ? void 0 : endpointParams.Bucket) || "";
       if (typeof endpointParams.Bucket === "string") {
         endpointParams.Bucket = bucket.replace(/#/g, encodeURIComponent("#")).replace(/\?/g, encodeURIComponent("?"));
       }
@@ -37229,14 +37352,14 @@ var require_dist_cjs44 = __commonJS({
       if (configKey === "credentialScope" || canonicalEndpointParamKey === "CredentialScope") {
         return async () => {
           const credentials = typeof config.credentials === "function" ? await config.credentials() : config.credentials;
-          const configValue = credentials?.credentialScope ?? credentials?.CredentialScope;
+          const configValue = (credentials == null ? void 0 : credentials.credentialScope) ?? (credentials == null ? void 0 : credentials.CredentialScope);
           return configValue;
         };
       }
       if (configKey === "accountId" || canonicalEndpointParamKey === "AccountId") {
         return async () => {
           const credentials = typeof config.credentials === "function" ? await config.credentials() : config.credentials;
-          const configValue = credentials?.accountId ?? credentials?.AccountId;
+          const configValue = (credentials == null ? void 0 : credentials.accountId) ?? (credentials == null ? void 0 : credentials.AccountId);
           return configValue;
         };
       }
@@ -37288,8 +37411,9 @@ var require_dist_cjs44 = __commonJS({
       return endpoint;
     }, "getEndpointFromInstructions");
     var resolveParams = /* @__PURE__ */ __name(async (commandInput, instructionsSupplier, clientConfig) => {
+      var _a;
       const endpointParams = {};
-      const instructions = instructionsSupplier?.getEndpointParameterInstructions?.() || {};
+      const instructions = ((_a = instructionsSupplier == null ? void 0 : instructionsSupplier.getEndpointParameterInstructions) == null ? void 0 : _a.call(instructionsSupplier)) || {};
       for (const [name, instruction] of Object.entries(instructions)) {
         switch (instruction.type) {
           case "staticContextParams":
@@ -37324,6 +37448,7 @@ var require_dist_cjs44 = __commonJS({
       instructions
     }) => {
       return (next, context3) => async (args) => {
+        var _a, _b, _c;
         if (config.endpoint) {
           (0, import_core4.setFeature)(context3, "ENDPOINT_OVERRIDE", "N");
         }
@@ -37338,13 +37463,13 @@ var require_dist_cjs44 = __commonJS({
           context3
         );
         context3.endpointV2 = endpoint;
-        context3.authSchemes = endpoint.properties?.authSchemes;
-        const authScheme = context3.authSchemes?.[0];
+        context3.authSchemes = (_a = endpoint.properties) == null ? void 0 : _a.authSchemes;
+        const authScheme = (_b = context3.authSchemes) == null ? void 0 : _b[0];
         if (authScheme) {
           context3["signing_region"] = authScheme.signingRegion;
           context3["signing_service"] = authScheme.signingName;
           const smithyContext = (0, import_util_middleware3.getSmithyContext)(context3);
-          const httpAuthOption = smithyContext?.selectedHttpAuthScheme?.httpAuthOption;
+          const httpAuthOption = (_c = smithyContext == null ? void 0 : smithyContext.selectedHttpAuthScheme) == null ? void 0 : _c.httpAuthOption;
           if (httpAuthOption) {
             httpAuthOption.signingProperties = Object.assign(
               httpAuthOption.signingProperties || {},
@@ -37805,28 +37930,24 @@ var require_dist_cjs45 = __commonJS({
       return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&apos;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\r/g, "&#x0D;").replace(/\n/g, "&#x0A;").replace(/\u0085/g, "&#x85;").replace(/\u2028/, "&#x2028;");
     }
     __name(escapeElement, "escapeElement");
-    var XmlText = class {
+    var _XmlText = class _XmlText {
       constructor(value) {
         this.value = value;
-      }
-      static {
-        __name(this, "XmlText");
       }
       toString() {
         return escapeElement("" + this.value);
       }
     };
-    var XmlNode = class _XmlNode {
+    __name(_XmlText, "XmlText");
+    var XmlText = _XmlText;
+    var _XmlNode = class _XmlNode2 {
       constructor(name, children = []) {
         this.name = name;
         this.children = children;
+        this.attributes = {};
       }
-      static {
-        __name(this, "XmlNode");
-      }
-      attributes = {};
       static of(name, childText, withName) {
-        const node = new _XmlNode(name);
+        const node = new _XmlNode2(name);
         if (childText !== void 0) {
           node.addChildNode(new XmlText(childText));
         }
@@ -37884,7 +38005,7 @@ var require_dist_cjs45 = __commonJS({
        */
       cc(input, field, withName = field) {
         if (input[field] != null) {
-          const node = _XmlNode.of(field, input[field]).withName(withName);
+          const node = _XmlNode2.of(field, input[field]).withName(withName);
           this.c(node);
         }
       }
@@ -37908,7 +38029,7 @@ var require_dist_cjs45 = __commonJS({
       lc(input, listName, memberName, valueProvider) {
         if (input[listName] != null) {
           const nodes = valueProvider();
-          const containerNode = new _XmlNode(memberName);
+          const containerNode = new _XmlNode2(memberName);
           nodes.map((node) => {
             containerNode.c(node);
           });
@@ -37928,6 +38049,8 @@ var require_dist_cjs45 = __commonJS({
         return xmlText += !hasChildren ? "/>" : `>${this.children.map((c) => c.toString()).join("")}</${this.name}>`;
       }
     };
+    __name(_XmlNode, "XmlNode");
+    var XmlNode = _XmlNode;
   }
 });
 
@@ -37937,7 +38060,7 @@ var require_package = __commonJS({
     module2.exports = {
       name: "@aws-sdk/client-s3",
       description: "AWS SDK for JavaScript S3 Client for Node.js, Browser and React Native",
-      version: "3.723.0",
+      version: "3.703.0",
       scripts: {
         build: "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
         "build:cjs": "node ../../scripts/compilation/inline client-s3",
@@ -37963,73 +38086,73 @@ var require_package = __commonJS({
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.723.0",
-        "@aws-sdk/client-sts": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.723.0",
-        "@aws-sdk/middleware-expect-continue": "3.723.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-location-constraint": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-sdk-s3": "3.723.0",
-        "@aws-sdk/middleware-ssec": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/signature-v4-multi-region": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@aws-sdk/xml-builder": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/eventstream-serde-browser": "^4.0.0",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.0",
-        "@smithy/eventstream-serde-node": "^4.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-blob-browser": "^4.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/hash-stream-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/md5-js": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/client-sts": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.696.0",
+        "@aws-sdk/middleware-expect-continue": "3.696.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.701.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-location-constraint": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-sdk-s3": "3.696.0",
+        "@aws-sdk/middleware-ssec": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/signature-v4-multi-region": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@aws-sdk/xml-builder": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/eventstream-serde-browser": "^3.0.13",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.10",
+        "@smithy/eventstream-serde-node": "^3.0.12",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-blob-browser": "^3.1.9",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/hash-stream-node": "^3.1.9",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/md5-js": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.9",
         tslib: "^2.6.2"
       },
       devDependencies: {
-        "@aws-sdk/signature-v4-crt": "3.723.0",
-        "@tsconfig/node18": "18.2.4",
-        "@types/node": "^18.19.69",
+        "@aws-sdk/signature-v4-crt": "3.696.0",
+        "@tsconfig/node16": "16.1.3",
+        "@types/node": "^16.18.96",
         concurrently: "7.0.0",
         "downlevel-dts": "0.10.1",
         rimraf: "3.0.2",
-        typescript: "~5.2.2"
+        typescript: "~4.9.5"
       },
       engines: {
-        node: ">=18.0.0"
+        node: ">=16.0.0"
       },
       typesVersions: {
         "<4.0": {
@@ -38104,7 +38227,8 @@ var require_dist_cjs46 = __commonJS({
     var ENV_CREDENTIAL_SCOPE = "AWS_CREDENTIAL_SCOPE";
     var ENV_ACCOUNT_ID = "AWS_ACCOUNT_ID";
     var fromEnv = /* @__PURE__ */ __name((init) => async () => {
-      init?.logger?.debug("@aws-sdk/credential-provider-env - fromEnv");
+      var _a;
+      (_a = init == null ? void 0 : init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-env - fromEnv");
       const accessKeyId = process.env[ENV_KEY];
       const secretAccessKey = process.env[ENV_SECRET];
       const sessionToken = process.env[ENV_SESSION];
@@ -38123,7 +38247,7 @@ var require_dist_cjs46 = __commonJS({
         (0, import_client2.setCredentialFeature)(credentials, "CREDENTIALS_ENV_VARS", "g");
         return credentials;
       }
-      throw new import_property_provider2.CredentialsProviderError("Unable to find environment variable credentials.", { logger: init?.logger });
+      throw new import_property_provider2.CredentialsProviderError("Unable to find environment variable credentials.", { logger: init == null ? void 0 : init.logger });
     }, "fromEnv");
   }
 });
@@ -38170,12 +38294,13 @@ var require_dist_cjs47 = __commonJS({
     var import_http = require("http");
     function httpRequest(options) {
       return new Promise((resolve, reject) => {
+        var _a;
         const req = (0, import_http.request)({
           method: "GET",
           ...options,
           // Node.js http module doesn't accept hostname with square brackets
           // Refs: https://github.com/nodejs/node/issues/39738
-          hostname: options.hostname?.replace(/^\[(.+)\]$/, "$1")
+          hostname: (_a = options.hostname) == null ? void 0 : _a.replace(/^\[(.+)\]$/, "$1")
         });
         req.on("error", (err) => {
           reject(Object.assign(new import_property_provider2.ProviderError("Unable to connect to instance metadata service"), err));
@@ -38299,17 +38424,16 @@ var require_dist_cjs47 = __commonJS({
         }
       );
     }, "getCmdsUri");
-    var InstanceMetadataV1FallbackError = class _InstanceMetadataV1FallbackError extends import_property_provider2.CredentialsProviderError {
+    var _InstanceMetadataV1FallbackError = class _InstanceMetadataV1FallbackError2 extends import_property_provider2.CredentialsProviderError {
       constructor(message, tryNextLink = true) {
         super(message, tryNextLink);
         this.tryNextLink = tryNextLink;
         this.name = "InstanceMetadataV1FallbackError";
-        Object.setPrototypeOf(this, _InstanceMetadataV1FallbackError.prototype);
-      }
-      static {
-        __name(this, "InstanceMetadataV1FallbackError");
+        Object.setPrototypeOf(this, _InstanceMetadataV1FallbackError2.prototype);
       }
     };
+    __name(_InstanceMetadataV1FallbackError, "InstanceMetadataV1FallbackError");
+    var InstanceMetadataV1FallbackError = _InstanceMetadataV1FallbackError;
     var import_node_config_provider = require_dist_cjs41();
     var import_url_parser = require_dist_cjs43();
     var Endpoint = /* @__PURE__ */ ((Endpoint2) => {
@@ -38368,7 +38492,7 @@ For more information, please visit: ` + STATIC_STABILITY_DOC_URL
       };
     }, "getExtendedInstanceMetadataCredentials");
     var staticStabilityProvider = /* @__PURE__ */ __name((provider, options = {}) => {
-      const logger = options?.logger || console;
+      const logger = (options == null ? void 0 : options.logger) || console;
       let pastCredentials;
       return async () => {
         let credentials;
@@ -38400,7 +38524,8 @@ For more information, please visit: ` + STATIC_STABILITY_DOC_URL
       const { logger, profile } = init;
       const { timeout, maxRetries } = providerConfigFromInit(init);
       const getCredentials = /* @__PURE__ */ __name(async (maxRetries2, options) => {
-        const isImdsV1Fallback = disableFetchToken || options.headers?.[X_AWS_EC2_METADATA_TOKEN] == null;
+        var _a;
+        const isImdsV1Fallback = disableFetchToken || ((_a = options.headers) == null ? void 0 : _a[X_AWS_EC2_METADATA_TOKEN]) == null;
         if (isImdsV1Fallback) {
           let fallbackBlockedFromProfile = false;
           let fallbackBlockedFromProcessEnv = false;
@@ -38471,21 +38596,21 @@ For more information, please visit: ` + STATIC_STABILITY_DOC_URL
       return async () => {
         const endpoint = await getInstanceMetadataEndpoint();
         if (disableFetchToken) {
-          logger?.debug("AWS SDK Instance Metadata", "using v1 fallback (no token fetch)");
+          logger == null ? void 0 : logger.debug("AWS SDK Instance Metadata", "using v1 fallback (no token fetch)");
           return getCredentials(maxRetries, { ...endpoint, timeout });
         } else {
           let token;
           try {
             token = (await getMetadataToken({ ...endpoint, timeout })).toString();
           } catch (error2) {
-            if (error2?.statusCode === 400) {
+            if ((error2 == null ? void 0 : error2.statusCode) === 400) {
               throw Object.assign(error2, {
                 message: "EC2 Metadata token request returned error"
               });
             } else if (error2.message === "TimeoutError" || [403, 404, 405].includes(error2.statusCode)) {
               disableFetchToken = true;
             }
-            logger?.debug("AWS SDK Instance Metadata", "using v1 fallback (initial)");
+            logger == null ? void 0 : logger.debug("AWS SDK Instance Metadata", "using v1 fallback (initial)");
             return getCredentials(maxRetries, { ...endpoint, timeout });
           }
           return getCredentials(maxRetries, {
@@ -38805,7 +38930,7 @@ var require_package2 = __commonJS({
     module2.exports = {
       name: "@aws-sdk/client-sso",
       description: "AWS SDK for JavaScript Sso Client for Node.js, Browser and React Native",
-      version: "3.723.0",
+      version: "3.696.0",
       scripts: {
         build: "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
         "build:cjs": "node ../../scripts/compilation/inline client-sso",
@@ -38824,53 +38949,53 @@ var require_package2 = __commonJS({
       dependencies: {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         tslib: "^2.6.2"
       },
       devDependencies: {
-        "@tsconfig/node18": "18.2.4",
-        "@types/node": "^18.19.69",
+        "@tsconfig/node16": "16.1.3",
+        "@types/node": "^16.18.96",
         concurrently: "7.0.0",
         "downlevel-dts": "0.10.1",
         rimraf: "3.0.2",
-        typescript: "~5.2.2"
+        typescript: "~4.9.5"
       },
       engines: {
-        node: ">=18.0.0"
+        node: ">=16.0.0"
       },
       typesVersions: {
         "<4.0": {
@@ -38948,6 +39073,7 @@ var require_dist_cjs49 = __commonJS({
     }, "isCrtAvailable");
     var createDefaultUserAgentProvider = /* @__PURE__ */ __name(({ serviceId, clientVersion }) => {
       return async (config) => {
+        var _a;
         const sections = [
           // sdk-metadata
           ["aws-sdk-js", clientVersion],
@@ -38970,7 +39096,7 @@ var require_dist_cjs49 = __commonJS({
         if (import_process.env.AWS_EXECUTION_ENV) {
           sections.push([`exec-env/${import_process.env.AWS_EXECUTION_ENV}`]);
         }
-        const appId = await config?.userAgentAppId?.();
+        const appId = await ((_a = config == null ? void 0 : config.userAgentAppId) == null ? void 0 : _a.call(config));
         const resolvedUserAgent = appId ? [...sections, [`app/${appId}`]] : [...sections];
         return resolvedUserAgent;
       };
@@ -38978,11 +39104,10 @@ var require_dist_cjs49 = __commonJS({
     var defaultUserAgent = createDefaultUserAgentProvider;
     var import_middleware_user_agent = require_dist_cjs32();
     var UA_APP_ID_ENV_NAME = "AWS_SDK_UA_APP_ID";
-    var UA_APP_ID_INI_NAME = "sdk_ua_app_id";
-    var UA_APP_ID_INI_NAME_DEPRECATED = "sdk-ua-app-id";
+    var UA_APP_ID_INI_NAME = "sdk-ua-app-id";
     var NODE_APP_ID_CONFIG_OPTIONS = {
       environmentVariableSelector: (env2) => env2[UA_APP_ID_ENV_NAME],
-      configFileSelector: (profile) => profile[UA_APP_ID_INI_NAME] ?? profile[UA_APP_ID_INI_NAME_DEPRECATED],
+      configFileSelector: (profile) => profile[UA_APP_ID_INI_NAME],
       default: import_middleware_user_agent.DEFAULT_UA_APP_ID
     };
   }
@@ -39018,10 +39143,7 @@ var require_dist_cjs50 = __commonJS({
     var import_util_utf8 = require_dist_cjs8();
     var import_buffer = require("buffer");
     var import_crypto5 = require("crypto");
-    var Hash = class {
-      static {
-        __name(this, "Hash");
-      }
+    var _Hash = class _Hash {
       constructor(algorithmIdentifier, secret) {
         this.algorithmIdentifier = algorithmIdentifier;
         this.secret = secret;
@@ -39037,6 +39159,8 @@ var require_dist_cjs50 = __commonJS({
         this.hash = this.secret ? (0, import_crypto5.createHmac)(this.algorithmIdentifier, castSourceData(this.secret)) : (0, import_crypto5.createHash)(this.algorithmIdentifier);
       }
     };
+    __name(_Hash, "Hash");
+    var Hash = _Hash;
     function castSourceData(toCast, encoding) {
       if (import_buffer.Buffer.isBuffer(toCast)) {
         return toCast;
@@ -39268,7 +39392,7 @@ var require_dist_cjs52 = __commonJS({
       defaultsMode = (0, import_node_config_provider.loadConfig)(NODE_DEFAULTS_MODE_CONFIG_OPTIONS)
     } = {}) => (0, import_property_provider2.memoize)(async () => {
       const mode = typeof defaultsMode === "function" ? await defaultsMode() : defaultsMode;
-      switch (mode?.toLowerCase()) {
+      switch (mode == null ? void 0 : mode.toLowerCase()) {
         case "auto":
           return resolveNodeDefaultsModeAuto(region);
         case "in-region":
@@ -39276,7 +39400,7 @@ var require_dist_cjs52 = __commonJS({
         case "mobile":
         case "standard":
         case "legacy":
-          return Promise.resolve(mode?.toLocaleLowerCase());
+          return Promise.resolve(mode == null ? void 0 : mode.toLocaleLowerCase());
         case void 0:
           return Promise.resolve("legacy");
         default:
@@ -39343,7 +39467,6 @@ var require_runtimeConfig = __commonJS({
       const defaultConfigProvider = () => defaultsMode().then(smithy_client_1.loadConfigsForDefaultMode);
       const clientSharedValues = (0, runtimeConfig_shared_1.getRuntimeConfig)(config);
       (0, core_1.emitWarningIfUnsupportedVersion)(process.version);
-      const profileConfig = { profile: config?.profile };
       return {
         ...clientSharedValues,
         ...config,
@@ -39351,18 +39474,18 @@ var require_runtimeConfig = __commonJS({
         defaultsMode,
         bodyLengthChecker: config?.bodyLengthChecker ?? util_body_length_node_1.calculateBodyLength,
         defaultUserAgentProvider: config?.defaultUserAgentProvider ?? (0, util_user_agent_node_1.createDefaultUserAgentProvider)({ serviceId: clientSharedValues.serviceId, clientVersion: package_json_1.default.version }),
-        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
-        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, { ...config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS, ...profileConfig }),
+        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS),
         requestHandler: node_http_handler_1.NodeHttpHandler.create(config?.requestHandler ?? defaultConfigProvider),
         retryMode: config?.retryMode ?? (0, node_config_provider_1.loadConfig)({
           ...middleware_retry_1.NODE_RETRY_MODE_CONFIG_OPTIONS,
           default: async () => (await defaultConfigProvider()).retryMode || util_retry_1.DEFAULT_RETRY_MODE
-        }, config),
+        }),
         sha256: config?.sha256 ?? hash_node_1.Hash.bind(null, "sha256"),
         streamCollector: config?.streamCollector ?? node_http_handler_1.streamCollector,
-        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS, profileConfig)
+        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),
+        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS),
+        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS)
       };
     };
     exports2.getRuntimeConfig = getRuntimeConfig;
@@ -39595,14 +39718,7 @@ var require_dist_cjs54 = __commonJS({
         ...resolveHttpAuthRuntimeConfig(extensionConfiguration)
       };
     }, "resolveRuntimeExtensions");
-    var SSOClient = class extends import_smithy_client4.Client {
-      static {
-        __name(this, "SSOClient");
-      }
-      /**
-       * The resolved configuration of SSOClient class. This is resolved and normalized from the {@link SSOClientConfig | constructor configuration interface}.
-       */
-      config;
+    var _SSOClient = class _SSOClient extends import_smithy_client4.Client {
       constructor(...[configuration]) {
         const _config_0 = (0, import_runtimeConfig.getRuntimeConfig)(configuration || {});
         const _config_1 = resolveClientEndpointParameters(_config_0);
@@ -39612,7 +39728,7 @@ var require_dist_cjs54 = __commonJS({
         const _config_5 = (0, import_middleware_host_header.resolveHostHeaderConfig)(_config_4);
         const _config_6 = (0, import_middleware_endpoint.resolveEndpointConfig)(_config_5);
         const _config_7 = (0, import_httpAuthSchemeProvider.resolveHttpAuthSchemeConfig)(_config_6);
-        const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
+        const _config_8 = resolveRuntimeExtensions(_config_7, (configuration == null ? void 0 : configuration.extensions) || []);
         super(_config_8);
         this.config = _config_8;
         this.middlewareStack.use((0, import_middleware_user_agent.getUserAgentPlugin)(this.config));
@@ -39640,25 +39756,21 @@ var require_dist_cjs54 = __commonJS({
         super.destroy();
       }
     };
+    __name(_SSOClient, "SSOClient");
+    var SSOClient = _SSOClient;
     var import_middleware_serde2 = require_dist_cjs5();
-    var SSOServiceException = class _SSOServiceException extends import_smithy_client4.ServiceException {
-      static {
-        __name(this, "SSOServiceException");
-      }
+    var _SSOServiceException = class _SSOServiceException2 extends import_smithy_client4.ServiceException {
       /**
        * @internal
        */
       constructor(options) {
         super(options);
-        Object.setPrototypeOf(this, _SSOServiceException.prototype);
+        Object.setPrototypeOf(this, _SSOServiceException2.prototype);
       }
     };
-    var InvalidRequestException = class _InvalidRequestException extends SSOServiceException {
-      static {
-        __name(this, "InvalidRequestException");
-      }
-      name = "InvalidRequestException";
-      $fault = "client";
+    __name(_SSOServiceException, "SSOServiceException");
+    var SSOServiceException = _SSOServiceException;
+    var _InvalidRequestException = class _InvalidRequestException2 extends SSOServiceException {
       /**
        * @internal
        */
@@ -39668,15 +39780,14 @@ var require_dist_cjs54 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidRequestException.prototype);
+        this.name = "InvalidRequestException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidRequestException2.prototype);
       }
     };
-    var ResourceNotFoundException = class _ResourceNotFoundException extends SSOServiceException {
-      static {
-        __name(this, "ResourceNotFoundException");
-      }
-      name = "ResourceNotFoundException";
-      $fault = "client";
+    __name(_InvalidRequestException, "InvalidRequestException");
+    var InvalidRequestException = _InvalidRequestException;
+    var _ResourceNotFoundException = class _ResourceNotFoundException2 extends SSOServiceException {
       /**
        * @internal
        */
@@ -39686,15 +39797,14 @@ var require_dist_cjs54 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ResourceNotFoundException.prototype);
+        this.name = "ResourceNotFoundException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ResourceNotFoundException2.prototype);
       }
     };
-    var TooManyRequestsException = class _TooManyRequestsException extends SSOServiceException {
-      static {
-        __name(this, "TooManyRequestsException");
-      }
-      name = "TooManyRequestsException";
-      $fault = "client";
+    __name(_ResourceNotFoundException, "ResourceNotFoundException");
+    var ResourceNotFoundException = _ResourceNotFoundException;
+    var _TooManyRequestsException = class _TooManyRequestsException2 extends SSOServiceException {
       /**
        * @internal
        */
@@ -39704,15 +39814,14 @@ var require_dist_cjs54 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _TooManyRequestsException.prototype);
+        this.name = "TooManyRequestsException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _TooManyRequestsException2.prototype);
       }
     };
-    var UnauthorizedException = class _UnauthorizedException extends SSOServiceException {
-      static {
-        __name(this, "UnauthorizedException");
-      }
-      name = "UnauthorizedException";
-      $fault = "client";
+    __name(_TooManyRequestsException, "TooManyRequestsException");
+    var TooManyRequestsException = _TooManyRequestsException;
+    var _UnauthorizedException = class _UnauthorizedException2 extends SSOServiceException {
       /**
        * @internal
        */
@@ -39722,9 +39831,13 @@ var require_dist_cjs54 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _UnauthorizedException.prototype);
+        this.name = "UnauthorizedException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _UnauthorizedException2.prototype);
       }
     };
+    __name(_UnauthorizedException, "UnauthorizedException");
+    var UnauthorizedException = _UnauthorizedException;
     var GetRoleCredentialsRequestFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
       ...obj,
       ...obj.accessToken && { accessToken: import_smithy_client4.SENSITIVE_STRING }
@@ -39955,57 +40068,52 @@ var require_dist_cjs54 = __commonJS({
     var _rN = "roleName";
     var _rn = "role_name";
     var _xasbt = "x-amz-sso_bearer_token";
-    var GetRoleCredentialsCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    var _GetRoleCredentialsCommand = class _GetRoleCredentialsCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("SWBPortalService", "GetRoleCredentials", {}).n("SSOClient", "GetRoleCredentialsCommand").f(GetRoleCredentialsRequestFilterSensitiveLog, GetRoleCredentialsResponseFilterSensitiveLog).ser(se_GetRoleCredentialsCommand).de(de_GetRoleCredentialsCommand).build() {
-      static {
-        __name(this, "GetRoleCredentialsCommand");
-      }
     };
-    var ListAccountRolesCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_GetRoleCredentialsCommand, "GetRoleCredentialsCommand");
+    var GetRoleCredentialsCommand = _GetRoleCredentialsCommand;
+    var _ListAccountRolesCommand = class _ListAccountRolesCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("SWBPortalService", "ListAccountRoles", {}).n("SSOClient", "ListAccountRolesCommand").f(ListAccountRolesRequestFilterSensitiveLog, void 0).ser(se_ListAccountRolesCommand).de(de_ListAccountRolesCommand).build() {
-      static {
-        __name(this, "ListAccountRolesCommand");
-      }
     };
-    var ListAccountsCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_ListAccountRolesCommand, "ListAccountRolesCommand");
+    var ListAccountRolesCommand = _ListAccountRolesCommand;
+    var _ListAccountsCommand = class _ListAccountsCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("SWBPortalService", "ListAccounts", {}).n("SSOClient", "ListAccountsCommand").f(ListAccountsRequestFilterSensitiveLog, void 0).ser(se_ListAccountsCommand).de(de_ListAccountsCommand).build() {
-      static {
-        __name(this, "ListAccountsCommand");
-      }
     };
-    var LogoutCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_ListAccountsCommand, "ListAccountsCommand");
+    var ListAccountsCommand = _ListAccountsCommand;
+    var _LogoutCommand = class _LogoutCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("SWBPortalService", "Logout", {}).n("SSOClient", "LogoutCommand").f(LogoutRequestFilterSensitiveLog, void 0).ser(se_LogoutCommand).de(de_LogoutCommand).build() {
-      static {
-        __name(this, "LogoutCommand");
-      }
     };
+    __name(_LogoutCommand, "LogoutCommand");
+    var LogoutCommand = _LogoutCommand;
     var commands = {
       GetRoleCredentialsCommand,
       ListAccountRolesCommand,
       ListAccountsCommand,
       LogoutCommand
     };
-    var SSO = class extends SSOClient {
-      static {
-        __name(this, "SSO");
-      }
+    var _SSO = class _SSO extends SSOClient {
     };
+    __name(_SSO, "SSO");
+    var SSO = _SSO;
     (0, import_smithy_client4.createAggregatedClient)(commands, SSO);
     var paginateListAccountRoles = (0, import_core4.createPaginator)(SSOClient, ListAccountRolesCommand, "nextToken", "nextToken", "maxResults");
     var paginateListAccounts = (0, import_core4.createPaginator)(SSOClient, ListAccountsCommand, "nextToken", "nextToken", "maxResults");
@@ -40087,7 +40195,7 @@ var require_package3 = __commonJS({
     module2.exports = {
       name: "@aws-sdk/client-sso-oidc",
       description: "AWS SDK for JavaScript Sso Oidc Client for Node.js, Browser and React Native",
-      version: "3.723.0",
+      version: "3.699.0",
       scripts: {
         build: "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
         "build:cjs": "node ../../scripts/compilation/inline client-sso-oidc",
@@ -40106,54 +40214,54 @@ var require_package3 = __commonJS({
       dependencies: {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         tslib: "^2.6.2"
       },
       devDependencies: {
-        "@tsconfig/node18": "18.2.4",
-        "@types/node": "^18.19.69",
+        "@tsconfig/node16": "16.1.3",
+        "@types/node": "^16.18.96",
         concurrently: "7.0.0",
         "downlevel-dts": "0.10.1",
         rimraf: "3.0.2",
-        typescript: "~5.2.2"
+        typescript: "~4.9.5"
       },
       engines: {
-        node: ">=18.0.0"
+        node: ">=16.0.0"
       },
       typesVersions: {
         "<4.0": {
@@ -40171,7 +40279,7 @@ var require_package3 = __commonJS({
       },
       license: "Apache-2.0",
       peerDependencies: {
-        "@aws-sdk/client-sts": "^3.723.0"
+        "@aws-sdk/client-sts": "^3.699.0"
       },
       browser: {
         "./dist-es/runtimeConfig": "./dist-es/runtimeConfig.browser"
@@ -40322,7 +40430,6 @@ var require_runtimeConfig2 = __commonJS({
       const defaultConfigProvider = () => defaultsMode().then(smithy_client_1.loadConfigsForDefaultMode);
       const clientSharedValues = (0, runtimeConfig_shared_1.getRuntimeConfig)(config);
       (0, core_1.emitWarningIfUnsupportedVersion)(process.version);
-      const profileConfig = { profile: config?.profile };
       return {
         ...clientSharedValues,
         ...config,
@@ -40331,18 +40438,18 @@ var require_runtimeConfig2 = __commonJS({
         bodyLengthChecker: config?.bodyLengthChecker ?? util_body_length_node_1.calculateBodyLength,
         credentialDefaultProvider: config?.credentialDefaultProvider ?? credential_provider_node_1.defaultProvider,
         defaultUserAgentProvider: config?.defaultUserAgentProvider ?? (0, util_user_agent_node_1.createDefaultUserAgentProvider)({ serviceId: clientSharedValues.serviceId, clientVersion: package_json_1.default.version }),
-        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
-        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, { ...config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS, ...profileConfig }),
+        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS),
         requestHandler: node_http_handler_1.NodeHttpHandler.create(config?.requestHandler ?? defaultConfigProvider),
         retryMode: config?.retryMode ?? (0, node_config_provider_1.loadConfig)({
           ...middleware_retry_1.NODE_RETRY_MODE_CONFIG_OPTIONS,
           default: async () => (await defaultConfigProvider()).retryMode || util_retry_1.DEFAULT_RETRY_MODE
-        }, config),
+        }),
         sha256: config?.sha256 ?? hash_node_1.Hash.bind(null, "sha256"),
         streamCollector: config?.streamCollector ?? node_http_handler_1.streamCollector,
-        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS, profileConfig)
+        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),
+        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS),
+        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS)
       };
     };
     exports2.getRuntimeConfig = getRuntimeConfig;
@@ -40485,14 +40592,7 @@ var require_dist_cjs55 = __commonJS({
         ...resolveHttpAuthRuntimeConfig(extensionConfiguration)
       };
     }, "resolveRuntimeExtensions");
-    var SSOOIDCClient = class extends import_smithy_client4.Client {
-      static {
-        __name(this, "SSOOIDCClient");
-      }
-      /**
-       * The resolved configuration of SSOOIDCClient class. This is resolved and normalized from the {@link SSOOIDCClientConfig | constructor configuration interface}.
-       */
-      config;
+    var _SSOOIDCClient = class _SSOOIDCClient extends import_smithy_client4.Client {
       constructor(...[configuration]) {
         const _config_0 = (0, import_runtimeConfig.getRuntimeConfig)(configuration || {});
         const _config_1 = resolveClientEndpointParameters(_config_0);
@@ -40502,7 +40602,7 @@ var require_dist_cjs55 = __commonJS({
         const _config_5 = (0, import_middleware_host_header.resolveHostHeaderConfig)(_config_4);
         const _config_6 = (0, import_middleware_endpoint.resolveEndpointConfig)(_config_5);
         const _config_7 = (0, import_httpAuthSchemeProvider.resolveHttpAuthSchemeConfig)(_config_6);
-        const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
+        const _config_8 = resolveRuntimeExtensions(_config_7, (configuration == null ? void 0 : configuration.extensions) || []);
         super(_config_8);
         this.config = _config_8;
         this.middlewareStack.use((0, import_middleware_user_agent.getUserAgentPlugin)(this.config));
@@ -40530,37 +40630,21 @@ var require_dist_cjs55 = __commonJS({
         super.destroy();
       }
     };
+    __name(_SSOOIDCClient, "SSOOIDCClient");
+    var SSOOIDCClient = _SSOOIDCClient;
     var import_middleware_serde2 = require_dist_cjs5();
-    var SSOOIDCServiceException = class _SSOOIDCServiceException extends import_smithy_client4.ServiceException {
-      static {
-        __name(this, "SSOOIDCServiceException");
-      }
+    var _SSOOIDCServiceException = class _SSOOIDCServiceException2 extends import_smithy_client4.ServiceException {
       /**
        * @internal
        */
       constructor(options) {
         super(options);
-        Object.setPrototypeOf(this, _SSOOIDCServiceException.prototype);
+        Object.setPrototypeOf(this, _SSOOIDCServiceException2.prototype);
       }
     };
-    var AccessDeniedException = class _AccessDeniedException extends SSOOIDCServiceException {
-      static {
-        __name(this, "AccessDeniedException");
-      }
-      name = "AccessDeniedException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>access_denied</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_SSOOIDCServiceException, "SSOOIDCServiceException");
+    var SSOOIDCServiceException = _SSOOIDCServiceException;
+    var _AccessDeniedException = class _AccessDeniedException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40570,29 +40654,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _AccessDeniedException.prototype);
+        this.name = "AccessDeniedException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _AccessDeniedException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var AuthorizationPendingException = class _AuthorizationPendingException extends SSOOIDCServiceException {
-      static {
-        __name(this, "AuthorizationPendingException");
-      }
-      name = "AuthorizationPendingException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>authorization_pending</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_AccessDeniedException, "AccessDeniedException");
+    var AccessDeniedException = _AccessDeniedException;
+    var _AuthorizationPendingException = class _AuthorizationPendingException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40602,29 +40673,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _AuthorizationPendingException.prototype);
+        this.name = "AuthorizationPendingException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _AuthorizationPendingException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var ExpiredTokenException = class _ExpiredTokenException extends SSOOIDCServiceException {
-      static {
-        __name(this, "ExpiredTokenException");
-      }
-      name = "ExpiredTokenException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>expired_token</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_AuthorizationPendingException, "AuthorizationPendingException");
+    var AuthorizationPendingException = _AuthorizationPendingException;
+    var _ExpiredTokenException = class _ExpiredTokenException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40634,29 +40692,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ExpiredTokenException.prototype);
+        this.name = "ExpiredTokenException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ExpiredTokenException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var InternalServerException = class _InternalServerException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InternalServerException");
-      }
-      name = "InternalServerException";
-      $fault = "server";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>server_error</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_ExpiredTokenException, "ExpiredTokenException");
+    var ExpiredTokenException = _ExpiredTokenException;
+    var _InternalServerException = class _InternalServerException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40666,29 +40711,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "server",
           ...opts
         });
-        Object.setPrototypeOf(this, _InternalServerException.prototype);
+        this.name = "InternalServerException";
+        this.$fault = "server";
+        Object.setPrototypeOf(this, _InternalServerException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var InvalidClientException = class _InvalidClientException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InvalidClientException");
-      }
-      name = "InvalidClientException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>invalid_client</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_InternalServerException, "InternalServerException");
+    var InternalServerException = _InternalServerException;
+    var _InvalidClientException = class _InvalidClientException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40698,29 +40730,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidClientException.prototype);
+        this.name = "InvalidClientException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidClientException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var InvalidGrantException = class _InvalidGrantException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InvalidGrantException");
-      }
-      name = "InvalidGrantException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>invalid_grant</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_InvalidClientException, "InvalidClientException");
+    var InvalidClientException = _InvalidClientException;
+    var _InvalidGrantException = class _InvalidGrantException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40730,29 +40749,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidGrantException.prototype);
+        this.name = "InvalidGrantException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidGrantException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var InvalidRequestException = class _InvalidRequestException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InvalidRequestException");
-      }
-      name = "InvalidRequestException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>invalid_request</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_InvalidGrantException, "InvalidGrantException");
+    var InvalidGrantException = _InvalidGrantException;
+    var _InvalidRequestException = class _InvalidRequestException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40762,29 +40768,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidRequestException.prototype);
+        this.name = "InvalidRequestException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidRequestException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var InvalidScopeException = class _InvalidScopeException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InvalidScopeException");
-      }
-      name = "InvalidScopeException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>invalid_scope</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_InvalidRequestException, "InvalidRequestException");
+    var InvalidRequestException = _InvalidRequestException;
+    var _InvalidScopeException = class _InvalidScopeException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40794,29 +40787,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidScopeException.prototype);
+        this.name = "InvalidScopeException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidScopeException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var SlowDownException = class _SlowDownException extends SSOOIDCServiceException {
-      static {
-        __name(this, "SlowDownException");
-      }
-      name = "SlowDownException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>slow_down</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_InvalidScopeException, "InvalidScopeException");
+    var InvalidScopeException = _InvalidScopeException;
+    var _SlowDownException = class _SlowDownException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40826,29 +40806,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _SlowDownException.prototype);
+        this.name = "SlowDownException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _SlowDownException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var UnauthorizedClientException = class _UnauthorizedClientException extends SSOOIDCServiceException {
-      static {
-        __name(this, "UnauthorizedClientException");
-      }
-      name = "UnauthorizedClientException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>unauthorized_client</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_SlowDownException, "SlowDownException");
+    var SlowDownException = _SlowDownException;
+    var _UnauthorizedClientException = class _UnauthorizedClientException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40858,29 +40825,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _UnauthorizedClientException.prototype);
+        this.name = "UnauthorizedClientException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _UnauthorizedClientException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var UnsupportedGrantTypeException = class _UnsupportedGrantTypeException extends SSOOIDCServiceException {
-      static {
-        __name(this, "UnsupportedGrantTypeException");
-      }
-      name = "UnsupportedGrantTypeException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>unsupported_grant_type</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_UnauthorizedClientException, "UnauthorizedClientException");
+    var UnauthorizedClientException = _UnauthorizedClientException;
+    var _UnsupportedGrantTypeException = class _UnsupportedGrantTypeException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40890,39 +40844,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _UnsupportedGrantTypeException.prototype);
+        this.name = "UnsupportedGrantTypeException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _UnsupportedGrantTypeException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var InvalidRequestRegionException = class _InvalidRequestRegionException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InvalidRequestRegionException");
-      }
-      name = "InvalidRequestRegionException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>invalid_request</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
-      /**
-       * <p>Indicates the IAM Identity Center endpoint which the requester may call with this token.</p>
-       * @public
-       */
-      endpoint;
-      /**
-       * <p>Indicates the region which the requester may call with this token.</p>
-       * @public
-       */
-      region;
+    __name(_UnsupportedGrantTypeException, "UnsupportedGrantTypeException");
+    var UnsupportedGrantTypeException = _UnsupportedGrantTypeException;
+    var _InvalidRequestRegionException = class _InvalidRequestRegionException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40932,31 +40863,18 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidRequestRegionException.prototype);
+        this.name = "InvalidRequestRegionException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidRequestRegionException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
         this.endpoint = opts.endpoint;
         this.region = opts.region;
       }
     };
-    var InvalidClientMetadataException = class _InvalidClientMetadataException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InvalidClientMetadataException");
-      }
-      name = "InvalidClientMetadataException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>invalid_client_metadata</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_InvalidRequestRegionException, "InvalidRequestRegionException");
+    var InvalidRequestRegionException = _InvalidRequestRegionException;
+    var _InvalidClientMetadataException = class _InvalidClientMetadataException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40966,29 +40884,16 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidClientMetadataException.prototype);
+        this.name = "InvalidClientMetadataException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidClientMetadataException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
-    var InvalidRedirectUriException = class _InvalidRedirectUriException extends SSOOIDCServiceException {
-      static {
-        __name(this, "InvalidRedirectUriException");
-      }
-      name = "InvalidRedirectUriException";
-      $fault = "client";
-      /**
-       * <p>Single error code.
-       *       For this exception the value will be <code>invalid_redirect_uri</code>.</p>
-       * @public
-       */
-      error;
-      /**
-       * <p>Human-readable text providing additional information, used to assist the
-       *       client developer in understanding the error that occurred.</p>
-       * @public
-       */
-      error_description;
+    __name(_InvalidClientMetadataException, "InvalidClientMetadataException");
+    var InvalidClientMetadataException = _InvalidClientMetadataException;
+    var _InvalidRedirectUriException = class _InvalidRedirectUriException2 extends SSOOIDCServiceException {
       /**
        * @internal
        */
@@ -40998,11 +40903,15 @@ var require_dist_cjs55 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidRedirectUriException.prototype);
+        this.name = "InvalidRedirectUriException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidRedirectUriException2.prototype);
         this.error = opts.error;
         this.error_description = opts.error_description;
       }
     };
+    __name(_InvalidRedirectUriException, "InvalidRedirectUriException");
+    var InvalidRedirectUriException = _InvalidRedirectUriException;
     var CreateTokenRequestFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
       ...obj,
       ...obj.clientSecret && { clientSecret: import_smithy_client4.SENSITIVE_STRING },
@@ -41466,57 +41375,52 @@ var require_dist_cjs55 = __commonJS({
       cfId: output.headers["x-amz-cf-id"]
     }), "deserializeMetadata");
     var _ai = "aws_iam";
-    var CreateTokenCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    var _CreateTokenCommand = class _CreateTokenCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSSOOIDCService", "CreateToken", {}).n("SSOOIDCClient", "CreateTokenCommand").f(CreateTokenRequestFilterSensitiveLog, CreateTokenResponseFilterSensitiveLog).ser(se_CreateTokenCommand).de(de_CreateTokenCommand).build() {
-      static {
-        __name(this, "CreateTokenCommand");
-      }
     };
-    var CreateTokenWithIAMCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_CreateTokenCommand, "CreateTokenCommand");
+    var CreateTokenCommand = _CreateTokenCommand;
+    var _CreateTokenWithIAMCommand = class _CreateTokenWithIAMCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSSOOIDCService", "CreateTokenWithIAM", {}).n("SSOOIDCClient", "CreateTokenWithIAMCommand").f(CreateTokenWithIAMRequestFilterSensitiveLog, CreateTokenWithIAMResponseFilterSensitiveLog).ser(se_CreateTokenWithIAMCommand).de(de_CreateTokenWithIAMCommand).build() {
-      static {
-        __name(this, "CreateTokenWithIAMCommand");
-      }
     };
-    var RegisterClientCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_CreateTokenWithIAMCommand, "CreateTokenWithIAMCommand");
+    var CreateTokenWithIAMCommand = _CreateTokenWithIAMCommand;
+    var _RegisterClientCommand = class _RegisterClientCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSSOOIDCService", "RegisterClient", {}).n("SSOOIDCClient", "RegisterClientCommand").f(void 0, RegisterClientResponseFilterSensitiveLog).ser(se_RegisterClientCommand).de(de_RegisterClientCommand).build() {
-      static {
-        __name(this, "RegisterClientCommand");
-      }
     };
-    var StartDeviceAuthorizationCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_RegisterClientCommand, "RegisterClientCommand");
+    var RegisterClientCommand = _RegisterClientCommand;
+    var _StartDeviceAuthorizationCommand = class _StartDeviceAuthorizationCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSSOOIDCService", "StartDeviceAuthorization", {}).n("SSOOIDCClient", "StartDeviceAuthorizationCommand").f(StartDeviceAuthorizationRequestFilterSensitiveLog, void 0).ser(se_StartDeviceAuthorizationCommand).de(de_StartDeviceAuthorizationCommand).build() {
-      static {
-        __name(this, "StartDeviceAuthorizationCommand");
-      }
     };
+    __name(_StartDeviceAuthorizationCommand, "StartDeviceAuthorizationCommand");
+    var StartDeviceAuthorizationCommand = _StartDeviceAuthorizationCommand;
     var commands = {
       CreateTokenCommand,
       CreateTokenWithIAMCommand,
       RegisterClientCommand,
       StartDeviceAuthorizationCommand
     };
-    var SSOOIDC = class extends SSOOIDCClient {
-      static {
-        __name(this, "SSOOIDC");
-      }
+    var _SSOOIDC = class _SSOOIDC extends SSOOIDCClient {
     };
+    __name(_SSOOIDC, "SSOOIDC");
+    var SSOOIDC = _SSOOIDC;
     (0, import_smithy_client4.createAggregatedClient)(commands, SSOOIDC);
   }
 });
@@ -41563,11 +41467,12 @@ var require_dist_cjs56 = __commonJS({
     var EXPIRE_WINDOW_MS = 5 * 60 * 1e3;
     var REFRESH_MESSAGE = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
     var getSsoOidcClient = /* @__PURE__ */ __name(async (ssoRegion, init = {}) => {
+      var _a, _b, _c;
       const { SSOOIDCClient } = await Promise.resolve().then(() => __toESM2(require_dist_cjs55()));
       const ssoOidcClient = new SSOOIDCClient(
         Object.assign({}, init.clientConfig ?? {}, {
-          region: ssoRegion ?? init.clientConfig?.region,
-          logger: init.clientConfig?.logger ?? init.parentClientConfig?.logger
+          region: ssoRegion ?? ((_a = init.clientConfig) == null ? void 0 : _a.region),
+          logger: ((_b = init.clientConfig) == null ? void 0 : _b.logger) ?? ((_c = init.parentClientConfig) == null ? void 0 : _c.logger)
         })
       );
       return ssoOidcClient;
@@ -41607,19 +41512,11 @@ var require_dist_cjs56 = __commonJS({
       return writeFile(tokenFilepath, tokenString);
     }, "writeSSOTokenToFile");
     var lastRefreshAttemptTime = /* @__PURE__ */ new Date(0);
-    var fromSso = /* @__PURE__ */ __name((_init = {}) => async ({ callerClientConfig } = {}) => {
-      const init = {
-        ..._init,
-        parentClientConfig: {
-          ...callerClientConfig,
-          ..._init.parentClientConfig
-        }
-      };
-      init.logger?.debug("@aws-sdk/token-providers - fromSso");
+    var fromSso = /* @__PURE__ */ __name((init = {}) => async () => {
+      var _a;
+      (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/token-providers - fromSso");
       const profiles = await (0, import_shared_ini_file_loader.parseKnownFiles)(init);
-      const profileName = (0, import_shared_ini_file_loader.getProfileName)({
-        profile: init.profile ?? callerClientConfig?.profile
-      });
+      const profileName = (0, import_shared_ini_file_loader.getProfileName)(init);
       const profile = profiles[profileName];
       if (!profile) {
         throw new import_property_provider2.TokenProviderError(`Profile '${profileName}' could not be found in shared credentials file.`, false);
@@ -41693,7 +41590,7 @@ var require_dist_cjs56 = __commonJS({
       }
     }, "fromSso");
     var fromStatic = /* @__PURE__ */ __name(({ token, logger }) => async () => {
-      logger?.debug("@aws-sdk/token-providers - fromStatic");
+      logger == null ? void 0 : logger.debug("@aws-sdk/token-providers - fromStatic");
       if (!token || !token.token) {
         throw new import_property_provider2.TokenProviderError(`Please pass a valid token to fromStatic`, false);
       }
@@ -41806,8 +41703,8 @@ var require_dist_cjs57 = __commonJS({
       const { SSOClient: SSOClient2, GetRoleCredentialsCommand: GetRoleCredentialsCommand2 } = await Promise.resolve().then(() => (init_loadSso(), loadSso_exports));
       const sso = ssoClient || new SSOClient2(
         Object.assign({}, clientConfig ?? {}, {
-          logger: clientConfig?.logger ?? parentClientConfig?.logger,
-          region: clientConfig?.region ?? ssoRegion
+          logger: (clientConfig == null ? void 0 : clientConfig.logger) ?? (parentClientConfig == null ? void 0 : parentClientConfig.logger),
+          region: (clientConfig == null ? void 0 : clientConfig.region) ?? ssoRegion
         })
       );
       let ssoResp;
@@ -41862,13 +41759,12 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.ht
       }
       return profile;
     }, "validateSsoProfile");
-    var fromSSO = /* @__PURE__ */ __name((init = {}) => async ({ callerClientConfig } = {}) => {
-      init.logger?.debug("@aws-sdk/credential-provider-sso - fromSSO");
+    var fromSSO = /* @__PURE__ */ __name((init = {}) => async () => {
+      var _a;
+      (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-sso - fromSSO");
       const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;
       const { ssoClient } = init;
-      const profileName = (0, import_shared_ini_file_loader.getProfileName)({
-        profile: init.profile ?? callerClientConfig?.profile
-      });
+      const profileName = (0, import_shared_ini_file_loader.getProfileName)(init);
       if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName && !ssoSession) {
         const profiles = await (0, import_shared_ini_file_loader.parseKnownFiles)(init);
         const profile = profiles[profileName];
@@ -41880,7 +41776,7 @@ Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.ht
             logger: init.logger
           });
         }
-        if (profile?.sso_session) {
+        if (profile == null ? void 0 : profile.sso_session) {
           const ssoSessions = await (0, import_shared_ini_file_loader.loadSsoSessionData)(init);
           const session = ssoSessions[profile.sso_session];
           const conflictMsg = ` configurations in profile ${profileName} and sso-session ${profile.sso_session}`;
@@ -42040,7 +41936,7 @@ var require_package4 = __commonJS({
     module2.exports = {
       name: "@aws-sdk/client-sts",
       description: "AWS SDK for JavaScript Sts Client for Node.js, Browser and React Native",
-      version: "3.723.0",
+      version: "3.699.0",
       scripts: {
         build: "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
         "build:cjs": "node ../../scripts/compilation/inline client-sts",
@@ -42061,55 +41957,55 @@ var require_package4 = __commonJS({
       dependencies: {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         tslib: "^2.6.2"
       },
       devDependencies: {
-        "@tsconfig/node18": "18.2.4",
-        "@types/node": "^18.19.69",
+        "@tsconfig/node16": "16.1.3",
+        "@types/node": "^16.18.96",
         concurrently: "7.0.0",
         "downlevel-dts": "0.10.1",
         rimraf: "3.0.2",
-        typescript: "~5.2.2"
+        typescript: "~4.9.5"
       },
       engines: {
-        node: ">=18.0.0"
+        node: ">=16.0.0"
       },
       typesVersions: {
         "<4.0": {
@@ -42288,7 +42184,6 @@ var require_runtimeConfig3 = __commonJS({
       const defaultConfigProvider = () => defaultsMode().then(smithy_client_1.loadConfigsForDefaultMode);
       const clientSharedValues = (0, runtimeConfig_shared_1.getRuntimeConfig)(config);
       (0, core_1.emitWarningIfUnsupportedVersion)(process.version);
-      const profileConfig = { profile: config?.profile };
       return {
         ...clientSharedValues,
         ...config,
@@ -42309,18 +42204,18 @@ var require_runtimeConfig3 = __commonJS({
             signer: new core_2.NoAuthSigner()
           }
         ],
-        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
-        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, { ...config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS, ...profileConfig }),
+        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS),
         requestHandler: node_http_handler_1.NodeHttpHandler.create(config?.requestHandler ?? defaultConfigProvider),
         retryMode: config?.retryMode ?? (0, node_config_provider_1.loadConfig)({
           ...middleware_retry_1.NODE_RETRY_MODE_CONFIG_OPTIONS,
           default: async () => (await defaultConfigProvider()).retryMode || util_retry_1.DEFAULT_RETRY_MODE
-        }, config),
+        }),
         sha256: config?.sha256 ?? hash_node_1.Hash.bind(null, "sha256"),
         streamCollector: config?.streamCollector ?? node_http_handler_1.streamCollector,
-        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS, profileConfig)
+        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),
+        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS),
+        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS)
       };
     };
     exports2.getRuntimeConfig = getRuntimeConfig;
@@ -42430,7 +42325,6 @@ var require_STSClient = __commonJS({
     var runtimeConfig_1 = require_runtimeConfig3();
     var runtimeExtensions_1 = require_runtimeExtensions();
     var STSClient2 = class extends smithy_client_1.Client {
-      config;
       constructor(...[configuration]) {
         const _config_0 = (0, runtimeConfig_1.getRuntimeConfig)(configuration || {});
         const _config_1 = (0, EndpointParameters_1.resolveClientEndpointParameters)(_config_0);
@@ -42529,24 +42423,18 @@ var require_dist_cjs58 = __commonJS({
     var import_middleware_serde2 = require_dist_cjs5();
     var import_EndpointParameters = require_EndpointParameters();
     var import_smithy_client4 = require_dist_cjs19();
-    var STSServiceException = class _STSServiceException extends import_smithy_client4.ServiceException {
-      static {
-        __name(this, "STSServiceException");
-      }
+    var _STSServiceException = class _STSServiceException2 extends import_smithy_client4.ServiceException {
       /**
        * @internal
        */
       constructor(options) {
         super(options);
-        Object.setPrototypeOf(this, _STSServiceException.prototype);
+        Object.setPrototypeOf(this, _STSServiceException2.prototype);
       }
     };
-    var ExpiredTokenException = class _ExpiredTokenException extends STSServiceException {
-      static {
-        __name(this, "ExpiredTokenException");
-      }
-      name = "ExpiredTokenException";
-      $fault = "client";
+    __name(_STSServiceException, "STSServiceException");
+    var STSServiceException = _STSServiceException;
+    var _ExpiredTokenException = class _ExpiredTokenException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42556,15 +42444,14 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ExpiredTokenException.prototype);
+        this.name = "ExpiredTokenException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ExpiredTokenException2.prototype);
       }
     };
-    var MalformedPolicyDocumentException = class _MalformedPolicyDocumentException extends STSServiceException {
-      static {
-        __name(this, "MalformedPolicyDocumentException");
-      }
-      name = "MalformedPolicyDocumentException";
-      $fault = "client";
+    __name(_ExpiredTokenException, "ExpiredTokenException");
+    var ExpiredTokenException = _ExpiredTokenException;
+    var _MalformedPolicyDocumentException = class _MalformedPolicyDocumentException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42574,15 +42461,14 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _MalformedPolicyDocumentException.prototype);
+        this.name = "MalformedPolicyDocumentException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _MalformedPolicyDocumentException2.prototype);
       }
     };
-    var PackedPolicyTooLargeException = class _PackedPolicyTooLargeException extends STSServiceException {
-      static {
-        __name(this, "PackedPolicyTooLargeException");
-      }
-      name = "PackedPolicyTooLargeException";
-      $fault = "client";
+    __name(_MalformedPolicyDocumentException, "MalformedPolicyDocumentException");
+    var MalformedPolicyDocumentException = _MalformedPolicyDocumentException;
+    var _PackedPolicyTooLargeException = class _PackedPolicyTooLargeException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42592,15 +42478,14 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _PackedPolicyTooLargeException.prototype);
+        this.name = "PackedPolicyTooLargeException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _PackedPolicyTooLargeException2.prototype);
       }
     };
-    var RegionDisabledException = class _RegionDisabledException extends STSServiceException {
-      static {
-        __name(this, "RegionDisabledException");
-      }
-      name = "RegionDisabledException";
-      $fault = "client";
+    __name(_PackedPolicyTooLargeException, "PackedPolicyTooLargeException");
+    var PackedPolicyTooLargeException = _PackedPolicyTooLargeException;
+    var _RegionDisabledException = class _RegionDisabledException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42610,15 +42495,14 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _RegionDisabledException.prototype);
+        this.name = "RegionDisabledException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _RegionDisabledException2.prototype);
       }
     };
-    var IDPRejectedClaimException = class _IDPRejectedClaimException extends STSServiceException {
-      static {
-        __name(this, "IDPRejectedClaimException");
-      }
-      name = "IDPRejectedClaimException";
-      $fault = "client";
+    __name(_RegionDisabledException, "RegionDisabledException");
+    var RegionDisabledException = _RegionDisabledException;
+    var _IDPRejectedClaimException = class _IDPRejectedClaimException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42628,15 +42512,14 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _IDPRejectedClaimException.prototype);
+        this.name = "IDPRejectedClaimException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _IDPRejectedClaimException2.prototype);
       }
     };
-    var InvalidIdentityTokenException = class _InvalidIdentityTokenException extends STSServiceException {
-      static {
-        __name(this, "InvalidIdentityTokenException");
-      }
-      name = "InvalidIdentityTokenException";
-      $fault = "client";
+    __name(_IDPRejectedClaimException, "IDPRejectedClaimException");
+    var IDPRejectedClaimException = _IDPRejectedClaimException;
+    var _InvalidIdentityTokenException = class _InvalidIdentityTokenException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42646,15 +42529,14 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidIdentityTokenException.prototype);
+        this.name = "InvalidIdentityTokenException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidIdentityTokenException2.prototype);
       }
     };
-    var IDPCommunicationErrorException = class _IDPCommunicationErrorException extends STSServiceException {
-      static {
-        __name(this, "IDPCommunicationErrorException");
-      }
-      name = "IDPCommunicationErrorException";
-      $fault = "client";
+    __name(_InvalidIdentityTokenException, "InvalidIdentityTokenException");
+    var InvalidIdentityTokenException = _InvalidIdentityTokenException;
+    var _IDPCommunicationErrorException = class _IDPCommunicationErrorException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42664,15 +42546,14 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _IDPCommunicationErrorException.prototype);
+        this.name = "IDPCommunicationErrorException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _IDPCommunicationErrorException2.prototype);
       }
     };
-    var InvalidAuthorizationMessageException = class _InvalidAuthorizationMessageException extends STSServiceException {
-      static {
-        __name(this, "InvalidAuthorizationMessageException");
-      }
-      name = "InvalidAuthorizationMessageException";
-      $fault = "client";
+    __name(_IDPCommunicationErrorException, "IDPCommunicationErrorException");
+    var IDPCommunicationErrorException = _IDPCommunicationErrorException;
+    var _InvalidAuthorizationMessageException = class _InvalidAuthorizationMessageException2 extends STSServiceException {
       /**
        * @internal
        */
@@ -42682,9 +42563,13 @@ var require_dist_cjs58 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidAuthorizationMessageException.prototype);
+        this.name = "InvalidAuthorizationMessageException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidAuthorizationMessageException2.prototype);
       }
     };
+    __name(_InvalidAuthorizationMessageException, "InvalidAuthorizationMessageException");
+    var InvalidAuthorizationMessageException = _InvalidAuthorizationMessageException;
     var CredentialsFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
       ...obj,
       ...obj.SecretAccessKey && { SecretAccessKey: import_smithy_client4.SENSITIVE_STRING }
@@ -43043,6 +42928,7 @@ var require_dist_cjs58 = __commonJS({
       return (0, import_smithy_client4.decorateServiceException)(exception2, body);
     }, "de_RegionDisabledExceptionRes");
     var se_AssumeRoleRequest = /* @__PURE__ */ __name((input, context3) => {
+      var _a2, _b, _c, _d;
       const entries = {};
       if (input[_RA] != null) {
         entries[_RA] = input[_RA];
@@ -43052,7 +42938,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_PA] != null) {
         const memberEntries = se_policyDescriptorListType(input[_PA], context3);
-        if (input[_PA]?.length === 0) {
+        if (((_a2 = input[_PA]) == null ? void 0 : _a2.length) === 0) {
           entries.PolicyArns = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43068,7 +42954,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_T] != null) {
         const memberEntries = se_tagListType(input[_T], context3);
-        if (input[_T]?.length === 0) {
+        if (((_b = input[_T]) == null ? void 0 : _b.length) === 0) {
           entries.Tags = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43078,7 +42964,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_TTK] != null) {
         const memberEntries = se_tagKeyListType(input[_TTK], context3);
-        if (input[_TTK]?.length === 0) {
+        if (((_c = input[_TTK]) == null ? void 0 : _c.length) === 0) {
           entries.TransitiveTagKeys = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43100,7 +42986,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_PC] != null) {
         const memberEntries = se_ProvidedContextsListType(input[_PC], context3);
-        if (input[_PC]?.length === 0) {
+        if (((_d = input[_PC]) == null ? void 0 : _d.length) === 0) {
           entries.ProvidedContexts = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43111,6 +42997,7 @@ var require_dist_cjs58 = __commonJS({
       return entries;
     }, "se_AssumeRoleRequest");
     var se_AssumeRoleWithSAMLRequest = /* @__PURE__ */ __name((input, context3) => {
+      var _a2;
       const entries = {};
       if (input[_RA] != null) {
         entries[_RA] = input[_RA];
@@ -43123,7 +43010,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_PA] != null) {
         const memberEntries = se_policyDescriptorListType(input[_PA], context3);
-        if (input[_PA]?.length === 0) {
+        if (((_a2 = input[_PA]) == null ? void 0 : _a2.length) === 0) {
           entries.PolicyArns = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43140,6 +43027,7 @@ var require_dist_cjs58 = __commonJS({
       return entries;
     }, "se_AssumeRoleWithSAMLRequest");
     var se_AssumeRoleWithWebIdentityRequest = /* @__PURE__ */ __name((input, context3) => {
+      var _a2;
       const entries = {};
       if (input[_RA] != null) {
         entries[_RA] = input[_RA];
@@ -43155,7 +43043,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_PA] != null) {
         const memberEntries = se_policyDescriptorListType(input[_PA], context3);
-        if (input[_PA]?.length === 0) {
+        if (((_a2 = input[_PA]) == null ? void 0 : _a2.length) === 0) {
           entries.PolicyArns = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43207,6 +43095,7 @@ var require_dist_cjs58 = __commonJS({
       return entries;
     }, "se_GetCallerIdentityRequest");
     var se_GetFederationTokenRequest = /* @__PURE__ */ __name((input, context3) => {
+      var _a2, _b;
       const entries = {};
       if (input[_N] != null) {
         entries[_N] = input[_N];
@@ -43216,7 +43105,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_PA] != null) {
         const memberEntries = se_policyDescriptorListType(input[_PA], context3);
-        if (input[_PA]?.length === 0) {
+        if (((_a2 = input[_PA]) == null ? void 0 : _a2.length) === 0) {
           entries.PolicyArns = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43229,7 +43118,7 @@ var require_dist_cjs58 = __commonJS({
       }
       if (input[_T] != null) {
         const memberEntries = se_tagListType(input[_T], context3);
-        if (input[_T]?.length === 0) {
+        if (((_b = input[_T]) == null ? void 0 : _b.length) === 0) {
           entries.Tags = [];
         }
         Object.entries(memberEntries).forEach(([key, value]) => {
@@ -43646,111 +43535,103 @@ var require_dist_cjs58 = __commonJS({
     var _m = "message";
     var buildFormUrlencodedString = /* @__PURE__ */ __name((formEntries) => Object.entries(formEntries).map(([key, value]) => (0, import_smithy_client4.extendedEncodeURIComponent)(key) + "=" + (0, import_smithy_client4.extendedEncodeURIComponent)(value)).join("&"), "buildFormUrlencodedString");
     var loadQueryErrorCode = /* @__PURE__ */ __name((output, data) => {
-      if (data.Error?.Code !== void 0) {
+      var _a2;
+      if (((_a2 = data.Error) == null ? void 0 : _a2.Code) !== void 0) {
         return data.Error.Code;
       }
       if (output.statusCode == 404) {
         return "NotFound";
       }
     }, "loadQueryErrorCode");
-    var AssumeRoleCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters.commonParams).m(function(Command, cs, config, o) {
+    var _AssumeRoleCommand = class _AssumeRoleCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "AssumeRole", {}).n("STSClient", "AssumeRoleCommand").f(void 0, AssumeRoleResponseFilterSensitiveLog).ser(se_AssumeRoleCommand).de(de_AssumeRoleCommand).build() {
-      static {
-        __name(this, "AssumeRoleCommand");
-      }
     };
+    __name(_AssumeRoleCommand, "AssumeRoleCommand");
+    var AssumeRoleCommand = _AssumeRoleCommand;
     var import_EndpointParameters2 = require_EndpointParameters();
-    var AssumeRoleWithSAMLCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters2.commonParams).m(function(Command, cs, config, o) {
+    var _AssumeRoleWithSAMLCommand = class _AssumeRoleWithSAMLCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters2.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "AssumeRoleWithSAML", {}).n("STSClient", "AssumeRoleWithSAMLCommand").f(AssumeRoleWithSAMLRequestFilterSensitiveLog, AssumeRoleWithSAMLResponseFilterSensitiveLog).ser(se_AssumeRoleWithSAMLCommand).de(de_AssumeRoleWithSAMLCommand).build() {
-      static {
-        __name(this, "AssumeRoleWithSAMLCommand");
-      }
     };
+    __name(_AssumeRoleWithSAMLCommand, "AssumeRoleWithSAMLCommand");
+    var AssumeRoleWithSAMLCommand = _AssumeRoleWithSAMLCommand;
     var import_EndpointParameters3 = require_EndpointParameters();
-    var AssumeRoleWithWebIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters3.commonParams).m(function(Command, cs, config, o) {
+    var _AssumeRoleWithWebIdentityCommand = class _AssumeRoleWithWebIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters3.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "AssumeRoleWithWebIdentity", {}).n("STSClient", "AssumeRoleWithWebIdentityCommand").f(AssumeRoleWithWebIdentityRequestFilterSensitiveLog, AssumeRoleWithWebIdentityResponseFilterSensitiveLog).ser(se_AssumeRoleWithWebIdentityCommand).de(de_AssumeRoleWithWebIdentityCommand).build() {
-      static {
-        __name(this, "AssumeRoleWithWebIdentityCommand");
-      }
     };
+    __name(_AssumeRoleWithWebIdentityCommand, "AssumeRoleWithWebIdentityCommand");
+    var AssumeRoleWithWebIdentityCommand = _AssumeRoleWithWebIdentityCommand;
     var import_EndpointParameters4 = require_EndpointParameters();
-    var AssumeRootCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters4.commonParams).m(function(Command, cs, config, o) {
+    var _AssumeRootCommand = class _AssumeRootCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters4.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "AssumeRoot", {}).n("STSClient", "AssumeRootCommand").f(void 0, AssumeRootResponseFilterSensitiveLog).ser(se_AssumeRootCommand).de(de_AssumeRootCommand).build() {
-      static {
-        __name(this, "AssumeRootCommand");
-      }
     };
+    __name(_AssumeRootCommand, "AssumeRootCommand");
+    var AssumeRootCommand = _AssumeRootCommand;
     var import_EndpointParameters5 = require_EndpointParameters();
-    var DecodeAuthorizationMessageCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters5.commonParams).m(function(Command, cs, config, o) {
+    var _DecodeAuthorizationMessageCommand = class _DecodeAuthorizationMessageCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters5.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "DecodeAuthorizationMessage", {}).n("STSClient", "DecodeAuthorizationMessageCommand").f(void 0, void 0).ser(se_DecodeAuthorizationMessageCommand).de(de_DecodeAuthorizationMessageCommand).build() {
-      static {
-        __name(this, "DecodeAuthorizationMessageCommand");
-      }
     };
+    __name(_DecodeAuthorizationMessageCommand, "DecodeAuthorizationMessageCommand");
+    var DecodeAuthorizationMessageCommand = _DecodeAuthorizationMessageCommand;
     var import_EndpointParameters6 = require_EndpointParameters();
-    var GetAccessKeyInfoCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters6.commonParams).m(function(Command, cs, config, o) {
+    var _GetAccessKeyInfoCommand = class _GetAccessKeyInfoCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters6.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "GetAccessKeyInfo", {}).n("STSClient", "GetAccessKeyInfoCommand").f(void 0, void 0).ser(se_GetAccessKeyInfoCommand).de(de_GetAccessKeyInfoCommand).build() {
-      static {
-        __name(this, "GetAccessKeyInfoCommand");
-      }
     };
+    __name(_GetAccessKeyInfoCommand, "GetAccessKeyInfoCommand");
+    var GetAccessKeyInfoCommand = _GetAccessKeyInfoCommand;
     var import_EndpointParameters7 = require_EndpointParameters();
-    var GetCallerIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters7.commonParams).m(function(Command, cs, config, o) {
+    var _GetCallerIdentityCommand = class _GetCallerIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters7.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "GetCallerIdentity", {}).n("STSClient", "GetCallerIdentityCommand").f(void 0, void 0).ser(se_GetCallerIdentityCommand).de(de_GetCallerIdentityCommand).build() {
-      static {
-        __name(this, "GetCallerIdentityCommand");
-      }
     };
+    __name(_GetCallerIdentityCommand, "GetCallerIdentityCommand");
+    var GetCallerIdentityCommand = _GetCallerIdentityCommand;
     var import_EndpointParameters8 = require_EndpointParameters();
-    var GetFederationTokenCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters8.commonParams).m(function(Command, cs, config, o) {
+    var _GetFederationTokenCommand = class _GetFederationTokenCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters8.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "GetFederationToken", {}).n("STSClient", "GetFederationTokenCommand").f(void 0, GetFederationTokenResponseFilterSensitiveLog).ser(se_GetFederationTokenCommand).de(de_GetFederationTokenCommand).build() {
-      static {
-        __name(this, "GetFederationTokenCommand");
-      }
     };
+    __name(_GetFederationTokenCommand, "GetFederationTokenCommand");
+    var GetFederationTokenCommand = _GetFederationTokenCommand;
     var import_EndpointParameters9 = require_EndpointParameters();
-    var GetSessionTokenCommand = class extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters9.commonParams).m(function(Command, cs, config, o) {
+    var _GetSessionTokenCommand = class _GetSessionTokenCommand extends import_smithy_client4.Command.classBuilder().ep(import_EndpointParameters9.commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSSecurityTokenServiceV20110615", "GetSessionToken", {}).n("STSClient", "GetSessionTokenCommand").f(void 0, GetSessionTokenResponseFilterSensitiveLog).ser(se_GetSessionTokenCommand).de(de_GetSessionTokenCommand).build() {
-      static {
-        __name(this, "GetSessionTokenCommand");
-      }
     };
+    __name(_GetSessionTokenCommand, "GetSessionTokenCommand");
+    var GetSessionTokenCommand = _GetSessionTokenCommand;
     var import_STSClient = require_STSClient();
     var commands = {
       AssumeRoleCommand,
@@ -43763,17 +43644,16 @@ var require_dist_cjs58 = __commonJS({
       GetFederationTokenCommand,
       GetSessionTokenCommand
     };
-    var STS = class extends import_STSClient.STSClient {
-      static {
-        __name(this, "STS");
-      }
+    var _STS = class _STS extends import_STSClient.STSClient {
     };
+    __name(_STS, "STS");
+    var STS = _STS;
     (0, import_smithy_client4.createAggregatedClient)(commands, STS);
     var import_EndpointParameters10 = require_EndpointParameters();
     var import_client2 = (init_client(), __toCommonJS(client_exports));
     var ASSUME_ROLE_DEFAULT_REGION = "us-east-1";
     var getAccountIdFromAssumedRoleUser = /* @__PURE__ */ __name((assumedRoleUser) => {
-      if (typeof assumedRoleUser?.Arn === "string") {
+      if (typeof (assumedRoleUser == null ? void 0 : assumedRoleUser.Arn) === "string") {
         const arnComponents = assumedRoleUser.Arn.split(":");
         if (arnComponents.length > 4 && arnComponents[4] !== "") {
           return arnComponents[4];
@@ -43782,9 +43662,11 @@ var require_dist_cjs58 = __commonJS({
       return void 0;
     }, "getAccountIdFromAssumedRoleUser");
     var resolveRegion = /* @__PURE__ */ __name(async (_region, _parentRegion, credentialProviderLogger) => {
+      var _a2;
       const region = typeof _region === "function" ? await _region() : _region;
       const parentRegion = typeof _parentRegion === "function" ? await _parentRegion() : _parentRegion;
-      credentialProviderLogger?.debug?.(
+      (_a2 = credentialProviderLogger == null ? void 0 : credentialProviderLogger.debug) == null ? void 0 : _a2.call(
+        credentialProviderLogger,
         "@aws-sdk/client-sts::resolveRegion",
         "accepting first of:",
         `${region} (provider)`,
@@ -43797,17 +43679,18 @@ var require_dist_cjs58 = __commonJS({
       let stsClient;
       let closureSourceCreds;
       return async (sourceCreds, params) => {
+        var _a2, _b, _c;
         closureSourceCreds = sourceCreds;
         if (!stsClient) {
           const {
-            logger = stsOptions?.parentClientConfig?.logger,
+            logger = (_a2 = stsOptions == null ? void 0 : stsOptions.parentClientConfig) == null ? void 0 : _a2.logger,
             region,
-            requestHandler = stsOptions?.parentClientConfig?.requestHandler,
+            requestHandler = (_b = stsOptions == null ? void 0 : stsOptions.parentClientConfig) == null ? void 0 : _b.requestHandler,
             credentialProviderLogger
           } = stsOptions;
           const resolvedRegion = await resolveRegion(
             region,
-            stsOptions?.parentClientConfig?.region,
+            (_c = stsOptions == null ? void 0 : stsOptions.parentClientConfig) == null ? void 0 : _c.region,
             credentialProviderLogger
           );
           const isCompatibleRequestHandler = !isH2(requestHandler);
@@ -43840,16 +43723,17 @@ var require_dist_cjs58 = __commonJS({
     var getDefaultRoleAssumerWithWebIdentity = /* @__PURE__ */ __name((stsOptions, stsClientCtor) => {
       let stsClient;
       return async (params) => {
+        var _a2, _b, _c;
         if (!stsClient) {
           const {
-            logger = stsOptions?.parentClientConfig?.logger,
+            logger = (_a2 = stsOptions == null ? void 0 : stsOptions.parentClientConfig) == null ? void 0 : _a2.logger,
             region,
-            requestHandler = stsOptions?.parentClientConfig?.requestHandler,
+            requestHandler = (_b = stsOptions == null ? void 0 : stsOptions.parentClientConfig) == null ? void 0 : _b.requestHandler,
             credentialProviderLogger
           } = stsOptions;
           const resolvedRegion = await resolveRegion(
             region,
-            stsOptions?.parentClientConfig?.region,
+            (_c = stsOptions == null ? void 0 : stsOptions.parentClientConfig) == null ? void 0 : _c.region,
             credentialProviderLogger
           );
           const isCompatibleRequestHandler = !isH2(requestHandler);
@@ -43881,24 +43765,23 @@ var require_dist_cjs58 = __commonJS({
       };
     }, "getDefaultRoleAssumerWithWebIdentity");
     var isH2 = /* @__PURE__ */ __name((requestHandler) => {
-      return requestHandler?.metadata?.handlerProtocol === "h2";
+      var _a2;
+      return ((_a2 = requestHandler == null ? void 0 : requestHandler.metadata) == null ? void 0 : _a2.handlerProtocol) === "h2";
     }, "isH2");
     var import_STSClient2 = require_STSClient();
     var getCustomizableStsClientCtor = /* @__PURE__ */ __name((baseCtor, customizations) => {
+      var _a2;
       if (!customizations)
         return baseCtor;
       else
-        return class CustomizableSTSClient extends baseCtor {
-          static {
-            __name(this, "CustomizableSTSClient");
-          }
+        return _a2 = class extends baseCtor {
           constructor(config) {
             super(config);
             for (const customization of customizations) {
               this.middlewareStack.use(customization);
             }
           }
-        };
+        }, __name(_a2, "CustomizableSTSClient"), _a2;
     }, "getCustomizableStsClientCtor");
     var getDefaultRoleAssumer2 = /* @__PURE__ */ __name((stsOptions = {}, stsPlugins) => getDefaultRoleAssumer(stsOptions, getCustomizableStsClientCtor(import_STSClient2.STSClient, stsPlugins)), "getDefaultRoleAssumer");
     var getDefaultRoleAssumerWithWebIdentity2 = /* @__PURE__ */ __name((stsOptions = {}, stsPlugins) => getDefaultRoleAssumerWithWebIdentity(stsOptions, getCustomizableStsClientCtor(import_STSClient2.STSClient, stsPlugins)), "getDefaultRoleAssumerWithWebIdentity");
@@ -43943,6 +43826,7 @@ var require_dist_cjs59 = __commonJS({
     var import_util = require("util");
     var import_client2 = (init_client(), __toCommonJS(client_exports));
     var getValidatedProcessCredentials = /* @__PURE__ */ __name((profileName, data, profiles) => {
+      var _a;
       if (data.Version !== 1) {
         throw Error(`Profile ${profileName} credential_process did not return Version 1.`);
       }
@@ -43957,7 +43841,7 @@ var require_dist_cjs59 = __commonJS({
         }
       }
       let accountId = data.AccountId;
-      if (!accountId && profiles?.[profileName]?.aws_account_id) {
+      if (!accountId && ((_a = profiles == null ? void 0 : profiles[profileName]) == null ? void 0 : _a.aws_account_id)) {
         accountId = profiles[profileName].aws_account_id;
       }
       const credentials = {
@@ -43998,16 +43882,11 @@ var require_dist_cjs59 = __commonJS({
         });
       }
     }, "resolveProcessCredentials");
-    var fromProcess = /* @__PURE__ */ __name((init = {}) => async ({ callerClientConfig } = {}) => {
-      init.logger?.debug("@aws-sdk/credential-provider-process - fromProcess");
+    var fromProcess = /* @__PURE__ */ __name((init = {}) => async () => {
+      var _a;
+      (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-process - fromProcess");
       const profiles = await (0, import_shared_ini_file_loader.parseKnownFiles)(init);
-      return resolveProcessCredentials(
-        (0, import_shared_ini_file_loader.getProfileName)({
-          profile: init.profile ?? callerClientConfig?.profile
-        }),
-        profiles,
-        init.logger
-      );
+      return resolveProcessCredentials((0, import_shared_ini_file_loader.getProfileName)(init), profiles, init.logger);
     }, "fromProcess");
   }
 });
@@ -44045,7 +43924,7 @@ var require_fromWebToken = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.fromWebToken = void 0;
-    var fromWebToken3 = (init) => async (awsIdentityProperties) => {
+    var fromWebToken3 = (init) => async () => {
       init.logger?.debug("@aws-sdk/credential-provider-web-identity - fromWebToken");
       const { roleArn, roleSessionName, webIdentityToken, providerId, policyArns, policy, durationSeconds } = init;
       let { roleAssumerWithWebIdentity } = init;
@@ -44054,10 +43933,7 @@ var require_fromWebToken = __commonJS({
         roleAssumerWithWebIdentity = getDefaultRoleAssumerWithWebIdentity({
           ...init.clientConfig,
           credentialProviderLogger: init.logger,
-          parentClientConfig: {
-            ...awsIdentityProperties?.callerClientConfig,
-            ...init.parentClientConfig
-          }
+          parentClientConfig: init.parentClientConfig
         }, init.clientPlugins);
       }
       return roleAssumerWithWebIdentity({
@@ -44182,16 +44058,16 @@ var require_dist_cjs61 = __commonJS({
         EcsContainer: async (options) => {
           const { fromHttp } = await Promise.resolve().then(() => __toESM2(require_dist_cjs48()));
           const { fromContainerMetadata } = await Promise.resolve().then(() => __toESM2(require_dist_cjs47()));
-          logger?.debug("@aws-sdk/credential-provider-ini - credential_source is EcsContainer");
+          logger == null ? void 0 : logger.debug("@aws-sdk/credential-provider-ini - credential_source is EcsContainer");
           return async () => (0, import_property_provider2.chain)(fromHttp(options ?? {}), fromContainerMetadata(options))().then(setNamedProvider);
         },
         Ec2InstanceMetadata: async (options) => {
-          logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Ec2InstanceMetadata");
+          logger == null ? void 0 : logger.debug("@aws-sdk/credential-provider-ini - credential_source is Ec2InstanceMetadata");
           const { fromInstanceMetadata } = await Promise.resolve().then(() => __toESM2(require_dist_cjs47()));
           return async () => fromInstanceMetadata(options)().then(setNamedProvider);
         },
         Environment: async (options) => {
-          logger?.debug("@aws-sdk/credential-provider-ini - credential_source is Environment");
+          logger == null ? void 0 : logger.debug("@aws-sdk/credential-provider-ini - credential_source is Environment");
           const { fromEnv } = await Promise.resolve().then(() => __toESM2(require_dist_cjs46()));
           return async () => fromEnv(options)().then(setNamedProvider);
         }
@@ -44210,44 +44086,44 @@ var require_dist_cjs61 = __commonJS({
       return Boolean(arg) && typeof arg === "object" && typeof arg.role_arn === "string" && ["undefined", "string"].indexOf(typeof arg.role_session_name) > -1 && ["undefined", "string"].indexOf(typeof arg.external_id) > -1 && ["undefined", "string"].indexOf(typeof arg.mfa_serial) > -1 && (isAssumeRoleWithSourceProfile(arg, { profile, logger }) || isCredentialSourceProfile(arg, { profile, logger }));
     }, "isAssumeRoleProfile");
     var isAssumeRoleWithSourceProfile = /* @__PURE__ */ __name((arg, { profile, logger }) => {
+      var _a;
       const withSourceProfile = typeof arg.source_profile === "string" && typeof arg.credential_source === "undefined";
       if (withSourceProfile) {
-        logger?.debug?.(`    ${profile} isAssumeRoleWithSourceProfile source_profile=${arg.source_profile}`);
+        (_a = logger == null ? void 0 : logger.debug) == null ? void 0 : _a.call(logger, `    ${profile} isAssumeRoleWithSourceProfile source_profile=${arg.source_profile}`);
       }
       return withSourceProfile;
     }, "isAssumeRoleWithSourceProfile");
     var isCredentialSourceProfile = /* @__PURE__ */ __name((arg, { profile, logger }) => {
+      var _a;
       const withProviderProfile = typeof arg.credential_source === "string" && typeof arg.source_profile === "undefined";
       if (withProviderProfile) {
-        logger?.debug?.(`    ${profile} isCredentialSourceProfile credential_source=${arg.credential_source}`);
+        (_a = logger == null ? void 0 : logger.debug) == null ? void 0 : _a.call(logger, `    ${profile} isCredentialSourceProfile credential_source=${arg.credential_source}`);
       }
       return withProviderProfile;
     }, "isCredentialSourceProfile");
     var resolveAssumeRoleCredentials = /* @__PURE__ */ __name(async (profileName, profiles, options, visitedProfiles = {}) => {
-      options.logger?.debug("@aws-sdk/credential-provider-ini - resolveAssumeRoleCredentials (STS)");
-      const profileData = profiles[profileName];
-      const { source_profile, region } = profileData;
+      var _a, _b;
+      (_a = options.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-ini - resolveAssumeRoleCredentials (STS)");
+      const data = profiles[profileName];
       if (!options.roleAssumer) {
         const { getDefaultRoleAssumer } = await Promise.resolve().then(() => __toESM2(require_dist_cjs58()));
         options.roleAssumer = getDefaultRoleAssumer(
           {
             ...options.clientConfig,
             credentialProviderLogger: options.logger,
-            parentClientConfig: {
-              ...options?.parentClientConfig,
-              region: region ?? options?.parentClientConfig?.region
-            }
+            parentClientConfig: options == null ? void 0 : options.parentClientConfig
           },
           options.clientPlugins
         );
       }
+      const { source_profile } = data;
       if (source_profile && source_profile in visitedProfiles) {
         throw new import_property_provider2.CredentialsProviderError(
           `Detected a cycle attempting to resolve credentials for profile ${(0, import_shared_ini_file_loader.getProfileName)(options)}. Profiles visited: ` + Object.keys(visitedProfiles).join(", "),
           { logger: options.logger }
         );
       }
-      options.logger?.debug(
+      (_b = options.logger) == null ? void 0 : _b.debug(
         `@aws-sdk/credential-provider-ini - finding credential resolver using ${source_profile ? `source_profile=[${source_profile}]` : `profile=[${profileName}]`}`
       );
       const sourceCredsProvider = source_profile ? resolveProfileData(
@@ -44259,17 +44135,17 @@ var require_dist_cjs61 = __commonJS({
           [source_profile]: true
         },
         isCredentialSourceWithoutRoleArn(profiles[source_profile] ?? {})
-      ) : (await resolveCredentialSource(profileData.credential_source, profileName, options.logger)(options))();
-      if (isCredentialSourceWithoutRoleArn(profileData)) {
+      ) : (await resolveCredentialSource(data.credential_source, profileName, options.logger)(options))();
+      if (isCredentialSourceWithoutRoleArn(data)) {
         return sourceCredsProvider.then((creds) => (0, import_client2.setCredentialFeature)(creds, "CREDENTIALS_PROFILE_SOURCE_PROFILE", "o"));
       } else {
         const params = {
-          RoleArn: profileData.role_arn,
-          RoleSessionName: profileData.role_session_name || `aws-sdk-js-${Date.now()}`,
-          ExternalId: profileData.external_id,
-          DurationSeconds: parseInt(profileData.duration_seconds || "3600", 10)
+          RoleArn: data.role_arn,
+          RoleSessionName: data.role_session_name || `aws-sdk-js-${Date.now()}`,
+          ExternalId: data.external_id,
+          DurationSeconds: parseInt(data.duration_seconds || "3600", 10)
         };
-        const { mfa_serial } = profileData;
+        const { mfa_serial } = data;
         if (mfa_serial) {
           if (!options.mfaCodeProvider) {
             throw new import_property_provider2.CredentialsProviderError(
@@ -44314,7 +44190,8 @@ var require_dist_cjs61 = __commonJS({
     var isSsoProfile = /* @__PURE__ */ __name((arg) => arg && (typeof arg.sso_start_url === "string" || typeof arg.sso_account_id === "string" || typeof arg.sso_session === "string" || typeof arg.sso_region === "string" || typeof arg.sso_role_name === "string"), "isSsoProfile");
     var isStaticCredsProfile = /* @__PURE__ */ __name((arg) => Boolean(arg) && typeof arg === "object" && typeof arg.aws_access_key_id === "string" && typeof arg.aws_secret_access_key === "string" && ["undefined", "string"].indexOf(typeof arg.aws_session_token) > -1 && ["undefined", "string"].indexOf(typeof arg.aws_account_id) > -1, "isStaticCredsProfile");
     var resolveStaticCredentials = /* @__PURE__ */ __name(async (profile, options) => {
-      options?.logger?.debug("@aws-sdk/credential-provider-ini - resolveStaticCredentials");
+      var _a;
+      (_a = options == null ? void 0 : options.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-ini - resolveStaticCredentials");
       const credentials = {
         accessKeyId: profile.aws_access_key_id,
         secretAccessKey: profile.aws_secret_access_key,
@@ -44360,23 +44237,11 @@ var require_dist_cjs61 = __commonJS({
         { logger: options.logger }
       );
     }, "resolveProfileData");
-    var fromIni = /* @__PURE__ */ __name((_init = {}) => async ({ callerClientConfig } = {}) => {
-      const init = {
-        ..._init,
-        parentClientConfig: {
-          ...callerClientConfig,
-          ..._init.parentClientConfig
-        }
-      };
-      init.logger?.debug("@aws-sdk/credential-provider-ini - fromIni");
+    var fromIni = /* @__PURE__ */ __name((init = {}) => async () => {
+      var _a;
+      (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-ini - fromIni");
       const profiles = await (0, import_shared_ini_file_loader.parseKnownFiles)(init);
-      return resolveProfileData(
-        (0, import_shared_ini_file_loader.getProfileName)({
-          profile: _init.profile ?? callerClientConfig?.profile
-        }),
-        profiles,
-        init
-      );
+      return resolveProfileData((0, import_shared_ini_file_loader.getProfileName)(init), profiles, init);
     }, "fromIni");
   }
 });
@@ -44425,9 +44290,10 @@ var require_dist_cjs62 = __commonJS({
     var import_property_provider2 = require_dist_cjs16();
     var ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
     var remoteProvider = /* @__PURE__ */ __name(async (init) => {
+      var _a, _b;
       const { ENV_CMDS_FULL_URI, ENV_CMDS_RELATIVE_URI, fromContainerMetadata, fromInstanceMetadata } = await Promise.resolve().then(() => __toESM2(require_dist_cjs47()));
       if (process.env[ENV_CMDS_RELATIVE_URI] || process.env[ENV_CMDS_FULL_URI]) {
-        init.logger?.debug("@aws-sdk/credential-provider-node - remoteProvider::fromHttp/fromContainerMetadata");
+        (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-node - remoteProvider::fromHttp/fromContainerMetadata");
         const { fromHttp } = await Promise.resolve().then(() => __toESM2(require_dist_cjs48()));
         return (0, import_property_provider2.chain)(fromHttp(init), fromContainerMetadata(init));
       }
@@ -44436,19 +44302,20 @@ var require_dist_cjs62 = __commonJS({
           throw new import_property_provider2.CredentialsProviderError("EC2 Instance Metadata Service access disabled", { logger: init.logger });
         };
       }
-      init.logger?.debug("@aws-sdk/credential-provider-node - remoteProvider::fromInstanceMetadata");
+      (_b = init.logger) == null ? void 0 : _b.debug("@aws-sdk/credential-provider-node - remoteProvider::fromInstanceMetadata");
       return fromInstanceMetadata(init);
     }, "remoteProvider");
     var multipleCredentialSourceWarningEmitted = false;
     var defaultProvider = /* @__PURE__ */ __name((init = {}) => (0, import_property_provider2.memoize)(
       (0, import_property_provider2.chain)(
         async () => {
+          var _a, _b, _c, _d;
           const profile = init.profile ?? process.env[import_shared_ini_file_loader.ENV_PROFILE];
           if (profile) {
             const envStaticCredentialsAreSet = process.env[import_credential_provider_env.ENV_KEY] && process.env[import_credential_provider_env.ENV_SECRET];
             if (envStaticCredentialsAreSet) {
               if (!multipleCredentialSourceWarningEmitted) {
-                const warnFn = init.logger?.warn && init.logger?.constructor?.name !== "NoOpLogger" ? init.logger.warn : console.warn;
+                const warnFn = ((_a = init.logger) == null ? void 0 : _a.warn) && ((_c = (_b = init.logger) == null ? void 0 : _b.constructor) == null ? void 0 : _c.name) !== "NoOpLogger" ? init.logger.warn : console.warn;
                 warnFn(
                   `@aws-sdk/credential-provider-node - defaultProvider::fromEnv WARNING:
     Multiple credential sources detected: 
@@ -44468,11 +44335,12 @@ var require_dist_cjs62 = __commonJS({
               tryNextLink: true
             });
           }
-          init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromEnv");
+          (_d = init.logger) == null ? void 0 : _d.debug("@aws-sdk/credential-provider-node - defaultProvider::fromEnv");
           return (0, import_credential_provider_env.fromEnv)(init)();
         },
         async () => {
-          init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromSSO");
+          var _a;
+          (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-node - defaultProvider::fromSSO");
           const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoSession } = init;
           if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName && !ssoSession) {
             throw new import_property_provider2.CredentialsProviderError(
@@ -44484,22 +44352,26 @@ var require_dist_cjs62 = __commonJS({
           return fromSSO(init)();
         },
         async () => {
-          init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromIni");
+          var _a;
+          (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-node - defaultProvider::fromIni");
           const { fromIni } = await Promise.resolve().then(() => __toESM2(require_dist_cjs61()));
           return fromIni(init)();
         },
         async () => {
-          init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromProcess");
+          var _a;
+          (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-node - defaultProvider::fromProcess");
           const { fromProcess } = await Promise.resolve().then(() => __toESM2(require_dist_cjs59()));
           return fromProcess(init)();
         },
         async () => {
-          init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::fromTokenFile");
+          var _a;
+          (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-node - defaultProvider::fromTokenFile");
           const { fromTokenFile: fromTokenFile2 } = await Promise.resolve().then(() => __toESM2(require_dist_cjs60()));
           return fromTokenFile2(init)();
         },
         async () => {
-          init.logger?.debug("@aws-sdk/credential-provider-node - defaultProvider::remoteProvider");
+          var _a;
+          (_a = init.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-node - defaultProvider::remoteProvider");
           return (await remoteProvider(init))();
         },
         async () => {
@@ -44512,8 +44384,8 @@ var require_dist_cjs62 = __commonJS({
       credentialsTreatedAsExpired,
       credentialsWillNeedRefresh
     ), "defaultProvider");
-    var credentialsWillNeedRefresh = /* @__PURE__ */ __name((credentials) => credentials?.expiration !== void 0, "credentialsWillNeedRefresh");
-    var credentialsTreatedAsExpired = /* @__PURE__ */ __name((credentials) => credentials?.expiration !== void 0 && credentials.expiration.getTime() - Date.now() < 3e5, "credentialsTreatedAsExpired");
+    var credentialsWillNeedRefresh = /* @__PURE__ */ __name((credentials) => (credentials == null ? void 0 : credentials.expiration) !== void 0, "credentialsWillNeedRefresh");
+    var credentialsTreatedAsExpired = /* @__PURE__ */ __name((credentials) => (credentials == null ? void 0 : credentials.expiration) !== void 0 && credentials.expiration.getTime() - Date.now() < 3e5, "credentialsTreatedAsExpired");
   }
 });
 
@@ -44653,7 +44525,7 @@ var require_dist_cjs63 = __commonJS({
       }
     }, "validateAccountId");
     var validateDNSHostLabel = /* @__PURE__ */ __name((label, options = { tlsCompatible: true }) => {
-      if (label.length >= 64 || !/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/.test(label) || /(\d+\.){3}\d+/.test(label) || /[.-]{2}/.test(label) || options?.tlsCompatible && DOT_PATTERN.test(label)) {
+      if (label.length >= 64 || !/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/.test(label) || /(\d+\.){3}\d+/.test(label) || /[.-]{2}/.test(label) || (options == null ? void 0 : options.tlsCompatible) && DOT_PATTERN.test(label)) {
         throw new Error(`Invalid DNS label ${label}`);
       }
     }, "validateDNSHostLabel");
@@ -45016,15 +44888,12 @@ var require_dist_cjs64 = __commonJS({
     module2.exports = __toCommonJS2(src_exports);
     var import_crc322 = require_main4();
     var import_util_hex_encoding = require_dist_cjs14();
-    var Int64 = class _Int64 {
+    var _Int64 = class _Int642 {
       constructor(bytes) {
         this.bytes = bytes;
         if (bytes.byteLength !== 8) {
           throw new Error("Int64 buffers must be exactly 8 bytes");
         }
-      }
-      static {
-        __name(this, "Int64");
       }
       static fromNumber(number) {
         if (number > 9223372036854776e3 || number < -9223372036854776e3) {
@@ -45037,7 +44906,7 @@ var require_dist_cjs64 = __commonJS({
         if (number < 0) {
           negate(bytes);
         }
-        return new _Int64(bytes);
+        return new _Int642(bytes);
       }
       /**
        * Called implicitly by infix arithmetic operators.
@@ -45054,6 +44923,8 @@ var require_dist_cjs64 = __commonJS({
         return String(this.valueOf());
       }
     };
+    __name(_Int64, "Int64");
+    var Int64 = _Int64;
     function negate(bytes) {
       for (let i = 0; i < 8; i++) {
         bytes[i] ^= 255;
@@ -45065,13 +44936,10 @@ var require_dist_cjs64 = __commonJS({
       }
     }
     __name(negate, "negate");
-    var HeaderMarshaller = class {
+    var _HeaderMarshaller = class _HeaderMarshaller {
       constructor(toUtf8, fromUtf8) {
         this.toUtf8 = toUtf8;
         this.fromUtf8 = fromUtf8;
-      }
-      static {
-        __name(this, "HeaderMarshaller");
       }
       format(headers) {
         const chunks = [];
@@ -45246,6 +45114,8 @@ var require_dist_cjs64 = __commonJS({
         return out;
       }
     };
+    __name(_HeaderMarshaller, "HeaderMarshaller");
+    var HeaderMarshaller = _HeaderMarshaller;
     var BOOLEAN_TAG = "boolean";
     var BYTE_TAG = "byte";
     var SHORT_TAG = "short";
@@ -45297,10 +45167,7 @@ var require_dist_cjs64 = __commonJS({
       };
     }
     __name(splitMessage, "splitMessage");
-    var EventStreamCodec = class {
-      static {
-        __name(this, "EventStreamCodec");
-      }
+    var _EventStreamCodec = class _EventStreamCodec {
       constructor(toUtf8, fromUtf8) {
         this.headerMarshaller = new HeaderMarshaller(toUtf8, fromUtf8);
         this.messageBuffer = [];
@@ -45371,12 +45238,11 @@ var require_dist_cjs64 = __commonJS({
         return this.headerMarshaller.format(rawHeaders);
       }
     };
-    var MessageDecoderStream = class {
+    __name(_EventStreamCodec, "EventStreamCodec");
+    var EventStreamCodec = _EventStreamCodec;
+    var _MessageDecoderStream = class _MessageDecoderStream {
       constructor(options) {
         this.options = options;
-      }
-      static {
-        __name(this, "MessageDecoderStream");
       }
       [Symbol.asyncIterator]() {
         return this.asyncIterator();
@@ -45388,12 +45254,11 @@ var require_dist_cjs64 = __commonJS({
         }
       }
     };
-    var MessageEncoderStream = class {
+    __name(_MessageDecoderStream, "MessageDecoderStream");
+    var MessageDecoderStream = _MessageDecoderStream;
+    var _MessageEncoderStream = class _MessageEncoderStream {
       constructor(options) {
         this.options = options;
-      }
-      static {
-        __name(this, "MessageEncoderStream");
       }
       [Symbol.asyncIterator]() {
         return this.asyncIterator();
@@ -45408,12 +45273,11 @@ var require_dist_cjs64 = __commonJS({
         }
       }
     };
-    var SmithyMessageDecoderStream = class {
+    __name(_MessageEncoderStream, "MessageEncoderStream");
+    var MessageEncoderStream = _MessageEncoderStream;
+    var _SmithyMessageDecoderStream = class _SmithyMessageDecoderStream {
       constructor(options) {
         this.options = options;
-      }
-      static {
-        __name(this, "SmithyMessageDecoderStream");
       }
       [Symbol.asyncIterator]() {
         return this.asyncIterator();
@@ -45427,12 +45291,11 @@ var require_dist_cjs64 = __commonJS({
         }
       }
     };
-    var SmithyMessageEncoderStream = class {
+    __name(_SmithyMessageDecoderStream, "SmithyMessageDecoderStream");
+    var SmithyMessageDecoderStream = _SmithyMessageDecoderStream;
+    var _SmithyMessageEncoderStream = class _SmithyMessageEncoderStream {
       constructor(options) {
         this.options = options;
-      }
-      static {
-        __name(this, "SmithyMessageEncoderStream");
       }
       [Symbol.asyncIterator]() {
         return this.asyncIterator();
@@ -45444,6 +45307,8 @@ var require_dist_cjs64 = __commonJS({
         }
       }
     };
+    __name(_SmithyMessageEncoderStream, "SmithyMessageEncoderStream");
+    var SmithyMessageEncoderStream = _SmithyMessageEncoderStream;
   }
 });
 
@@ -45589,10 +45454,7 @@ var require_dist_cjs65 = __commonJS({
       };
     }
     __name(getMessageUnmarshaller, "getMessageUnmarshaller");
-    var EventStreamMarshaller = class {
-      static {
-        __name(this, "EventStreamMarshaller");
-      }
+    var _EventStreamMarshaller = class _EventStreamMarshaller {
       constructor({ utf8Encoder, utf8Decoder }) {
         this.eventStreamCodec = new import_eventstream_codec.EventStreamCodec(utf8Encoder, utf8Decoder);
         this.utfEncoder = utf8Encoder;
@@ -45613,6 +45475,8 @@ var require_dist_cjs65 = __commonJS({
         });
       }
     };
+    __name(_EventStreamMarshaller, "EventStreamMarshaller");
+    var EventStreamMarshaller = _EventStreamMarshaller;
     var eventStreamSerdeProvider = /* @__PURE__ */ __name((options) => new EventStreamMarshaller(options), "eventStreamSerdeProvider");
   }
 });
@@ -45673,10 +45537,7 @@ var require_dist_cjs66 = __commonJS({
       }
     }
     __name(readabletoIterable, "readabletoIterable");
-    var EventStreamMarshaller = class {
-      static {
-        __name(this, "EventStreamMarshaller");
-      }
+    var _EventStreamMarshaller = class _EventStreamMarshaller {
       constructor({ utf8Encoder, utf8Decoder }) {
         this.universalMarshaller = new import_eventstream_serde_universal.EventStreamMarshaller({
           utf8Decoder,
@@ -45691,6 +45552,8 @@ var require_dist_cjs66 = __commonJS({
         return import_stream.Readable.from(this.universalMarshaller.serialize(input, serializer));
       }
     };
+    __name(_EventStreamMarshaller, "EventStreamMarshaller");
+    var EventStreamMarshaller = _EventStreamMarshaller;
     var eventStreamSerdeProvider = /* @__PURE__ */ __name((options) => new EventStreamMarshaller(options), "eventStreamSerdeProvider");
   }
 });
@@ -45725,13 +45588,10 @@ var require_dist_cjs67 = __commonJS({
     var import_fs = require("fs");
     var import_util_utf8 = require_dist_cjs8();
     var import_stream = require("stream");
-    var HashCalculator = class extends import_stream.Writable {
+    var _HashCalculator = class _HashCalculator extends import_stream.Writable {
       constructor(hash, options) {
         super(options);
         this.hash = hash;
-      }
-      static {
-        __name(this, "HashCalculator");
       }
       _write(chunk, encoding, callback) {
         try {
@@ -45742,6 +45602,8 @@ var require_dist_cjs67 = __commonJS({
         callback();
       }
     };
+    __name(_HashCalculator, "HashCalculator");
+    var HashCalculator = _HashCalculator;
     var fileStreamHasher = /* @__PURE__ */ __name((hashCtor, fileStream) => new Promise((resolve, reject) => {
       if (!isReadStream(fileStream)) {
         reject(new Error("Unable to calculate hash for non-file streams."));
@@ -45870,7 +45732,6 @@ var require_runtimeConfig4 = __commonJS({
       const defaultConfigProvider = () => defaultsMode().then(smithy_client_1.loadConfigsForDefaultMode);
       const clientSharedValues = (0, runtimeConfig_shared_1.getRuntimeConfig)(config);
       (0, core_1.emitWarningIfUnsupportedVersion)(process.version);
-      const profileConfig = { profile: config?.profile };
       return {
         ...clientSharedValues,
         ...config,
@@ -45879,27 +45740,27 @@ var require_runtimeConfig4 = __commonJS({
         bodyLengthChecker: config?.bodyLengthChecker ?? util_body_length_node_1.calculateBodyLength,
         credentialDefaultProvider: config?.credentialDefaultProvider ?? credential_provider_node_1.defaultProvider,
         defaultUserAgentProvider: config?.defaultUserAgentProvider ?? (0, util_user_agent_node_1.createDefaultUserAgentProvider)({ serviceId: clientSharedValues.serviceId, clientVersion: package_json_1.default.version }),
-        disableS3ExpressSessionAuth: config?.disableS3ExpressSessionAuth ?? (0, node_config_provider_1.loadConfig)(middleware_sdk_s3_1.NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS, profileConfig),
+        disableS3ExpressSessionAuth: config?.disableS3ExpressSessionAuth ?? (0, node_config_provider_1.loadConfig)(middleware_sdk_s3_1.NODE_DISABLE_S3_EXPRESS_SESSION_AUTH_OPTIONS),
         eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventstream_serde_node_1.eventStreamSerdeProvider,
-        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
+        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
         md5: config?.md5 ?? hash_node_1.Hash.bind(null, "md5"),
-        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, { ...config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS, ...profileConfig }),
-        requestChecksumCalculation: config?.requestChecksumCalculation ?? (0, node_config_provider_1.loadConfig)(middleware_flexible_checksums_1.NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS, profileConfig),
+        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS),
+        requestChecksumCalculation: config?.requestChecksumCalculation ?? (0, node_config_provider_1.loadConfig)(middleware_flexible_checksums_1.NODE_REQUEST_CHECKSUM_CALCULATION_CONFIG_OPTIONS),
         requestHandler: node_http_handler_1.NodeHttpHandler.create(config?.requestHandler ?? defaultConfigProvider),
-        responseChecksumValidation: config?.responseChecksumValidation ?? (0, node_config_provider_1.loadConfig)(middleware_flexible_checksums_1.NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS, profileConfig),
+        responseChecksumValidation: config?.responseChecksumValidation ?? (0, node_config_provider_1.loadConfig)(middleware_flexible_checksums_1.NODE_RESPONSE_CHECKSUM_VALIDATION_CONFIG_OPTIONS),
         retryMode: config?.retryMode ?? (0, node_config_provider_1.loadConfig)({
           ...middleware_retry_1.NODE_RETRY_MODE_CONFIG_OPTIONS,
           default: async () => (await defaultConfigProvider()).retryMode || util_retry_1.DEFAULT_RETRY_MODE
-        }, config),
+        }),
         sha1: config?.sha1 ?? hash_node_1.Hash.bind(null, "sha1"),
         sha256: config?.sha256 ?? hash_node_1.Hash.bind(null, "sha256"),
-        sigv4aSigningRegionSet: config?.sigv4aSigningRegionSet ?? (0, node_config_provider_1.loadConfig)(core_1.NODE_SIGV4A_CONFIG_OPTIONS, profileConfig),
+        sigv4aSigningRegionSet: config?.sigv4aSigningRegionSet ?? (0, node_config_provider_1.loadConfig)(core_1.NODE_SIGV4A_CONFIG_OPTIONS),
         streamCollector: config?.streamCollector ?? node_http_handler_1.streamCollector,
         streamHasher: config?.streamHasher ?? hash_stream_node_1.readableStreamHasher,
-        useArnRegion: config?.useArnRegion ?? (0, node_config_provider_1.loadConfig)(middleware_bucket_endpoint_1.NODE_USE_ARN_REGION_CONFIG_OPTIONS, profileConfig),
-        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS, profileConfig)
+        useArnRegion: config?.useArnRegion ?? (0, node_config_provider_1.loadConfig)(middleware_bucket_endpoint_1.NODE_USE_ARN_REGION_CONFIG_OPTIONS),
+        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),
+        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS),
+        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS)
       };
     };
     exports2.getRuntimeConfig = getRuntimeConfig;
@@ -46035,7 +45896,7 @@ var require_dist_cjs69 = __commonJS({
       return (next) => async (args) => {
         const { CreateBucketConfiguration } = args.input;
         const region = await options.region();
-        if (!CreateBucketConfiguration?.LocationConstraint && !CreateBucketConfiguration?.Location) {
+        if (!(CreateBucketConfiguration == null ? void 0 : CreateBucketConfiguration.LocationConstraint) && !(CreateBucketConfiguration == null ? void 0 : CreateBucketConfiguration.Location)) {
           args = {
             ...args,
             input: {
@@ -46138,6 +45999,7 @@ var require_dist_cjs70 = __commonJS({
     }, "exponentialBackoffWithJitter");
     var randomInRange = /* @__PURE__ */ __name((min, max) => min + Math.random() * (max - min), "randomInRange");
     var runPolling = /* @__PURE__ */ __name(async ({ minDelay, maxDelay, maxWaitTime, abortController, client, abortSignal }, input, acceptorChecks) => {
+      var _a;
       const observedResponses = {};
       const { state: state2, reason } = await acceptorChecks(client, input);
       if (reason) {
@@ -46152,7 +46014,7 @@ var require_dist_cjs70 = __commonJS({
       const waitUntil = Date.now() + maxWaitTime * 1e3;
       const attemptCeiling = Math.log(maxDelay / minDelay) / Math.log(2) + 1;
       while (true) {
-        if (abortController?.signal?.aborted || abortSignal?.aborted) {
+        if (((_a = abortController == null ? void 0 : abortController.signal) == null ? void 0 : _a.aborted) || (abortSignal == null ? void 0 : abortSignal.aborted)) {
           const message = "AbortController signal aborted.";
           observedResponses[message] |= 0;
           observedResponses[message] += 1;
@@ -46176,16 +46038,17 @@ var require_dist_cjs70 = __commonJS({
       }
     }, "runPolling");
     var createMessageFromResponse = /* @__PURE__ */ __name((reason) => {
-      if (reason?.$responseBodyText) {
+      var _a;
+      if (reason == null ? void 0 : reason.$responseBodyText) {
         return `Deserialization error for body: ${reason.$responseBodyText}`;
       }
-      if (reason?.$metadata?.httpStatusCode) {
+      if ((_a = reason == null ? void 0 : reason.$metadata) == null ? void 0 : _a.httpStatusCode) {
         if (reason.$response || reason.message) {
           return `${reason.$response.statusCode ?? reason.$metadata.httpStatusCode ?? "Unknown"}: ${reason.message}`;
         }
         return `${reason.$metadata.httpStatusCode}: OK`;
       }
-      return String(reason?.message ?? JSON.stringify(reason) ?? "Unknown");
+      return String((reason == null ? void 0 : reason.message) ?? JSON.stringify(reason) ?? "Unknown");
     }, "createMessageFromResponse");
     var validateWaiterOptions = /* @__PURE__ */ __name((options) => {
       if (options.maxWaitTime < 1) {
@@ -46281,7 +46144,6 @@ var require_dist_cjs71 = __commonJS({
       CopyObjectOutputFilterSensitiveLog: () => CopyObjectOutputFilterSensitiveLog,
       CopyObjectRequestFilterSensitiveLog: () => CopyObjectRequestFilterSensitiveLog,
       CreateBucketCommand: () => CreateBucketCommand,
-      CreateBucketMetadataTableConfigurationCommand: () => CreateBucketMetadataTableConfigurationCommand,
       CreateMultipartUploadCommand: () => CreateMultipartUploadCommand,
       CreateMultipartUploadOutputFilterSensitiveLog: () => CreateMultipartUploadOutputFilterSensitiveLog,
       CreateMultipartUploadRequestFilterSensitiveLog: () => CreateMultipartUploadRequestFilterSensitiveLog,
@@ -46296,7 +46158,6 @@ var require_dist_cjs71 = __commonJS({
       DeleteBucketIntelligentTieringConfigurationCommand: () => DeleteBucketIntelligentTieringConfigurationCommand,
       DeleteBucketInventoryConfigurationCommand: () => DeleteBucketInventoryConfigurationCommand,
       DeleteBucketLifecycleCommand: () => DeleteBucketLifecycleCommand,
-      DeleteBucketMetadataTableConfigurationCommand: () => DeleteBucketMetadataTableConfigurationCommand,
       DeleteBucketMetricsConfigurationCommand: () => DeleteBucketMetricsConfigurationCommand,
       DeleteBucketOwnershipControlsCommand: () => DeleteBucketOwnershipControlsCommand,
       DeleteBucketPolicyCommand: () => DeleteBucketPolicyCommand,
@@ -46329,7 +46190,6 @@ var require_dist_cjs71 = __commonJS({
       GetBucketLifecycleConfigurationCommand: () => GetBucketLifecycleConfigurationCommand,
       GetBucketLocationCommand: () => GetBucketLocationCommand,
       GetBucketLoggingCommand: () => GetBucketLoggingCommand,
-      GetBucketMetadataTableConfigurationCommand: () => GetBucketMetadataTableConfigurationCommand,
       GetBucketMetricsConfigurationCommand: () => GetBucketMetricsConfigurationCommand,
       GetBucketNotificationConfigurationCommand: () => GetBucketNotificationConfigurationCommand,
       GetBucketOwnershipControlsCommand: () => GetBucketOwnershipControlsCommand,
@@ -46541,30 +46401,24 @@ var require_dist_cjs71 = __commonJS({
       UseDualStack: { type: "builtInParams", name: "useDualstackEndpoint" }
     };
     var import_smithy_client4 = require_dist_cjs19();
-    var S3ServiceException = class _S3ServiceException extends import_smithy_client4.ServiceException {
-      static {
-        __name(this, "S3ServiceException");
-      }
+    var _S3ServiceException = class _S3ServiceException2 extends import_smithy_client4.ServiceException {
       /**
        * @internal
        */
       constructor(options) {
         super(options);
-        Object.setPrototypeOf(this, _S3ServiceException.prototype);
+        Object.setPrototypeOf(this, _S3ServiceException2.prototype);
       }
     };
+    __name(_S3ServiceException, "S3ServiceException");
+    var S3ServiceException = _S3ServiceException;
     var RequestCharged = {
       requester: "requester"
     };
     var RequestPayer = {
       requester: "requester"
     };
-    var NoSuchUpload = class _NoSuchUpload extends S3ServiceException {
-      static {
-        __name(this, "NoSuchUpload");
-      }
-      name = "NoSuchUpload";
-      $fault = "client";
+    var _NoSuchUpload = class _NoSuchUpload2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -46574,9 +46428,13 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _NoSuchUpload.prototype);
+        this.name = "NoSuchUpload";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _NoSuchUpload2.prototype);
       }
     };
+    __name(_NoSuchUpload, "NoSuchUpload");
+    var NoSuchUpload = _NoSuchUpload;
     var BucketAccelerateStatus = {
       Enabled: "Enabled",
       Suspended: "Suspended"
@@ -46645,12 +46503,7 @@ var require_dist_cjs71 = __commonJS({
       COPY: "COPY",
       REPLACE: "REPLACE"
     };
-    var ObjectNotInActiveTierError = class _ObjectNotInActiveTierError extends S3ServiceException {
-      static {
-        __name(this, "ObjectNotInActiveTierError");
-      }
-      name = "ObjectNotInActiveTierError";
-      $fault = "client";
+    var _ObjectNotInActiveTierError = class _ObjectNotInActiveTierError2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -46660,15 +46513,14 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ObjectNotInActiveTierError.prototype);
+        this.name = "ObjectNotInActiveTierError";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ObjectNotInActiveTierError2.prototype);
       }
     };
-    var BucketAlreadyExists = class _BucketAlreadyExists extends S3ServiceException {
-      static {
-        __name(this, "BucketAlreadyExists");
-      }
-      name = "BucketAlreadyExists";
-      $fault = "client";
+    __name(_ObjectNotInActiveTierError, "ObjectNotInActiveTierError");
+    var ObjectNotInActiveTierError = _ObjectNotInActiveTierError;
+    var _BucketAlreadyExists = class _BucketAlreadyExists2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -46678,15 +46530,14 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _BucketAlreadyExists.prototype);
+        this.name = "BucketAlreadyExists";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _BucketAlreadyExists2.prototype);
       }
     };
-    var BucketAlreadyOwnedByYou = class _BucketAlreadyOwnedByYou extends S3ServiceException {
-      static {
-        __name(this, "BucketAlreadyOwnedByYou");
-      }
-      name = "BucketAlreadyOwnedByYou";
-      $fault = "client";
+    __name(_BucketAlreadyExists, "BucketAlreadyExists");
+    var BucketAlreadyExists = _BucketAlreadyExists;
+    var _BucketAlreadyOwnedByYou = class _BucketAlreadyOwnedByYou2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -46696,9 +46547,13 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _BucketAlreadyOwnedByYou.prototype);
+        this.name = "BucketAlreadyOwnedByYou";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _BucketAlreadyOwnedByYou2.prototype);
       }
     };
+    __name(_BucketAlreadyOwnedByYou, "BucketAlreadyOwnedByYou");
+    var BucketAlreadyOwnedByYou = _BucketAlreadyOwnedByYou;
     var BucketCannedACL = {
       authenticated_read: "authenticated-read",
       private: "private",
@@ -46755,12 +46610,7 @@ var require_dist_cjs71 = __commonJS({
       ReadOnly: "ReadOnly",
       ReadWrite: "ReadWrite"
     };
-    var NoSuchBucket = class _NoSuchBucket extends S3ServiceException {
-      static {
-        __name(this, "NoSuchBucket");
-      }
-      name = "NoSuchBucket";
-      $fault = "client";
+    var _NoSuchBucket = class _NoSuchBucket2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -46770,9 +46620,13 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _NoSuchBucket.prototype);
+        this.name = "NoSuchBucket";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _NoSuchBucket2.prototype);
       }
     };
+    __name(_NoSuchBucket, "NoSuchBucket");
+    var NoSuchBucket = _NoSuchBucket;
     var AnalyticsFilter;
     ((AnalyticsFilter2) => {
       AnalyticsFilter2.visit = /* @__PURE__ */ __name((value, visitor) => {
@@ -46955,14 +46809,7 @@ var require_dist_cjs71 = __commonJS({
     var ChecksumMode = {
       ENABLED: "ENABLED"
     };
-    var InvalidObjectState = class _InvalidObjectState extends S3ServiceException {
-      static {
-        __name(this, "InvalidObjectState");
-      }
-      name = "InvalidObjectState";
-      $fault = "client";
-      StorageClass;
-      AccessTier;
+    var _InvalidObjectState = class _InvalidObjectState2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -46972,17 +46819,16 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidObjectState.prototype);
+        this.name = "InvalidObjectState";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidObjectState2.prototype);
         this.StorageClass = opts.StorageClass;
         this.AccessTier = opts.AccessTier;
       }
     };
-    var NoSuchKey = class _NoSuchKey extends S3ServiceException {
-      static {
-        __name(this, "NoSuchKey");
-      }
-      name = "NoSuchKey";
-      $fault = "client";
+    __name(_InvalidObjectState, "InvalidObjectState");
+    var InvalidObjectState = _InvalidObjectState;
+    var _NoSuchKey = class _NoSuchKey2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -46992,9 +46838,13 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _NoSuchKey.prototype);
+        this.name = "NoSuchKey";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _NoSuchKey2.prototype);
       }
     };
+    __name(_NoSuchKey, "NoSuchKey");
+    var NoSuchKey = _NoSuchKey;
     var ObjectAttributes = {
       CHECKSUM: "Checksum",
       ETAG: "ETag",
@@ -47009,12 +46859,7 @@ var require_dist_cjs71 = __commonJS({
       COMPLIANCE: "COMPLIANCE",
       GOVERNANCE: "GOVERNANCE"
     };
-    var NotFound = class _NotFound extends S3ServiceException {
-      static {
-        __name(this, "NotFound");
-      }
-      name = "NotFound";
-      $fault = "client";
+    var _NotFound = class _NotFound2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -47024,9 +46869,13 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _NotFound.prototype);
+        this.name = "NotFound";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _NotFound2.prototype);
       }
     };
+    __name(_NotFound, "NotFound");
+    var NotFound = _NotFound;
     var ArchiveStatus = {
       ARCHIVE_ACCESS: "ARCHIVE_ACCESS",
       DEEP_ARCHIVE_ACCESS: "DEEP_ARCHIVE_ACCESS"
@@ -47187,6 +47036,20 @@ var require_dist_cjs71 = __commonJS({
       ...obj,
       ...obj.SSECustomerKey && { SSECustomerKey: import_smithy_client4.SENSITIVE_STRING }
     }), "ListPartsRequestFilterSensitiveLog");
+    var PutBucketEncryptionRequestFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
+      ...obj,
+      ...obj.ServerSideEncryptionConfiguration && {
+        ServerSideEncryptionConfiguration: ServerSideEncryptionConfigurationFilterSensitiveLog(
+          obj.ServerSideEncryptionConfiguration
+        )
+      }
+    }), "PutBucketEncryptionRequestFilterSensitiveLog");
+    var PutBucketInventoryConfigurationRequestFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
+      ...obj,
+      ...obj.InventoryConfiguration && {
+        InventoryConfiguration: InventoryConfigurationFilterSensitiveLog(obj.InventoryConfiguration)
+      }
+    }), "PutBucketInventoryConfigurationRequestFilterSensitiveLog");
     var import_core4 = (init_dist_es2(), __toCommonJS(dist_es_exports2));
     var import_xml_builder = require_dist_cjs45();
     var import_core22 = (init_dist_es(), __toCommonJS(dist_es_exports));
@@ -47195,12 +47058,7 @@ var require_dist_cjs71 = __commonJS({
       Disabled: "Disabled",
       Enabled: "Enabled"
     };
-    var EncryptionTypeMismatch = class _EncryptionTypeMismatch extends S3ServiceException {
-      static {
-        __name(this, "EncryptionTypeMismatch");
-      }
-      name = "EncryptionTypeMismatch";
-      $fault = "client";
+    var _EncryptionTypeMismatch = class _EncryptionTypeMismatch2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -47210,15 +47068,14 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _EncryptionTypeMismatch.prototype);
+        this.name = "EncryptionTypeMismatch";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _EncryptionTypeMismatch2.prototype);
       }
     };
-    var InvalidRequest = class _InvalidRequest extends S3ServiceException {
-      static {
-        __name(this, "InvalidRequest");
-      }
-      name = "InvalidRequest";
-      $fault = "client";
+    __name(_EncryptionTypeMismatch, "EncryptionTypeMismatch");
+    var EncryptionTypeMismatch = _EncryptionTypeMismatch;
+    var _InvalidRequest = class _InvalidRequest2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -47228,15 +47085,14 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidRequest.prototype);
+        this.name = "InvalidRequest";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidRequest2.prototype);
       }
     };
-    var InvalidWriteOffset = class _InvalidWriteOffset extends S3ServiceException {
-      static {
-        __name(this, "InvalidWriteOffset");
-      }
-      name = "InvalidWriteOffset";
-      $fault = "client";
+    __name(_InvalidRequest, "InvalidRequest");
+    var InvalidRequest = _InvalidRequest;
+    var _InvalidWriteOffset = class _InvalidWriteOffset2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -47246,15 +47102,14 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidWriteOffset.prototype);
+        this.name = "InvalidWriteOffset";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidWriteOffset2.prototype);
       }
     };
-    var TooManyParts = class _TooManyParts extends S3ServiceException {
-      static {
-        __name(this, "TooManyParts");
-      }
-      name = "TooManyParts";
-      $fault = "client";
+    __name(_InvalidWriteOffset, "InvalidWriteOffset");
+    var InvalidWriteOffset = _InvalidWriteOffset;
+    var _TooManyParts = class _TooManyParts2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -47264,15 +47119,14 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _TooManyParts.prototype);
+        this.name = "TooManyParts";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _TooManyParts2.prototype);
       }
     };
-    var ObjectAlreadyInActiveTierError = class _ObjectAlreadyInActiveTierError extends S3ServiceException {
-      static {
-        __name(this, "ObjectAlreadyInActiveTierError");
-      }
-      name = "ObjectAlreadyInActiveTierError";
-      $fault = "client";
+    __name(_TooManyParts, "TooManyParts");
+    var TooManyParts = _TooManyParts;
+    var _ObjectAlreadyInActiveTierError = class _ObjectAlreadyInActiveTierError2 extends S3ServiceException {
       /**
        * @internal
        */
@@ -47282,9 +47136,13 @@ var require_dist_cjs71 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ObjectAlreadyInActiveTierError.prototype);
+        this.name = "ObjectAlreadyInActiveTierError";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ObjectAlreadyInActiveTierError2.prototype);
       }
     };
+    __name(_ObjectAlreadyInActiveTierError, "ObjectAlreadyInActiveTierError");
+    var ObjectAlreadyInActiveTierError = _ObjectAlreadyInActiveTierError;
     var Tier = {
       Bulk: "Bulk",
       Expedited: "Expedited",
@@ -47330,20 +47188,6 @@ var require_dist_cjs71 = __commonJS({
         return visitor._(value.$unknown[0], value.$unknown[1]);
       }, "visit");
     })(SelectObjectContentEventStream || (SelectObjectContentEventStream = {}));
-    var PutBucketEncryptionRequestFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
-      ...obj,
-      ...obj.ServerSideEncryptionConfiguration && {
-        ServerSideEncryptionConfiguration: ServerSideEncryptionConfigurationFilterSensitiveLog(
-          obj.ServerSideEncryptionConfiguration
-        )
-      }
-    }), "PutBucketEncryptionRequestFilterSensitiveLog");
-    var PutBucketInventoryConfigurationRequestFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
-      ...obj,
-      ...obj.InventoryConfiguration && {
-        InventoryConfiguration: InventoryConfigurationFilterSensitiveLog(obj.InventoryConfiguration)
-      }
-    }), "PutBucketInventoryConfigurationRequestFilterSensitiveLog");
     var PutObjectOutputFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
       ...obj,
       ...obj.SSEKMSKeyId && { SSEKMSKeyId: import_smithy_client4.SENSITIVE_STRING },
@@ -47552,30 +47396,6 @@ var require_dist_cjs71 = __commonJS({
       b.m("PUT").h(headers).b(body);
       return b.build();
     }, "se_CreateBucketCommand");
-    var se_CreateBucketMetadataTableConfigurationCommand = /* @__PURE__ */ __name(async (input, context3) => {
-      const b = (0, import_core22.requestBuilder)(input, context3);
-      const headers = (0, import_smithy_client4.map)({}, import_smithy_client4.isSerializableHeaderValue, {
-        "content-type": "application/xml",
-        [_cm]: input[_CMD],
-        [_xasca]: input[_CA],
-        [_xaebo]: input[_EBO]
-      });
-      b.bp("/");
-      b.p("Bucket", () => input.Bucket, "{Bucket}", false);
-      const query = (0, import_smithy_client4.map)({
-        [_mT]: [, ""]
-      });
-      let body;
-      let contents;
-      if (input.MetadataTableConfiguration !== void 0) {
-        contents = se_MetadataTableConfiguration(input.MetadataTableConfiguration, context3);
-        body = _ve;
-        contents.a("xmlns", "http://s3.amazonaws.com/doc/2006-03-01/");
-        body += contents.toString();
-      }
-      b.m("POST").h(headers).q(query).b(body);
-      return b.build();
-    }, "se_CreateBucketMetadataTableConfigurationCommand");
     var se_CreateMultipartUploadCommand = /* @__PURE__ */ __name(async (input, context3) => {
       const b = (0, import_core22.requestBuilder)(input, context3);
       const headers = (0, import_smithy_client4.map)({}, import_smithy_client4.isSerializableHeaderValue, {
@@ -47735,20 +47555,6 @@ var require_dist_cjs71 = __commonJS({
       b.m("DELETE").h(headers).q(query).b(body);
       return b.build();
     }, "se_DeleteBucketLifecycleCommand");
-    var se_DeleteBucketMetadataTableConfigurationCommand = /* @__PURE__ */ __name(async (input, context3) => {
-      const b = (0, import_core22.requestBuilder)(input, context3);
-      const headers = (0, import_smithy_client4.map)({}, import_smithy_client4.isSerializableHeaderValue, {
-        [_xaebo]: input[_EBO]
-      });
-      b.bp("/");
-      b.p("Bucket", () => input.Bucket, "{Bucket}", false);
-      const query = (0, import_smithy_client4.map)({
-        [_mT]: [, ""]
-      });
-      let body;
-      b.m("DELETE").h(headers).q(query).b(body);
-      return b.build();
-    }, "se_DeleteBucketMetadataTableConfigurationCommand");
     var se_DeleteBucketMetricsConfigurationCommand = /* @__PURE__ */ __name(async (input, context3) => {
       const b = (0, import_core22.requestBuilder)(input, context3);
       const headers = (0, import_smithy_client4.map)({}, import_smithy_client4.isSerializableHeaderValue, {
@@ -48057,20 +47863,6 @@ var require_dist_cjs71 = __commonJS({
       b.m("GET").h(headers).q(query).b(body);
       return b.build();
     }, "se_GetBucketLoggingCommand");
-    var se_GetBucketMetadataTableConfigurationCommand = /* @__PURE__ */ __name(async (input, context3) => {
-      const b = (0, import_core22.requestBuilder)(input, context3);
-      const headers = (0, import_smithy_client4.map)({}, import_smithy_client4.isSerializableHeaderValue, {
-        [_xaebo]: input[_EBO]
-      });
-      b.bp("/");
-      b.p("Bucket", () => input.Bucket, "{Bucket}", false);
-      const query = (0, import_smithy_client4.map)({
-        [_mT]: [, ""]
-      });
-      let body;
-      b.m("GET").h(headers).q(query).b(body);
-      return b.build();
-    }, "se_GetBucketMetadataTableConfigurationCommand");
     var se_GetBucketMetricsConfigurationCommand = /* @__PURE__ */ __name(async (input, context3) => {
       const b = (0, import_core22.requestBuilder)(input, context3);
       const headers = (0, import_smithy_client4.map)({}, import_smithy_client4.isSerializableHeaderValue, {
@@ -49565,16 +49357,6 @@ var require_dist_cjs71 = __commonJS({
       await (0, import_smithy_client4.collectBody)(output.body, context3);
       return contents;
     }, "de_CreateBucketCommand");
-    var de_CreateBucketMetadataTableConfigurationCommand = /* @__PURE__ */ __name(async (output, context3) => {
-      if (output.statusCode !== 200 && output.statusCode >= 300) {
-        return de_CommandError(output, context3);
-      }
-      const contents = (0, import_smithy_client4.map)({
-        $metadata: deserializeMetadata(output)
-      });
-      await (0, import_smithy_client4.collectBody)(output.body, context3);
-      return contents;
-    }, "de_CreateBucketMetadataTableConfigurationCommand");
     var de_CreateMultipartUploadCommand = /* @__PURE__ */ __name(async (output, context3) => {
       if (output.statusCode !== 200 && output.statusCode >= 300) {
         return de_CommandError(output, context3);
@@ -49694,16 +49476,6 @@ var require_dist_cjs71 = __commonJS({
       await (0, import_smithy_client4.collectBody)(output.body, context3);
       return contents;
     }, "de_DeleteBucketLifecycleCommand");
-    var de_DeleteBucketMetadataTableConfigurationCommand = /* @__PURE__ */ __name(async (output, context3) => {
-      if (output.statusCode !== 204 && output.statusCode >= 300) {
-        return de_CommandError(output, context3);
-      }
-      const contents = (0, import_smithy_client4.map)({
-        $metadata: deserializeMetadata(output)
-      });
-      await (0, import_smithy_client4.collectBody)(output.body, context3);
-      return contents;
-    }, "de_DeleteBucketMetadataTableConfigurationCommand");
     var de_DeleteBucketMetricsConfigurationCommand = /* @__PURE__ */ __name(async (output, context3) => {
       if (output.statusCode !== 204 && output.statusCode >= 300) {
         return de_CommandError(output, context3);
@@ -49952,17 +49724,6 @@ var require_dist_cjs71 = __commonJS({
       }
       return contents;
     }, "de_GetBucketLoggingCommand");
-    var de_GetBucketMetadataTableConfigurationCommand = /* @__PURE__ */ __name(async (output, context3) => {
-      if (output.statusCode !== 200 && output.statusCode >= 300) {
-        return de_CommandError(output, context3);
-      }
-      const contents = (0, import_smithy_client4.map)({
-        $metadata: deserializeMetadata(output)
-      });
-      const data = (0, import_smithy_client4.expectObject)(await (0, import_core4.parseXmlBody)(output.body, context3));
-      contents.GetBucketMetadataTableConfigurationResult = de_GetBucketMetadataTableConfigurationResult(data, context3);
-      return contents;
-    }, "de_GetBucketMetadataTableConfigurationCommand");
     var de_GetBucketMetricsConfigurationCommand = /* @__PURE__ */ __name(async (output, context3) => {
       if (output.statusCode !== 200 && output.statusCode >= 300) {
         return de_CommandError(output, context3);
@@ -51961,13 +51722,6 @@ var require_dist_cjs71 = __commonJS({
       }
       return bn;
     }, "se_MetadataEntry");
-    var se_MetadataTableConfiguration = /* @__PURE__ */ __name((input, context3) => {
-      const bn = new import_xml_builder.XmlNode(_MTC);
-      if (input[_STD] != null) {
-        bn.c(se_S3TablesDestination(input[_STD], context3).n(_STD));
-      }
-      return bn;
-    }, "se_MetadataTableConfiguration");
     var se_Metrics = /* @__PURE__ */ __name((input, context3) => {
       const bn = new import_xml_builder.XmlNode(_Me);
       if (input[_S] != null) {
@@ -52386,16 +52140,6 @@ var require_dist_cjs71 = __commonJS({
       bn.cc(input, _SC);
       return bn;
     }, "se_S3Location");
-    var se_S3TablesDestination = /* @__PURE__ */ __name((input, context3) => {
-      const bn = new import_xml_builder.XmlNode(_STD);
-      if (input[_TBA] != null) {
-        bn.c(import_xml_builder.XmlNode.of(_STBA, input[_TBA]).n(_TBA));
-      }
-      if (input[_TN] != null) {
-        bn.c(import_xml_builder.XmlNode.of(_STN, input[_TN]).n(_TN));
-      }
-      return bn;
-    }, "se_S3TablesDestination");
     var se_ScanRange = /* @__PURE__ */ __name((input, context3) => {
       const bn = new import_xml_builder.XmlNode(_SR);
       if (input[_St] != null) {
@@ -52992,16 +52736,6 @@ var require_dist_cjs71 = __commonJS({
       }
       return contents;
     }, "de__Error");
-    var de_ErrorDetails = /* @__PURE__ */ __name((output, context3) => {
-      const contents = {};
-      if (output[_EC] != null) {
-        contents[_EC] = (0, import_smithy_client4.expectString)(output[_EC]);
-      }
-      if (output[_EM] != null) {
-        contents[_EM] = (0, import_smithy_client4.expectString)(output[_EM]);
-      }
-      return contents;
-    }, "de_ErrorDetails");
     var de_ErrorDocument = /* @__PURE__ */ __name((output, context3) => {
       const contents = {};
       if (output[_K] != null) {
@@ -53050,19 +52784,6 @@ var require_dist_cjs71 = __commonJS({
         return de_FilterRule(entry, context3);
       });
     }, "de_FilterRuleList");
-    var de_GetBucketMetadataTableConfigurationResult = /* @__PURE__ */ __name((output, context3) => {
-      const contents = {};
-      if (output[_MTCR] != null) {
-        contents[_MTCR] = de_MetadataTableConfigurationResult(output[_MTCR], context3);
-      }
-      if (output[_S] != null) {
-        contents[_S] = (0, import_smithy_client4.expectString)(output[_S]);
-      }
-      if (output[_Er] != null) {
-        contents[_Er] = de_ErrorDetails(output[_Er], context3);
-      }
-      return contents;
-    }, "de_GetBucketMetadataTableConfigurationResult");
     var de_GetObjectAttributesParts = /* @__PURE__ */ __name((output, context3) => {
       const contents = {};
       if (output[_PC] != null) {
@@ -53404,13 +53125,6 @@ var require_dist_cjs71 = __commonJS({
       }
       return contents;
     }, "de_LoggingEnabled");
-    var de_MetadataTableConfigurationResult = /* @__PURE__ */ __name((output, context3) => {
-      const contents = {};
-      if (output[_STDR] != null) {
-        contents[_STDR] = de_S3TablesDestinationResult(output[_STDR], context3);
-      }
-      return contents;
-    }, "de_MetadataTableConfigurationResult");
     var de_Metrics = /* @__PURE__ */ __name((output, context3) => {
       const contents = {};
       if (output[_S] != null) {
@@ -53967,22 +53681,6 @@ var require_dist_cjs71 = __commonJS({
       }
       return contents;
     }, "de_S3KeyFilter");
-    var de_S3TablesDestinationResult = /* @__PURE__ */ __name((output, context3) => {
-      const contents = {};
-      if (output[_TBA] != null) {
-        contents[_TBA] = (0, import_smithy_client4.expectString)(output[_TBA]);
-      }
-      if (output[_TN] != null) {
-        contents[_TN] = (0, import_smithy_client4.expectString)(output[_TN]);
-      }
-      if (output[_TAa] != null) {
-        contents[_TAa] = (0, import_smithy_client4.expectString)(output[_TAa]);
-      }
-      if (output[_TNa] != null) {
-        contents[_TNa] = (0, import_smithy_client4.expectString)(output[_TNa]);
-      }
-      return contents;
-    }, "de_S3TablesDestinationResult");
     var de_ServerSideEncryptionByDefault = /* @__PURE__ */ __name((output, context3) => {
       const contents = {};
       if (output[_SSEA] != null) {
@@ -54458,8 +54156,6 @@ var require_dist_cjs71 = __commonJS({
     var _MM = "MissingMeta";
     var _MP = "MaxParts";
     var _MS = "MetricsStatus";
-    var _MTC = "MetadataTableConfiguration";
-    var _MTCR = "MetadataTableConfigurationResult";
     var _MU = "MaxUploads";
     var _MV = "MetadataValue";
     var _Me = "Metrics";
@@ -54615,10 +54311,6 @@ var require_dist_cjs71 = __commonJS({
     var _SSER = "ServerSideEncryptionRule";
     var _SSES = "SSES3";
     var _ST = "SessionToken";
-    var _STBA = "S3TablesBucketArn";
-    var _STD = "S3TablesDestination";
-    var _STDR = "S3TablesDestinationResult";
-    var _STN = "S3TablesName";
     var _S_ = "S3";
     var _Sc = "Schedule";
     var _Se = "Setting";
@@ -54627,9 +54319,7 @@ var require_dist_cjs71 = __commonJS({
     var _Su = "Suffix";
     var _T = "Tagging";
     var _TA = "TopicArn";
-    var _TAa = "TableArn";
     var _TB = "TargetBucket";
-    var _TBA = "TableBucketArn";
     var _TC = "TagCount";
     var _TCo = "TopicConfiguration";
     var _TCop = "TopicConfigurations";
@@ -54637,8 +54327,6 @@ var require_dist_cjs71 = __commonJS({
     var _TDMOS = "TransitionDefaultMinimumObjectSize";
     var _TG = "TargetGrants";
     var _TGa = "TargetGrant";
-    var _TN = "TableName";
-    var _TNa = "TableNamespace";
     var _TOKF = "TargetObjectKeyFormat";
     var _TP = "TargetPrefix";
     var _TPC = "TotalPartsCount";
@@ -54711,7 +54399,6 @@ var require_dist_cjs71 = __commonJS({
     var _log = "logging";
     var _lt = "list-type";
     var _m = "metrics";
-    var _mT = "metadataTable";
     var _ma = "marker";
     var _mb = "max-buckets";
     var _mdb = "max-directory-buckets";
@@ -54869,7 +54556,7 @@ var require_dist_cjs71 = __commonJS({
     var _xawob = "x-amz-write-offset-bytes";
     var _xawrl = "x-amz-website-redirect-location";
     var _xi = "x-id";
-    var CreateSessionCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _CreateSessionCommand = class _CreateSessionCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       DisableS3ExpressSessionAuth: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -54880,10 +54567,9 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s3.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "CreateSession", {}).n("S3Client", "CreateSessionCommand").f(CreateSessionRequestFilterSensitiveLog, CreateSessionOutputFilterSensitiveLog).ser(se_CreateSessionCommand).de(de_CreateSessionCommand).build() {
-      static {
-        __name(this, "CreateSessionCommand");
-      }
     };
+    __name(_CreateSessionCommand, "CreateSessionCommand");
+    var CreateSessionCommand = _CreateSessionCommand;
     var import_runtimeConfig = require_runtimeConfig4();
     var import_region_config_resolver = require_dist_cjs53();
     var getHttpAuthExtensionConfiguration = /* @__PURE__ */ __name((runtimeConfig) => {
@@ -54940,14 +54626,7 @@ var require_dist_cjs71 = __commonJS({
         ...resolveHttpAuthRuntimeConfig(extensionConfiguration)
       };
     }, "resolveRuntimeExtensions");
-    var S3Client2 = class extends import_smithy_client4.Client {
-      static {
-        __name(this, "S3Client");
-      }
-      /**
-       * The resolved configuration of S3Client class. This is resolved and normalized from the {@link S3ClientConfig | constructor configuration interface}.
-       */
-      config;
+    var _S3Client = class _S3Client extends import_smithy_client4.Client {
       constructor(...[configuration]) {
         const _config_0 = (0, import_runtimeConfig.getRuntimeConfig)(configuration || {});
         const _config_1 = resolveClientEndpointParameters(_config_0);
@@ -54960,7 +54639,7 @@ var require_dist_cjs71 = __commonJS({
         const _config_8 = (0, import_eventstream_serde_config_resolver.resolveEventStreamSerdeConfig)(_config_7);
         const _config_9 = (0, import_httpAuthSchemeProvider.resolveHttpAuthSchemeConfig)(_config_8);
         const _config_10 = (0, import_middleware_sdk_s32.resolveS3Config)(_config_9, { session: [() => this, CreateSessionCommand] });
-        const _config_11 = resolveRuntimeExtensions(_config_10, configuration?.extensions || []);
+        const _config_11 = resolveRuntimeExtensions(_config_10, (configuration == null ? void 0 : configuration.extensions) || []);
         super(_config_11);
         this.config = _config_11;
         this.middlewareStack.use((0, import_middleware_user_agent.getUserAgentPlugin)(this.config));
@@ -54994,8 +54673,10 @@ var require_dist_cjs71 = __commonJS({
         super.destroy();
       }
     };
+    __name(_S3Client, "S3Client");
+    var S3Client2 = _S3Client;
     var import_middleware_sdk_s33 = require_dist_cjs29();
-    var AbortMultipartUploadCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _AbortMultipartUploadCommand = class _AbortMultipartUploadCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -55006,13 +54687,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s33.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "AbortMultipartUpload", {}).n("S3Client", "AbortMultipartUploadCommand").f(void 0, void 0).ser(se_AbortMultipartUploadCommand).de(de_AbortMultipartUploadCommand).build() {
-      static {
-        __name(this, "AbortMultipartUploadCommand");
-      }
     };
+    __name(_AbortMultipartUploadCommand, "AbortMultipartUploadCommand");
+    var AbortMultipartUploadCommand = _AbortMultipartUploadCommand;
     var import_middleware_sdk_s34 = require_dist_cjs29();
     var import_middleware_ssec = require_dist_cjs68();
-    var CompleteMultipartUploadCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _CompleteMultipartUploadCommand = class _CompleteMultipartUploadCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -55024,12 +54704,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "CompleteMultipartUpload", {}).n("S3Client", "CompleteMultipartUploadCommand").f(CompleteMultipartUploadRequestFilterSensitiveLog, CompleteMultipartUploadOutputFilterSensitiveLog).ser(se_CompleteMultipartUploadCommand).de(de_CompleteMultipartUploadCommand).build() {
-      static {
-        __name(this, "CompleteMultipartUploadCommand");
-      }
     };
+    __name(_CompleteMultipartUploadCommand, "CompleteMultipartUploadCommand");
+    var CompleteMultipartUploadCommand = _CompleteMultipartUploadCommand;
     var import_middleware_sdk_s35 = require_dist_cjs29();
-    var CopyObjectCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _CopyObjectCommand = class _CopyObjectCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       DisableS3ExpressSessionAuth: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" },
@@ -55043,13 +54722,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "CopyObject", {}).n("S3Client", "CopyObjectCommand").f(CopyObjectRequestFilterSensitiveLog, CopyObjectOutputFilterSensitiveLog).ser(se_CopyObjectCommand).de(de_CopyObjectCommand).build() {
-      static {
-        __name(this, "CopyObjectCommand");
-      }
     };
+    __name(_CopyObjectCommand, "CopyObjectCommand");
+    var CopyObjectCommand = _CopyObjectCommand;
     var import_middleware_location_constraint = require_dist_cjs69();
     var import_middleware_sdk_s36 = require_dist_cjs29();
-    var CreateBucketCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _CreateBucketCommand = class _CreateBucketCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       DisableAccessPoints: { type: "staticContextParams", value: true },
@@ -55062,30 +54740,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_location_constraint.getLocationConstraintPlugin)(config)
       ];
     }).s("AmazonS3", "CreateBucket", {}).n("S3Client", "CreateBucketCommand").f(void 0, void 0).ser(se_CreateBucketCommand).de(de_CreateBucketCommand).build() {
-      static {
-        __name(this, "CreateBucketCommand");
-      }
     };
-    var CreateBucketMetadataTableConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
-      ...commonParams,
-      UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
-      Bucket: { type: "contextParams", name: "Bucket" }
-    }).m(function(Command, cs, config, o) {
-      return [
-        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
-        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
-          requestChecksumRequired: true
-        })
-      ];
-    }).s("AmazonS3", "CreateBucketMetadataTableConfiguration", {}).n("S3Client", "CreateBucketMetadataTableConfigurationCommand").f(void 0, void 0).ser(se_CreateBucketMetadataTableConfigurationCommand).de(de_CreateBucketMetadataTableConfigurationCommand).build() {
-      static {
-        __name(this, "CreateBucketMetadataTableConfigurationCommand");
-      }
-    };
+    __name(_CreateBucketCommand, "CreateBucketCommand");
+    var CreateBucketCommand = _CreateBucketCommand;
     var import_middleware_sdk_s37 = require_dist_cjs29();
-    var CreateMultipartUploadCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _CreateMultipartUploadCommand = class _CreateMultipartUploadCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -55097,11 +54756,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "CreateMultipartUpload", {}).n("S3Client", "CreateMultipartUploadCommand").f(CreateMultipartUploadRequestFilterSensitiveLog, CreateMultipartUploadOutputFilterSensitiveLog).ser(se_CreateMultipartUploadCommand).de(de_CreateMultipartUploadCommand).build() {
-      static {
-        __name(this, "CreateMultipartUploadCommand");
-      }
     };
-    var DeleteBucketAnalyticsConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_CreateMultipartUploadCommand, "CreateMultipartUploadCommand");
+    var CreateMultipartUploadCommand = _CreateMultipartUploadCommand;
+    var _DeleteBucketAnalyticsConfigurationCommand = class _DeleteBucketAnalyticsConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55111,11 +54769,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketAnalyticsConfiguration", {}).n("S3Client", "DeleteBucketAnalyticsConfigurationCommand").f(void 0, void 0).ser(se_DeleteBucketAnalyticsConfigurationCommand).de(de_DeleteBucketAnalyticsConfigurationCommand).build() {
-      static {
-        __name(this, "DeleteBucketAnalyticsConfigurationCommand");
-      }
     };
-    var DeleteBucketCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketAnalyticsConfigurationCommand, "DeleteBucketAnalyticsConfigurationCommand");
+    var DeleteBucketAnalyticsConfigurationCommand = _DeleteBucketAnalyticsConfigurationCommand;
+    var _DeleteBucketCommand = class _DeleteBucketCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55125,11 +54782,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucket", {}).n("S3Client", "DeleteBucketCommand").f(void 0, void 0).ser(se_DeleteBucketCommand).de(de_DeleteBucketCommand).build() {
-      static {
-        __name(this, "DeleteBucketCommand");
-      }
     };
-    var DeleteBucketCorsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketCommand, "DeleteBucketCommand");
+    var DeleteBucketCommand = _DeleteBucketCommand;
+    var _DeleteBucketCorsCommand = class _DeleteBucketCorsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55139,11 +54795,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketCors", {}).n("S3Client", "DeleteBucketCorsCommand").f(void 0, void 0).ser(se_DeleteBucketCorsCommand).de(de_DeleteBucketCorsCommand).build() {
-      static {
-        __name(this, "DeleteBucketCorsCommand");
-      }
     };
-    var DeleteBucketEncryptionCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketCorsCommand, "DeleteBucketCorsCommand");
+    var DeleteBucketCorsCommand = _DeleteBucketCorsCommand;
+    var _DeleteBucketEncryptionCommand = class _DeleteBucketEncryptionCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55153,11 +54808,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketEncryption", {}).n("S3Client", "DeleteBucketEncryptionCommand").f(void 0, void 0).ser(se_DeleteBucketEncryptionCommand).de(de_DeleteBucketEncryptionCommand).build() {
-      static {
-        __name(this, "DeleteBucketEncryptionCommand");
-      }
     };
-    var DeleteBucketIntelligentTieringConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketEncryptionCommand, "DeleteBucketEncryptionCommand");
+    var DeleteBucketEncryptionCommand = _DeleteBucketEncryptionCommand;
+    var _DeleteBucketIntelligentTieringConfigurationCommand = class _DeleteBucketIntelligentTieringConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55167,11 +54821,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketIntelligentTieringConfiguration", {}).n("S3Client", "DeleteBucketIntelligentTieringConfigurationCommand").f(void 0, void 0).ser(se_DeleteBucketIntelligentTieringConfigurationCommand).de(de_DeleteBucketIntelligentTieringConfigurationCommand).build() {
-      static {
-        __name(this, "DeleteBucketIntelligentTieringConfigurationCommand");
-      }
     };
-    var DeleteBucketInventoryConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketIntelligentTieringConfigurationCommand, "DeleteBucketIntelligentTieringConfigurationCommand");
+    var DeleteBucketIntelligentTieringConfigurationCommand = _DeleteBucketIntelligentTieringConfigurationCommand;
+    var _DeleteBucketInventoryConfigurationCommand = class _DeleteBucketInventoryConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55181,11 +54834,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketInventoryConfiguration", {}).n("S3Client", "DeleteBucketInventoryConfigurationCommand").f(void 0, void 0).ser(se_DeleteBucketInventoryConfigurationCommand).de(de_DeleteBucketInventoryConfigurationCommand).build() {
-      static {
-        __name(this, "DeleteBucketInventoryConfigurationCommand");
-      }
     };
-    var DeleteBucketLifecycleCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketInventoryConfigurationCommand, "DeleteBucketInventoryConfigurationCommand");
+    var DeleteBucketInventoryConfigurationCommand = _DeleteBucketInventoryConfigurationCommand;
+    var _DeleteBucketLifecycleCommand = class _DeleteBucketLifecycleCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55195,25 +54847,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketLifecycle", {}).n("S3Client", "DeleteBucketLifecycleCommand").f(void 0, void 0).ser(se_DeleteBucketLifecycleCommand).de(de_DeleteBucketLifecycleCommand).build() {
-      static {
-        __name(this, "DeleteBucketLifecycleCommand");
-      }
     };
-    var DeleteBucketMetadataTableConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
-      ...commonParams,
-      UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
-      Bucket: { type: "contextParams", name: "Bucket" }
-    }).m(function(Command, cs, config, o) {
-      return [
-        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
-        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
-      ];
-    }).s("AmazonS3", "DeleteBucketMetadataTableConfiguration", {}).n("S3Client", "DeleteBucketMetadataTableConfigurationCommand").f(void 0, void 0).ser(se_DeleteBucketMetadataTableConfigurationCommand).de(de_DeleteBucketMetadataTableConfigurationCommand).build() {
-      static {
-        __name(this, "DeleteBucketMetadataTableConfigurationCommand");
-      }
-    };
-    var DeleteBucketMetricsConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketLifecycleCommand, "DeleteBucketLifecycleCommand");
+    var DeleteBucketLifecycleCommand = _DeleteBucketLifecycleCommand;
+    var _DeleteBucketMetricsConfigurationCommand = class _DeleteBucketMetricsConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55223,11 +54860,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketMetricsConfiguration", {}).n("S3Client", "DeleteBucketMetricsConfigurationCommand").f(void 0, void 0).ser(se_DeleteBucketMetricsConfigurationCommand).de(de_DeleteBucketMetricsConfigurationCommand).build() {
-      static {
-        __name(this, "DeleteBucketMetricsConfigurationCommand");
-      }
     };
-    var DeleteBucketOwnershipControlsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketMetricsConfigurationCommand, "DeleteBucketMetricsConfigurationCommand");
+    var DeleteBucketMetricsConfigurationCommand = _DeleteBucketMetricsConfigurationCommand;
+    var _DeleteBucketOwnershipControlsCommand = class _DeleteBucketOwnershipControlsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55237,11 +54873,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketOwnershipControls", {}).n("S3Client", "DeleteBucketOwnershipControlsCommand").f(void 0, void 0).ser(se_DeleteBucketOwnershipControlsCommand).de(de_DeleteBucketOwnershipControlsCommand).build() {
-      static {
-        __name(this, "DeleteBucketOwnershipControlsCommand");
-      }
     };
-    var DeleteBucketPolicyCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketOwnershipControlsCommand, "DeleteBucketOwnershipControlsCommand");
+    var DeleteBucketOwnershipControlsCommand = _DeleteBucketOwnershipControlsCommand;
+    var _DeleteBucketPolicyCommand = class _DeleteBucketPolicyCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55251,11 +54886,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketPolicy", {}).n("S3Client", "DeleteBucketPolicyCommand").f(void 0, void 0).ser(se_DeleteBucketPolicyCommand).de(de_DeleteBucketPolicyCommand).build() {
-      static {
-        __name(this, "DeleteBucketPolicyCommand");
-      }
     };
-    var DeleteBucketReplicationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketPolicyCommand, "DeleteBucketPolicyCommand");
+    var DeleteBucketPolicyCommand = _DeleteBucketPolicyCommand;
+    var _DeleteBucketReplicationCommand = class _DeleteBucketReplicationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55265,11 +54899,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketReplication", {}).n("S3Client", "DeleteBucketReplicationCommand").f(void 0, void 0).ser(se_DeleteBucketReplicationCommand).de(de_DeleteBucketReplicationCommand).build() {
-      static {
-        __name(this, "DeleteBucketReplicationCommand");
-      }
     };
-    var DeleteBucketTaggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketReplicationCommand, "DeleteBucketReplicationCommand");
+    var DeleteBucketReplicationCommand = _DeleteBucketReplicationCommand;
+    var _DeleteBucketTaggingCommand = class _DeleteBucketTaggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55279,11 +54912,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketTagging", {}).n("S3Client", "DeleteBucketTaggingCommand").f(void 0, void 0).ser(se_DeleteBucketTaggingCommand).de(de_DeleteBucketTaggingCommand).build() {
-      static {
-        __name(this, "DeleteBucketTaggingCommand");
-      }
     };
-    var DeleteBucketWebsiteCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteBucketTaggingCommand, "DeleteBucketTaggingCommand");
+    var DeleteBucketTaggingCommand = _DeleteBucketTaggingCommand;
+    var _DeleteBucketWebsiteCommand = class _DeleteBucketWebsiteCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55293,12 +54925,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeleteBucketWebsite", {}).n("S3Client", "DeleteBucketWebsiteCommand").f(void 0, void 0).ser(se_DeleteBucketWebsiteCommand).de(de_DeleteBucketWebsiteCommand).build() {
-      static {
-        __name(this, "DeleteBucketWebsiteCommand");
-      }
     };
+    __name(_DeleteBucketWebsiteCommand, "DeleteBucketWebsiteCommand");
+    var DeleteBucketWebsiteCommand = _DeleteBucketWebsiteCommand;
     var import_middleware_sdk_s38 = require_dist_cjs29();
-    var DeleteObjectCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _DeleteObjectCommand = class _DeleteObjectCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -55309,12 +54940,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s38.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "DeleteObject", {}).n("S3Client", "DeleteObjectCommand").f(void 0, void 0).ser(se_DeleteObjectCommand).de(de_DeleteObjectCommand).build() {
-      static {
-        __name(this, "DeleteObjectCommand");
-      }
     };
+    __name(_DeleteObjectCommand, "DeleteObjectCommand");
+    var DeleteObjectCommand = _DeleteObjectCommand;
     var import_middleware_sdk_s39 = require_dist_cjs29();
-    var DeleteObjectsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _DeleteObjectsCommand = class _DeleteObjectsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -55322,18 +54952,18 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         }),
         (0, import_middleware_sdk_s39.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "DeleteObjects", {}).n("S3Client", "DeleteObjectsCommand").f(void 0, void 0).ser(se_DeleteObjectsCommand).de(de_DeleteObjectsCommand).build() {
-      static {
-        __name(this, "DeleteObjectsCommand");
-      }
     };
+    __name(_DeleteObjectsCommand, "DeleteObjectsCommand");
+    var DeleteObjectsCommand = _DeleteObjectsCommand;
     var import_middleware_sdk_s310 = require_dist_cjs29();
-    var DeleteObjectTaggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _DeleteObjectTaggingCommand = class _DeleteObjectTaggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -55343,11 +54973,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s310.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "DeleteObjectTagging", {}).n("S3Client", "DeleteObjectTaggingCommand").f(void 0, void 0).ser(se_DeleteObjectTaggingCommand).de(de_DeleteObjectTaggingCommand).build() {
-      static {
-        __name(this, "DeleteObjectTaggingCommand");
-      }
     };
-    var DeletePublicAccessBlockCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_DeleteObjectTaggingCommand, "DeleteObjectTaggingCommand");
+    var DeleteObjectTaggingCommand = _DeleteObjectTaggingCommand;
+    var _DeletePublicAccessBlockCommand = class _DeletePublicAccessBlockCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55357,12 +54986,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "DeletePublicAccessBlock", {}).n("S3Client", "DeletePublicAccessBlockCommand").f(void 0, void 0).ser(se_DeletePublicAccessBlockCommand).de(de_DeletePublicAccessBlockCommand).build() {
-      static {
-        __name(this, "DeletePublicAccessBlockCommand");
-      }
     };
+    __name(_DeletePublicAccessBlockCommand, "DeletePublicAccessBlockCommand");
+    var DeletePublicAccessBlockCommand = _DeletePublicAccessBlockCommand;
     var import_middleware_sdk_s311 = require_dist_cjs29();
-    var GetBucketAccelerateConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketAccelerateConfigurationCommand = class _GetBucketAccelerateConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55373,12 +55001,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s311.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketAccelerateConfiguration", {}).n("S3Client", "GetBucketAccelerateConfigurationCommand").f(void 0, void 0).ser(se_GetBucketAccelerateConfigurationCommand).de(de_GetBucketAccelerateConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketAccelerateConfigurationCommand");
-      }
     };
+    __name(_GetBucketAccelerateConfigurationCommand, "GetBucketAccelerateConfigurationCommand");
+    var GetBucketAccelerateConfigurationCommand = _GetBucketAccelerateConfigurationCommand;
     var import_middleware_sdk_s312 = require_dist_cjs29();
-    var GetBucketAclCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketAclCommand = class _GetBucketAclCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55389,12 +55016,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s312.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketAcl", {}).n("S3Client", "GetBucketAclCommand").f(void 0, void 0).ser(se_GetBucketAclCommand).de(de_GetBucketAclCommand).build() {
-      static {
-        __name(this, "GetBucketAclCommand");
-      }
     };
+    __name(_GetBucketAclCommand, "GetBucketAclCommand");
+    var GetBucketAclCommand = _GetBucketAclCommand;
     var import_middleware_sdk_s313 = require_dist_cjs29();
-    var GetBucketAnalyticsConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketAnalyticsConfigurationCommand = class _GetBucketAnalyticsConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55405,12 +55031,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s313.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketAnalyticsConfiguration", {}).n("S3Client", "GetBucketAnalyticsConfigurationCommand").f(void 0, void 0).ser(se_GetBucketAnalyticsConfigurationCommand).de(de_GetBucketAnalyticsConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketAnalyticsConfigurationCommand");
-      }
     };
+    __name(_GetBucketAnalyticsConfigurationCommand, "GetBucketAnalyticsConfigurationCommand");
+    var GetBucketAnalyticsConfigurationCommand = _GetBucketAnalyticsConfigurationCommand;
     var import_middleware_sdk_s314 = require_dist_cjs29();
-    var GetBucketCorsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketCorsCommand = class _GetBucketCorsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55421,12 +55046,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s314.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketCors", {}).n("S3Client", "GetBucketCorsCommand").f(void 0, void 0).ser(se_GetBucketCorsCommand).de(de_GetBucketCorsCommand).build() {
-      static {
-        __name(this, "GetBucketCorsCommand");
-      }
     };
+    __name(_GetBucketCorsCommand, "GetBucketCorsCommand");
+    var GetBucketCorsCommand = _GetBucketCorsCommand;
     var import_middleware_sdk_s315 = require_dist_cjs29();
-    var GetBucketEncryptionCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketEncryptionCommand = class _GetBucketEncryptionCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55437,12 +55061,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s315.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketEncryption", {}).n("S3Client", "GetBucketEncryptionCommand").f(void 0, GetBucketEncryptionOutputFilterSensitiveLog).ser(se_GetBucketEncryptionCommand).de(de_GetBucketEncryptionCommand).build() {
-      static {
-        __name(this, "GetBucketEncryptionCommand");
-      }
     };
+    __name(_GetBucketEncryptionCommand, "GetBucketEncryptionCommand");
+    var GetBucketEncryptionCommand = _GetBucketEncryptionCommand;
     var import_middleware_sdk_s316 = require_dist_cjs29();
-    var GetBucketIntelligentTieringConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketIntelligentTieringConfigurationCommand = class _GetBucketIntelligentTieringConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55453,12 +55076,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s316.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketIntelligentTieringConfiguration", {}).n("S3Client", "GetBucketIntelligentTieringConfigurationCommand").f(void 0, void 0).ser(se_GetBucketIntelligentTieringConfigurationCommand).de(de_GetBucketIntelligentTieringConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketIntelligentTieringConfigurationCommand");
-      }
     };
+    __name(_GetBucketIntelligentTieringConfigurationCommand, "GetBucketIntelligentTieringConfigurationCommand");
+    var GetBucketIntelligentTieringConfigurationCommand = _GetBucketIntelligentTieringConfigurationCommand;
     var import_middleware_sdk_s317 = require_dist_cjs29();
-    var GetBucketInventoryConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketInventoryConfigurationCommand = class _GetBucketInventoryConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55469,12 +55091,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s317.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketInventoryConfiguration", {}).n("S3Client", "GetBucketInventoryConfigurationCommand").f(void 0, GetBucketInventoryConfigurationOutputFilterSensitiveLog).ser(se_GetBucketInventoryConfigurationCommand).de(de_GetBucketInventoryConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketInventoryConfigurationCommand");
-      }
     };
+    __name(_GetBucketInventoryConfigurationCommand, "GetBucketInventoryConfigurationCommand");
+    var GetBucketInventoryConfigurationCommand = _GetBucketInventoryConfigurationCommand;
     var import_middleware_sdk_s318 = require_dist_cjs29();
-    var GetBucketLifecycleConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketLifecycleConfigurationCommand = class _GetBucketLifecycleConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55485,12 +55106,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s318.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketLifecycleConfiguration", {}).n("S3Client", "GetBucketLifecycleConfigurationCommand").f(void 0, void 0).ser(se_GetBucketLifecycleConfigurationCommand).de(de_GetBucketLifecycleConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketLifecycleConfigurationCommand");
-      }
     };
+    __name(_GetBucketLifecycleConfigurationCommand, "GetBucketLifecycleConfigurationCommand");
+    var GetBucketLifecycleConfigurationCommand = _GetBucketLifecycleConfigurationCommand;
     var import_middleware_sdk_s319 = require_dist_cjs29();
-    var GetBucketLocationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketLocationCommand = class _GetBucketLocationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55501,12 +55121,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s319.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketLocation", {}).n("S3Client", "GetBucketLocationCommand").f(void 0, void 0).ser(se_GetBucketLocationCommand).de(de_GetBucketLocationCommand).build() {
-      static {
-        __name(this, "GetBucketLocationCommand");
-      }
     };
+    __name(_GetBucketLocationCommand, "GetBucketLocationCommand");
+    var GetBucketLocationCommand = _GetBucketLocationCommand;
     var import_middleware_sdk_s320 = require_dist_cjs29();
-    var GetBucketLoggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketLoggingCommand = class _GetBucketLoggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55517,12 +55136,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_sdk_s320.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetBucketLogging", {}).n("S3Client", "GetBucketLoggingCommand").f(void 0, void 0).ser(se_GetBucketLoggingCommand).de(de_GetBucketLoggingCommand).build() {
-      static {
-        __name(this, "GetBucketLoggingCommand");
-      }
     };
+    __name(_GetBucketLoggingCommand, "GetBucketLoggingCommand");
+    var GetBucketLoggingCommand = _GetBucketLoggingCommand;
     var import_middleware_sdk_s321 = require_dist_cjs29();
-    var GetBucketMetadataTableConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketMetricsConfigurationCommand = class _GetBucketMetricsConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55532,13 +55150,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s321.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketMetadataTableConfiguration", {}).n("S3Client", "GetBucketMetadataTableConfigurationCommand").f(void 0, void 0).ser(se_GetBucketMetadataTableConfigurationCommand).de(de_GetBucketMetadataTableConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketMetadataTableConfigurationCommand");
-      }
+    }).s("AmazonS3", "GetBucketMetricsConfiguration", {}).n("S3Client", "GetBucketMetricsConfigurationCommand").f(void 0, void 0).ser(se_GetBucketMetricsConfigurationCommand).de(de_GetBucketMetricsConfigurationCommand).build() {
     };
+    __name(_GetBucketMetricsConfigurationCommand, "GetBucketMetricsConfigurationCommand");
+    var GetBucketMetricsConfigurationCommand = _GetBucketMetricsConfigurationCommand;
     var import_middleware_sdk_s322 = require_dist_cjs29();
-    var GetBucketMetricsConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketNotificationConfigurationCommand = class _GetBucketNotificationConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55548,13 +55165,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s322.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketMetricsConfiguration", {}).n("S3Client", "GetBucketMetricsConfigurationCommand").f(void 0, void 0).ser(se_GetBucketMetricsConfigurationCommand).de(de_GetBucketMetricsConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketMetricsConfigurationCommand");
-      }
+    }).s("AmazonS3", "GetBucketNotificationConfiguration", {}).n("S3Client", "GetBucketNotificationConfigurationCommand").f(void 0, void 0).ser(se_GetBucketNotificationConfigurationCommand).de(de_GetBucketNotificationConfigurationCommand).build() {
     };
+    __name(_GetBucketNotificationConfigurationCommand, "GetBucketNotificationConfigurationCommand");
+    var GetBucketNotificationConfigurationCommand = _GetBucketNotificationConfigurationCommand;
     var import_middleware_sdk_s323 = require_dist_cjs29();
-    var GetBucketNotificationConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketOwnershipControlsCommand = class _GetBucketOwnershipControlsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55564,13 +55180,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s323.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketNotificationConfiguration", {}).n("S3Client", "GetBucketNotificationConfigurationCommand").f(void 0, void 0).ser(se_GetBucketNotificationConfigurationCommand).de(de_GetBucketNotificationConfigurationCommand).build() {
-      static {
-        __name(this, "GetBucketNotificationConfigurationCommand");
-      }
+    }).s("AmazonS3", "GetBucketOwnershipControls", {}).n("S3Client", "GetBucketOwnershipControlsCommand").f(void 0, void 0).ser(se_GetBucketOwnershipControlsCommand).de(de_GetBucketOwnershipControlsCommand).build() {
     };
+    __name(_GetBucketOwnershipControlsCommand, "GetBucketOwnershipControlsCommand");
+    var GetBucketOwnershipControlsCommand = _GetBucketOwnershipControlsCommand;
     var import_middleware_sdk_s324 = require_dist_cjs29();
-    var GetBucketOwnershipControlsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketPolicyCommand = class _GetBucketPolicyCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55580,13 +55195,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s324.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketOwnershipControls", {}).n("S3Client", "GetBucketOwnershipControlsCommand").f(void 0, void 0).ser(se_GetBucketOwnershipControlsCommand).de(de_GetBucketOwnershipControlsCommand).build() {
-      static {
-        __name(this, "GetBucketOwnershipControlsCommand");
-      }
+    }).s("AmazonS3", "GetBucketPolicy", {}).n("S3Client", "GetBucketPolicyCommand").f(void 0, void 0).ser(se_GetBucketPolicyCommand).de(de_GetBucketPolicyCommand).build() {
     };
+    __name(_GetBucketPolicyCommand, "GetBucketPolicyCommand");
+    var GetBucketPolicyCommand = _GetBucketPolicyCommand;
     var import_middleware_sdk_s325 = require_dist_cjs29();
-    var GetBucketPolicyCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketPolicyStatusCommand = class _GetBucketPolicyStatusCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55596,13 +55210,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s325.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketPolicy", {}).n("S3Client", "GetBucketPolicyCommand").f(void 0, void 0).ser(se_GetBucketPolicyCommand).de(de_GetBucketPolicyCommand).build() {
-      static {
-        __name(this, "GetBucketPolicyCommand");
-      }
+    }).s("AmazonS3", "GetBucketPolicyStatus", {}).n("S3Client", "GetBucketPolicyStatusCommand").f(void 0, void 0).ser(se_GetBucketPolicyStatusCommand).de(de_GetBucketPolicyStatusCommand).build() {
     };
+    __name(_GetBucketPolicyStatusCommand, "GetBucketPolicyStatusCommand");
+    var GetBucketPolicyStatusCommand = _GetBucketPolicyStatusCommand;
     var import_middleware_sdk_s326 = require_dist_cjs29();
-    var GetBucketPolicyStatusCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketReplicationCommand = class _GetBucketReplicationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55612,13 +55225,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s326.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketPolicyStatus", {}).n("S3Client", "GetBucketPolicyStatusCommand").f(void 0, void 0).ser(se_GetBucketPolicyStatusCommand).de(de_GetBucketPolicyStatusCommand).build() {
-      static {
-        __name(this, "GetBucketPolicyStatusCommand");
-      }
+    }).s("AmazonS3", "GetBucketReplication", {}).n("S3Client", "GetBucketReplicationCommand").f(void 0, void 0).ser(se_GetBucketReplicationCommand).de(de_GetBucketReplicationCommand).build() {
     };
+    __name(_GetBucketReplicationCommand, "GetBucketReplicationCommand");
+    var GetBucketReplicationCommand = _GetBucketReplicationCommand;
     var import_middleware_sdk_s327 = require_dist_cjs29();
-    var GetBucketReplicationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketRequestPaymentCommand = class _GetBucketRequestPaymentCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55628,13 +55240,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s327.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketReplication", {}).n("S3Client", "GetBucketReplicationCommand").f(void 0, void 0).ser(se_GetBucketReplicationCommand).de(de_GetBucketReplicationCommand).build() {
-      static {
-        __name(this, "GetBucketReplicationCommand");
-      }
+    }).s("AmazonS3", "GetBucketRequestPayment", {}).n("S3Client", "GetBucketRequestPaymentCommand").f(void 0, void 0).ser(se_GetBucketRequestPaymentCommand).de(de_GetBucketRequestPaymentCommand).build() {
     };
+    __name(_GetBucketRequestPaymentCommand, "GetBucketRequestPaymentCommand");
+    var GetBucketRequestPaymentCommand = _GetBucketRequestPaymentCommand;
     var import_middleware_sdk_s328 = require_dist_cjs29();
-    var GetBucketRequestPaymentCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketTaggingCommand = class _GetBucketTaggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55644,13 +55255,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s328.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketRequestPayment", {}).n("S3Client", "GetBucketRequestPaymentCommand").f(void 0, void 0).ser(se_GetBucketRequestPaymentCommand).de(de_GetBucketRequestPaymentCommand).build() {
-      static {
-        __name(this, "GetBucketRequestPaymentCommand");
-      }
+    }).s("AmazonS3", "GetBucketTagging", {}).n("S3Client", "GetBucketTaggingCommand").f(void 0, void 0).ser(se_GetBucketTaggingCommand).de(de_GetBucketTaggingCommand).build() {
     };
+    __name(_GetBucketTaggingCommand, "GetBucketTaggingCommand");
+    var GetBucketTaggingCommand = _GetBucketTaggingCommand;
     var import_middleware_sdk_s329 = require_dist_cjs29();
-    var GetBucketTaggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketVersioningCommand = class _GetBucketVersioningCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55660,13 +55270,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s329.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketTagging", {}).n("S3Client", "GetBucketTaggingCommand").f(void 0, void 0).ser(se_GetBucketTaggingCommand).de(de_GetBucketTaggingCommand).build() {
-      static {
-        __name(this, "GetBucketTaggingCommand");
-      }
+    }).s("AmazonS3", "GetBucketVersioning", {}).n("S3Client", "GetBucketVersioningCommand").f(void 0, void 0).ser(se_GetBucketVersioningCommand).de(de_GetBucketVersioningCommand).build() {
     };
+    __name(_GetBucketVersioningCommand, "GetBucketVersioningCommand");
+    var GetBucketVersioningCommand = _GetBucketVersioningCommand;
     var import_middleware_sdk_s330 = require_dist_cjs29();
-    var GetBucketVersioningCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetBucketWebsiteCommand = class _GetBucketWebsiteCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55676,29 +55285,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s330.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetBucketVersioning", {}).n("S3Client", "GetBucketVersioningCommand").f(void 0, void 0).ser(se_GetBucketVersioningCommand).de(de_GetBucketVersioningCommand).build() {
-      static {
-        __name(this, "GetBucketVersioningCommand");
-      }
-    };
-    var import_middleware_sdk_s331 = require_dist_cjs29();
-    var GetBucketWebsiteCommand = class extends import_smithy_client4.Command.classBuilder().ep({
-      ...commonParams,
-      UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
-      Bucket: { type: "contextParams", name: "Bucket" }
-    }).m(function(Command, cs, config, o) {
-      return [
-        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
-        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s331.getThrow200ExceptionsPlugin)(config)
-      ];
     }).s("AmazonS3", "GetBucketWebsite", {}).n("S3Client", "GetBucketWebsiteCommand").f(void 0, void 0).ser(se_GetBucketWebsiteCommand).de(de_GetBucketWebsiteCommand).build() {
-      static {
-        __name(this, "GetBucketWebsiteCommand");
-      }
     };
-    var import_middleware_sdk_s332 = require_dist_cjs29();
-    var GetObjectAclCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_GetBucketWebsiteCommand, "GetBucketWebsiteCommand");
+    var GetBucketWebsiteCommand = _GetBucketWebsiteCommand;
+    var import_middleware_sdk_s331 = require_dist_cjs29();
+    var _GetObjectAclCommand = class _GetObjectAclCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -55706,31 +55298,29 @@ var require_dist_cjs71 = __commonJS({
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s332.getThrow200ExceptionsPlugin)(config)
+        (0, import_middleware_sdk_s331.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetObjectAcl", {}).n("S3Client", "GetObjectAclCommand").f(void 0, void 0).ser(se_GetObjectAclCommand).de(de_GetObjectAclCommand).build() {
-      static {
-        __name(this, "GetObjectAclCommand");
-      }
     };
-    var import_middleware_sdk_s333 = require_dist_cjs29();
-    var GetObjectAttributesCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_GetObjectAclCommand, "GetObjectAclCommand");
+    var GetObjectAclCommand = _GetObjectAclCommand;
+    var import_middleware_sdk_s332 = require_dist_cjs29();
+    var _GetObjectAttributesCommand = class _GetObjectAttributesCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s333.getThrow200ExceptionsPlugin)(config),
+        (0, import_middleware_sdk_s332.getThrow200ExceptionsPlugin)(config),
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "GetObjectAttributes", {}).n("S3Client", "GetObjectAttributesCommand").f(GetObjectAttributesRequestFilterSensitiveLog, void 0).ser(se_GetObjectAttributesCommand).de(de_GetObjectAttributesCommand).build() {
-      static {
-        __name(this, "GetObjectAttributesCommand");
-      }
     };
-    var import_middleware_sdk_s334 = require_dist_cjs29();
-    var GetObjectCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_GetObjectAttributesCommand, "GetObjectAttributesCommand");
+    var GetObjectAttributesCommand = _GetObjectAttributesCommand;
+    var import_middleware_sdk_s333 = require_dist_cjs29();
+    var _GetObjectCommand = class _GetObjectCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -55744,15 +55334,28 @@ var require_dist_cjs71 = __commonJS({
           responseAlgorithms: ["CRC32", "CRC32C", "SHA256", "SHA1"]
         }),
         (0, import_middleware_ssec.getSsecPlugin)(config),
-        (0, import_middleware_sdk_s334.getS3ExpiresMiddlewarePlugin)(config)
+        (0, import_middleware_sdk_s333.getS3ExpiresMiddlewarePlugin)(config)
       ];
     }).s("AmazonS3", "GetObject", {}).n("S3Client", "GetObjectCommand").f(GetObjectRequestFilterSensitiveLog, GetObjectOutputFilterSensitiveLog).ser(se_GetObjectCommand).de(de_GetObjectCommand).build() {
-      static {
-        __name(this, "GetObjectCommand");
-      }
     };
+    __name(_GetObjectCommand, "GetObjectCommand");
+    var GetObjectCommand = _GetObjectCommand;
+    var import_middleware_sdk_s334 = require_dist_cjs29();
+    var _GetObjectLegalHoldCommand = class _GetObjectLegalHoldCommand extends import_smithy_client4.Command.classBuilder().ep({
+      ...commonParams,
+      Bucket: { type: "contextParams", name: "Bucket" }
+    }).m(function(Command, cs, config, o) {
+      return [
+        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
+        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
+        (0, import_middleware_sdk_s334.getThrow200ExceptionsPlugin)(config)
+      ];
+    }).s("AmazonS3", "GetObjectLegalHold", {}).n("S3Client", "GetObjectLegalHoldCommand").f(void 0, void 0).ser(se_GetObjectLegalHoldCommand).de(de_GetObjectLegalHoldCommand).build() {
+    };
+    __name(_GetObjectLegalHoldCommand, "GetObjectLegalHoldCommand");
+    var GetObjectLegalHoldCommand = _GetObjectLegalHoldCommand;
     var import_middleware_sdk_s335 = require_dist_cjs29();
-    var GetObjectLegalHoldCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetObjectLockConfigurationCommand = class _GetObjectLockConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -55761,13 +55364,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s335.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetObjectLegalHold", {}).n("S3Client", "GetObjectLegalHoldCommand").f(void 0, void 0).ser(se_GetObjectLegalHoldCommand).de(de_GetObjectLegalHoldCommand).build() {
-      static {
-        __name(this, "GetObjectLegalHoldCommand");
-      }
+    }).s("AmazonS3", "GetObjectLockConfiguration", {}).n("S3Client", "GetObjectLockConfigurationCommand").f(void 0, void 0).ser(se_GetObjectLockConfigurationCommand).de(de_GetObjectLockConfigurationCommand).build() {
     };
+    __name(_GetObjectLockConfigurationCommand, "GetObjectLockConfigurationCommand");
+    var GetObjectLockConfigurationCommand = _GetObjectLockConfigurationCommand;
     var import_middleware_sdk_s336 = require_dist_cjs29();
-    var GetObjectLockConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetObjectRetentionCommand = class _GetObjectRetentionCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -55776,13 +55378,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s336.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetObjectLockConfiguration", {}).n("S3Client", "GetObjectLockConfigurationCommand").f(void 0, void 0).ser(se_GetObjectLockConfigurationCommand).de(de_GetObjectLockConfigurationCommand).build() {
-      static {
-        __name(this, "GetObjectLockConfigurationCommand");
-      }
+    }).s("AmazonS3", "GetObjectRetention", {}).n("S3Client", "GetObjectRetentionCommand").f(void 0, void 0).ser(se_GetObjectRetentionCommand).de(de_GetObjectRetentionCommand).build() {
     };
+    __name(_GetObjectRetentionCommand, "GetObjectRetentionCommand");
+    var GetObjectRetentionCommand = _GetObjectRetentionCommand;
     var import_middleware_sdk_s337 = require_dist_cjs29();
-    var GetObjectRetentionCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _GetObjectTaggingCommand = class _GetObjectTaggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -55791,27 +55392,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s337.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "GetObjectRetention", {}).n("S3Client", "GetObjectRetentionCommand").f(void 0, void 0).ser(se_GetObjectRetentionCommand).de(de_GetObjectRetentionCommand).build() {
-      static {
-        __name(this, "GetObjectRetentionCommand");
-      }
-    };
-    var import_middleware_sdk_s338 = require_dist_cjs29();
-    var GetObjectTaggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
-      ...commonParams,
-      Bucket: { type: "contextParams", name: "Bucket" }
-    }).m(function(Command, cs, config, o) {
-      return [
-        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
-        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s338.getThrow200ExceptionsPlugin)(config)
-      ];
     }).s("AmazonS3", "GetObjectTagging", {}).n("S3Client", "GetObjectTaggingCommand").f(void 0, void 0).ser(se_GetObjectTaggingCommand).de(de_GetObjectTaggingCommand).build() {
-      static {
-        __name(this, "GetObjectTaggingCommand");
-      }
     };
-    var GetObjectTorrentCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_GetObjectTaggingCommand, "GetObjectTaggingCommand");
+    var GetObjectTaggingCommand = _GetObjectTaggingCommand;
+    var _GetObjectTorrentCommand = class _GetObjectTorrentCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -55820,12 +55405,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "GetObjectTorrent", {}).n("S3Client", "GetObjectTorrentCommand").f(void 0, GetObjectTorrentOutputFilterSensitiveLog).ser(se_GetObjectTorrentCommand).de(de_GetObjectTorrentCommand).build() {
-      static {
-        __name(this, "GetObjectTorrentCommand");
-      }
     };
-    var import_middleware_sdk_s339 = require_dist_cjs29();
-    var GetPublicAccessBlockCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_GetObjectTorrentCommand, "GetObjectTorrentCommand");
+    var GetObjectTorrentCommand = _GetObjectTorrentCommand;
+    var import_middleware_sdk_s338 = require_dist_cjs29();
+    var _GetPublicAccessBlockCommand = class _GetPublicAccessBlockCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55833,30 +55417,28 @@ var require_dist_cjs71 = __commonJS({
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s339.getThrow200ExceptionsPlugin)(config)
+        (0, import_middleware_sdk_s338.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "GetPublicAccessBlock", {}).n("S3Client", "GetPublicAccessBlockCommand").f(void 0, void 0).ser(se_GetPublicAccessBlockCommand).de(de_GetPublicAccessBlockCommand).build() {
-      static {
-        __name(this, "GetPublicAccessBlockCommand");
-      }
     };
-    var import_middleware_sdk_s340 = require_dist_cjs29();
-    var HeadBucketCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_GetPublicAccessBlockCommand, "GetPublicAccessBlockCommand");
+    var GetPublicAccessBlockCommand = _GetPublicAccessBlockCommand;
+    var import_middleware_sdk_s339 = require_dist_cjs29();
+    var _HeadBucketCommand = class _HeadBucketCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s340.getThrow200ExceptionsPlugin)(config)
+        (0, import_middleware_sdk_s339.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "HeadBucket", {}).n("S3Client", "HeadBucketCommand").f(void 0, void 0).ser(se_HeadBucketCommand).de(de_HeadBucketCommand).build() {
-      static {
-        __name(this, "HeadBucketCommand");
-      }
     };
-    var import_middleware_sdk_s341 = require_dist_cjs29();
-    var HeadObjectCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_HeadBucketCommand, "HeadBucketCommand");
+    var HeadBucketCommand = _HeadBucketCommand;
+    var import_middleware_sdk_s340 = require_dist_cjs29();
+    var _HeadObjectCommand = class _HeadObjectCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -55864,17 +55446,31 @@ var require_dist_cjs71 = __commonJS({
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s341.getThrow200ExceptionsPlugin)(config),
+        (0, import_middleware_sdk_s340.getThrow200ExceptionsPlugin)(config),
         (0, import_middleware_ssec.getSsecPlugin)(config),
-        (0, import_middleware_sdk_s341.getS3ExpiresMiddlewarePlugin)(config)
+        (0, import_middleware_sdk_s340.getS3ExpiresMiddlewarePlugin)(config)
       ];
     }).s("AmazonS3", "HeadObject", {}).n("S3Client", "HeadObjectCommand").f(HeadObjectRequestFilterSensitiveLog, HeadObjectOutputFilterSensitiveLog).ser(se_HeadObjectCommand).de(de_HeadObjectCommand).build() {
-      static {
-        __name(this, "HeadObjectCommand");
-      }
     };
+    __name(_HeadObjectCommand, "HeadObjectCommand");
+    var HeadObjectCommand = _HeadObjectCommand;
+    var import_middleware_sdk_s341 = require_dist_cjs29();
+    var _ListBucketAnalyticsConfigurationsCommand = class _ListBucketAnalyticsConfigurationsCommand extends import_smithy_client4.Command.classBuilder().ep({
+      ...commonParams,
+      UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
+      Bucket: { type: "contextParams", name: "Bucket" }
+    }).m(function(Command, cs, config, o) {
+      return [
+        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
+        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
+        (0, import_middleware_sdk_s341.getThrow200ExceptionsPlugin)(config)
+      ];
+    }).s("AmazonS3", "ListBucketAnalyticsConfigurations", {}).n("S3Client", "ListBucketAnalyticsConfigurationsCommand").f(void 0, void 0).ser(se_ListBucketAnalyticsConfigurationsCommand).de(de_ListBucketAnalyticsConfigurationsCommand).build() {
+    };
+    __name(_ListBucketAnalyticsConfigurationsCommand, "ListBucketAnalyticsConfigurationsCommand");
+    var ListBucketAnalyticsConfigurationsCommand = _ListBucketAnalyticsConfigurationsCommand;
     var import_middleware_sdk_s342 = require_dist_cjs29();
-    var ListBucketAnalyticsConfigurationsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _ListBucketIntelligentTieringConfigurationsCommand = class _ListBucketIntelligentTieringConfigurationsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55884,13 +55480,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s342.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "ListBucketAnalyticsConfigurations", {}).n("S3Client", "ListBucketAnalyticsConfigurationsCommand").f(void 0, void 0).ser(se_ListBucketAnalyticsConfigurationsCommand).de(de_ListBucketAnalyticsConfigurationsCommand).build() {
-      static {
-        __name(this, "ListBucketAnalyticsConfigurationsCommand");
-      }
+    }).s("AmazonS3", "ListBucketIntelligentTieringConfigurations", {}).n("S3Client", "ListBucketIntelligentTieringConfigurationsCommand").f(void 0, void 0).ser(se_ListBucketIntelligentTieringConfigurationsCommand).de(de_ListBucketIntelligentTieringConfigurationsCommand).build() {
     };
+    __name(_ListBucketIntelligentTieringConfigurationsCommand, "ListBucketIntelligentTieringConfigurationsCommand");
+    var ListBucketIntelligentTieringConfigurationsCommand = _ListBucketIntelligentTieringConfigurationsCommand;
     var import_middleware_sdk_s343 = require_dist_cjs29();
-    var ListBucketIntelligentTieringConfigurationsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _ListBucketInventoryConfigurationsCommand = class _ListBucketInventoryConfigurationsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -55900,15 +55495,13 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s343.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "ListBucketIntelligentTieringConfigurations", {}).n("S3Client", "ListBucketIntelligentTieringConfigurationsCommand").f(void 0, void 0).ser(se_ListBucketIntelligentTieringConfigurationsCommand).de(de_ListBucketIntelligentTieringConfigurationsCommand).build() {
-      static {
-        __name(this, "ListBucketIntelligentTieringConfigurationsCommand");
-      }
+    }).s("AmazonS3", "ListBucketInventoryConfigurations", {}).n("S3Client", "ListBucketInventoryConfigurationsCommand").f(void 0, ListBucketInventoryConfigurationsOutputFilterSensitiveLog).ser(se_ListBucketInventoryConfigurationsCommand).de(de_ListBucketInventoryConfigurationsCommand).build() {
     };
+    __name(_ListBucketInventoryConfigurationsCommand, "ListBucketInventoryConfigurationsCommand");
+    var ListBucketInventoryConfigurationsCommand = _ListBucketInventoryConfigurationsCommand;
     var import_middleware_sdk_s344 = require_dist_cjs29();
-    var ListBucketInventoryConfigurationsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _ListBucketMetricsConfigurationsCommand = class _ListBucketMetricsConfigurationsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
-      UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
       return [
@@ -55916,55 +55509,52 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s344.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "ListBucketInventoryConfigurations", {}).n("S3Client", "ListBucketInventoryConfigurationsCommand").f(void 0, ListBucketInventoryConfigurationsOutputFilterSensitiveLog).ser(se_ListBucketInventoryConfigurationsCommand).de(de_ListBucketInventoryConfigurationsCommand).build() {
-      static {
-        __name(this, "ListBucketInventoryConfigurationsCommand");
-      }
+    }).s("AmazonS3", "ListBucketMetricsConfigurations", {}).n("S3Client", "ListBucketMetricsConfigurationsCommand").f(void 0, void 0).ser(se_ListBucketMetricsConfigurationsCommand).de(de_ListBucketMetricsConfigurationsCommand).build() {
     };
+    __name(_ListBucketMetricsConfigurationsCommand, "ListBucketMetricsConfigurationsCommand");
+    var ListBucketMetricsConfigurationsCommand = _ListBucketMetricsConfigurationsCommand;
     var import_middleware_sdk_s345 = require_dist_cjs29();
-    var ListBucketMetricsConfigurationsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
-      ...commonParams,
-      Bucket: { type: "contextParams", name: "Bucket" }
-    }).m(function(Command, cs, config, o) {
+    var _ListBucketsCommand = class _ListBucketsCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s345.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "ListBucketMetricsConfigurations", {}).n("S3Client", "ListBucketMetricsConfigurationsCommand").f(void 0, void 0).ser(se_ListBucketMetricsConfigurationsCommand).de(de_ListBucketMetricsConfigurationsCommand).build() {
-      static {
-        __name(this, "ListBucketMetricsConfigurationsCommand");
-      }
-    };
-    var import_middleware_sdk_s346 = require_dist_cjs29();
-    var ListBucketsCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
-      return [
-        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
-        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s346.getThrow200ExceptionsPlugin)(config)
-      ];
     }).s("AmazonS3", "ListBuckets", {}).n("S3Client", "ListBucketsCommand").f(void 0, void 0).ser(se_ListBucketsCommand).de(de_ListBucketsCommand).build() {
-      static {
-        __name(this, "ListBucketsCommand");
-      }
     };
-    var import_middleware_sdk_s347 = require_dist_cjs29();
-    var ListDirectoryBucketsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_ListBucketsCommand, "ListBucketsCommand");
+    var ListBucketsCommand = _ListBucketsCommand;
+    var import_middleware_sdk_s346 = require_dist_cjs29();
+    var _ListDirectoryBucketsCommand = class _ListDirectoryBucketsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true }
     }).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s347.getThrow200ExceptionsPlugin)(config)
+        (0, import_middleware_sdk_s346.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "ListDirectoryBuckets", {}).n("S3Client", "ListDirectoryBucketsCommand").f(void 0, void 0).ser(se_ListDirectoryBucketsCommand).de(de_ListDirectoryBucketsCommand).build() {
-      static {
-        __name(this, "ListDirectoryBucketsCommand");
-      }
     };
+    __name(_ListDirectoryBucketsCommand, "ListDirectoryBucketsCommand");
+    var ListDirectoryBucketsCommand = _ListDirectoryBucketsCommand;
+    var import_middleware_sdk_s347 = require_dist_cjs29();
+    var _ListMultipartUploadsCommand = class _ListMultipartUploadsCommand extends import_smithy_client4.Command.classBuilder().ep({
+      ...commonParams,
+      Bucket: { type: "contextParams", name: "Bucket" },
+      Prefix: { type: "contextParams", name: "Prefix" }
+    }).m(function(Command, cs, config, o) {
+      return [
+        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
+        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
+        (0, import_middleware_sdk_s347.getThrow200ExceptionsPlugin)(config)
+      ];
+    }).s("AmazonS3", "ListMultipartUploads", {}).n("S3Client", "ListMultipartUploadsCommand").f(void 0, void 0).ser(se_ListMultipartUploadsCommand).de(de_ListMultipartUploadsCommand).build() {
+    };
+    __name(_ListMultipartUploadsCommand, "ListMultipartUploadsCommand");
+    var ListMultipartUploadsCommand = _ListMultipartUploadsCommand;
     var import_middleware_sdk_s348 = require_dist_cjs29();
-    var ListMultipartUploadsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _ListObjectsCommand = class _ListObjectsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Prefix: { type: "contextParams", name: "Prefix" }
@@ -55974,13 +55564,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s348.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "ListMultipartUploads", {}).n("S3Client", "ListMultipartUploadsCommand").f(void 0, void 0).ser(se_ListMultipartUploadsCommand).de(de_ListMultipartUploadsCommand).build() {
-      static {
-        __name(this, "ListMultipartUploadsCommand");
-      }
+    }).s("AmazonS3", "ListObjects", {}).n("S3Client", "ListObjectsCommand").f(void 0, void 0).ser(se_ListObjectsCommand).de(de_ListObjectsCommand).build() {
     };
+    __name(_ListObjectsCommand, "ListObjectsCommand");
+    var ListObjectsCommand = _ListObjectsCommand;
     var import_middleware_sdk_s349 = require_dist_cjs29();
-    var ListObjectsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _ListObjectsV2Command = class _ListObjectsV2Command extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Prefix: { type: "contextParams", name: "Prefix" }
@@ -55990,13 +55579,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s349.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "ListObjects", {}).n("S3Client", "ListObjectsCommand").f(void 0, void 0).ser(se_ListObjectsCommand).de(de_ListObjectsCommand).build() {
-      static {
-        __name(this, "ListObjectsCommand");
-      }
+    }).s("AmazonS3", "ListObjectsV2", {}).n("S3Client", "ListObjectsV2Command").f(void 0, void 0).ser(se_ListObjectsV2Command).de(de_ListObjectsV2Command).build() {
     };
+    __name(_ListObjectsV2Command, "ListObjectsV2Command");
+    var ListObjectsV2Command = _ListObjectsV2Command;
     var import_middleware_sdk_s350 = require_dist_cjs29();
-    var ListObjectsV2Command = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _ListObjectVersionsCommand = class _ListObjectVersionsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Prefix: { type: "contextParams", name: "Prefix" }
@@ -56006,29 +55594,12 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_sdk_s350.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "ListObjectsV2", {}).n("S3Client", "ListObjectsV2Command").f(void 0, void 0).ser(se_ListObjectsV2Command).de(de_ListObjectsV2Command).build() {
-      static {
-        __name(this, "ListObjectsV2Command");
-      }
-    };
-    var import_middleware_sdk_s351 = require_dist_cjs29();
-    var ListObjectVersionsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
-      ...commonParams,
-      Bucket: { type: "contextParams", name: "Bucket" },
-      Prefix: { type: "contextParams", name: "Prefix" }
-    }).m(function(Command, cs, config, o) {
-      return [
-        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
-        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s351.getThrow200ExceptionsPlugin)(config)
-      ];
     }).s("AmazonS3", "ListObjectVersions", {}).n("S3Client", "ListObjectVersionsCommand").f(void 0, void 0).ser(se_ListObjectVersionsCommand).de(de_ListObjectVersionsCommand).build() {
-      static {
-        __name(this, "ListObjectVersionsCommand");
-      }
     };
-    var import_middleware_sdk_s352 = require_dist_cjs29();
-    var ListPartsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_ListObjectVersionsCommand, "ListObjectVersionsCommand");
+    var ListObjectVersionsCommand = _ListObjectVersionsCommand;
+    var import_middleware_sdk_s351 = require_dist_cjs29();
+    var _ListPartsCommand = class _ListPartsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -56036,15 +55607,14 @@ var require_dist_cjs71 = __commonJS({
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s352.getThrow200ExceptionsPlugin)(config),
+        (0, import_middleware_sdk_s351.getThrow200ExceptionsPlugin)(config),
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "ListParts", {}).n("S3Client", "ListPartsCommand").f(ListPartsRequestFilterSensitiveLog, void 0).ser(se_ListPartsCommand).de(de_ListPartsCommand).build() {
-      static {
-        __name(this, "ListPartsCommand");
-      }
     };
-    var PutBucketAccelerateConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_ListPartsCommand, "ListPartsCommand");
+    var ListPartsCommand = _ListPartsCommand;
+    var _PutBucketAccelerateConfigurationCommand = class _PutBucketAccelerateConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56053,16 +55623,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: false
         })
       ];
     }).s("AmazonS3", "PutBucketAccelerateConfiguration", {}).n("S3Client", "PutBucketAccelerateConfigurationCommand").f(void 0, void 0).ser(se_PutBucketAccelerateConfigurationCommand).de(de_PutBucketAccelerateConfigurationCommand).build() {
-      static {
-        __name(this, "PutBucketAccelerateConfigurationCommand");
-      }
     };
-    var PutBucketAclCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketAccelerateConfigurationCommand, "PutBucketAccelerateConfigurationCommand");
+    var PutBucketAccelerateConfigurationCommand = _PutBucketAccelerateConfigurationCommand;
+    var _PutBucketAclCommand = class _PutBucketAclCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56071,16 +55641,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketAcl", {}).n("S3Client", "PutBucketAclCommand").f(void 0, void 0).ser(se_PutBucketAclCommand).de(de_PutBucketAclCommand).build() {
-      static {
-        __name(this, "PutBucketAclCommand");
-      }
     };
-    var PutBucketAnalyticsConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketAclCommand, "PutBucketAclCommand");
+    var PutBucketAclCommand = _PutBucketAclCommand;
+    var _PutBucketAnalyticsConfigurationCommand = class _PutBucketAnalyticsConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56090,11 +55660,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "PutBucketAnalyticsConfiguration", {}).n("S3Client", "PutBucketAnalyticsConfigurationCommand").f(void 0, void 0).ser(se_PutBucketAnalyticsConfigurationCommand).de(de_PutBucketAnalyticsConfigurationCommand).build() {
-      static {
-        __name(this, "PutBucketAnalyticsConfigurationCommand");
-      }
     };
-    var PutBucketCorsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketAnalyticsConfigurationCommand, "PutBucketAnalyticsConfigurationCommand");
+    var PutBucketAnalyticsConfigurationCommand = _PutBucketAnalyticsConfigurationCommand;
+    var _PutBucketCorsCommand = class _PutBucketCorsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56103,16 +55672,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketCors", {}).n("S3Client", "PutBucketCorsCommand").f(void 0, void 0).ser(se_PutBucketCorsCommand).de(de_PutBucketCorsCommand).build() {
-      static {
-        __name(this, "PutBucketCorsCommand");
-      }
     };
-    var PutBucketEncryptionCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketCorsCommand, "PutBucketCorsCommand");
+    var PutBucketCorsCommand = _PutBucketCorsCommand;
+    var _PutBucketEncryptionCommand = class _PutBucketEncryptionCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56121,16 +55690,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketEncryption", {}).n("S3Client", "PutBucketEncryptionCommand").f(PutBucketEncryptionRequestFilterSensitiveLog, void 0).ser(se_PutBucketEncryptionCommand).de(de_PutBucketEncryptionCommand).build() {
-      static {
-        __name(this, "PutBucketEncryptionCommand");
-      }
     };
-    var PutBucketIntelligentTieringConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketEncryptionCommand, "PutBucketEncryptionCommand");
+    var PutBucketEncryptionCommand = _PutBucketEncryptionCommand;
+    var _PutBucketIntelligentTieringConfigurationCommand = class _PutBucketIntelligentTieringConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56140,11 +55709,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "PutBucketIntelligentTieringConfiguration", {}).n("S3Client", "PutBucketIntelligentTieringConfigurationCommand").f(void 0, void 0).ser(se_PutBucketIntelligentTieringConfigurationCommand).de(de_PutBucketIntelligentTieringConfigurationCommand).build() {
-      static {
-        __name(this, "PutBucketIntelligentTieringConfigurationCommand");
-      }
     };
-    var PutBucketInventoryConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketIntelligentTieringConfigurationCommand, "PutBucketIntelligentTieringConfigurationCommand");
+    var PutBucketIntelligentTieringConfigurationCommand = _PutBucketIntelligentTieringConfigurationCommand;
+    var _PutBucketInventoryConfigurationCommand = class _PutBucketInventoryConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56154,12 +55722,11 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "PutBucketInventoryConfiguration", {}).n("S3Client", "PutBucketInventoryConfigurationCommand").f(PutBucketInventoryConfigurationRequestFilterSensitiveLog, void 0).ser(se_PutBucketInventoryConfigurationCommand).de(de_PutBucketInventoryConfigurationCommand).build() {
-      static {
-        __name(this, "PutBucketInventoryConfigurationCommand");
-      }
     };
-    var import_middleware_sdk_s353 = require_dist_cjs29();
-    var PutBucketLifecycleConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketInventoryConfigurationCommand, "PutBucketInventoryConfigurationCommand");
+    var PutBucketInventoryConfigurationCommand = _PutBucketInventoryConfigurationCommand;
+    var import_middleware_sdk_s352 = require_dist_cjs29();
+    var _PutBucketLifecycleConfigurationCommand = class _PutBucketLifecycleConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56168,17 +55735,17 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         }),
-        (0, import_middleware_sdk_s353.getThrow200ExceptionsPlugin)(config)
+        (0, import_middleware_sdk_s352.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "PutBucketLifecycleConfiguration", {}).n("S3Client", "PutBucketLifecycleConfigurationCommand").f(void 0, void 0).ser(se_PutBucketLifecycleConfigurationCommand).de(de_PutBucketLifecycleConfigurationCommand).build() {
-      static {
-        __name(this, "PutBucketLifecycleConfigurationCommand");
-      }
     };
-    var PutBucketLoggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketLifecycleConfigurationCommand, "PutBucketLifecycleConfigurationCommand");
+    var PutBucketLifecycleConfigurationCommand = _PutBucketLifecycleConfigurationCommand;
+    var _PutBucketLoggingCommand = class _PutBucketLoggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56187,16 +55754,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketLogging", {}).n("S3Client", "PutBucketLoggingCommand").f(void 0, void 0).ser(se_PutBucketLoggingCommand).de(de_PutBucketLoggingCommand).build() {
-      static {
-        __name(this, "PutBucketLoggingCommand");
-      }
     };
-    var PutBucketMetricsConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketLoggingCommand, "PutBucketLoggingCommand");
+    var PutBucketLoggingCommand = _PutBucketLoggingCommand;
+    var _PutBucketMetricsConfigurationCommand = class _PutBucketMetricsConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56206,11 +55773,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "PutBucketMetricsConfiguration", {}).n("S3Client", "PutBucketMetricsConfigurationCommand").f(void 0, void 0).ser(se_PutBucketMetricsConfigurationCommand).de(de_PutBucketMetricsConfigurationCommand).build() {
-      static {
-        __name(this, "PutBucketMetricsConfigurationCommand");
-      }
     };
-    var PutBucketNotificationConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketMetricsConfigurationCommand, "PutBucketMetricsConfigurationCommand");
+    var PutBucketMetricsConfigurationCommand = _PutBucketMetricsConfigurationCommand;
+    var _PutBucketNotificationConfigurationCommand = class _PutBucketNotificationConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56220,11 +55786,10 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "PutBucketNotificationConfiguration", {}).n("S3Client", "PutBucketNotificationConfigurationCommand").f(void 0, void 0).ser(se_PutBucketNotificationConfigurationCommand).de(de_PutBucketNotificationConfigurationCommand).build() {
-      static {
-        __name(this, "PutBucketNotificationConfigurationCommand");
-      }
     };
-    var PutBucketOwnershipControlsCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketNotificationConfigurationCommand, "PutBucketNotificationConfigurationCommand");
+    var PutBucketNotificationConfigurationCommand = _PutBucketNotificationConfigurationCommand;
+    var _PutBucketOwnershipControlsCommand = class _PutBucketOwnershipControlsCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56237,11 +55802,10 @@ var require_dist_cjs71 = __commonJS({
         })
       ];
     }).s("AmazonS3", "PutBucketOwnershipControls", {}).n("S3Client", "PutBucketOwnershipControlsCommand").f(void 0, void 0).ser(se_PutBucketOwnershipControlsCommand).de(de_PutBucketOwnershipControlsCommand).build() {
-      static {
-        __name(this, "PutBucketOwnershipControlsCommand");
-      }
     };
-    var PutBucketPolicyCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketOwnershipControlsCommand, "PutBucketOwnershipControlsCommand");
+    var PutBucketOwnershipControlsCommand = _PutBucketOwnershipControlsCommand;
+    var _PutBucketPolicyCommand = class _PutBucketPolicyCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56250,16 +55814,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketPolicy", {}).n("S3Client", "PutBucketPolicyCommand").f(void 0, void 0).ser(se_PutBucketPolicyCommand).de(de_PutBucketPolicyCommand).build() {
-      static {
-        __name(this, "PutBucketPolicyCommand");
-      }
     };
-    var PutBucketReplicationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketPolicyCommand, "PutBucketPolicyCommand");
+    var PutBucketPolicyCommand = _PutBucketPolicyCommand;
+    var _PutBucketReplicationCommand = class _PutBucketReplicationCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56268,16 +55832,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketReplication", {}).n("S3Client", "PutBucketReplicationCommand").f(void 0, void 0).ser(se_PutBucketReplicationCommand).de(de_PutBucketReplicationCommand).build() {
-      static {
-        __name(this, "PutBucketReplicationCommand");
-      }
     };
-    var PutBucketRequestPaymentCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketReplicationCommand, "PutBucketReplicationCommand");
+    var PutBucketReplicationCommand = _PutBucketReplicationCommand;
+    var _PutBucketRequestPaymentCommand = class _PutBucketRequestPaymentCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56286,16 +55850,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketRequestPayment", {}).n("S3Client", "PutBucketRequestPaymentCommand").f(void 0, void 0).ser(se_PutBucketRequestPaymentCommand).de(de_PutBucketRequestPaymentCommand).build() {
-      static {
-        __name(this, "PutBucketRequestPaymentCommand");
-      }
     };
-    var PutBucketTaggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketRequestPaymentCommand, "PutBucketRequestPaymentCommand");
+    var PutBucketRequestPaymentCommand = _PutBucketRequestPaymentCommand;
+    var _PutBucketTaggingCommand = class _PutBucketTaggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56304,16 +55868,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketTagging", {}).n("S3Client", "PutBucketTaggingCommand").f(void 0, void 0).ser(se_PutBucketTaggingCommand).de(de_PutBucketTaggingCommand).build() {
-      static {
-        __name(this, "PutBucketTaggingCommand");
-      }
     };
-    var PutBucketVersioningCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketTaggingCommand, "PutBucketTaggingCommand");
+    var PutBucketTaggingCommand = _PutBucketTaggingCommand;
+    var _PutBucketVersioningCommand = class _PutBucketVersioningCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56322,16 +55886,16 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketVersioning", {}).n("S3Client", "PutBucketVersioningCommand").f(void 0, void 0).ser(se_PutBucketVersioningCommand).de(de_PutBucketVersioningCommand).build() {
-      static {
-        __name(this, "PutBucketVersioningCommand");
-      }
     };
-    var PutBucketWebsiteCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketVersioningCommand, "PutBucketVersioningCommand");
+    var PutBucketVersioningCommand = _PutBucketVersioningCommand;
+    var _PutBucketWebsiteCommand = class _PutBucketWebsiteCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56340,17 +55904,17 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutBucketWebsite", {}).n("S3Client", "PutBucketWebsiteCommand").f(void 0, void 0).ser(se_PutBucketWebsiteCommand).de(de_PutBucketWebsiteCommand).build() {
-      static {
-        __name(this, "PutBucketWebsiteCommand");
-      }
     };
-    var import_middleware_sdk_s354 = require_dist_cjs29();
-    var PutObjectAclCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutBucketWebsiteCommand, "PutBucketWebsiteCommand");
+    var PutBucketWebsiteCommand = _PutBucketWebsiteCommand;
+    var import_middleware_sdk_s353 = require_dist_cjs29();
+    var _PutObjectAclCommand = class _PutObjectAclCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -56359,18 +55923,18 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         }),
-        (0, import_middleware_sdk_s354.getThrow200ExceptionsPlugin)(config)
+        (0, import_middleware_sdk_s353.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "PutObjectAcl", {}).n("S3Client", "PutObjectAclCommand").f(void 0, void 0).ser(se_PutObjectAclCommand).de(de_PutObjectAclCommand).build() {
-      static {
-        __name(this, "PutObjectAclCommand");
-      }
     };
-    var import_middleware_sdk_s355 = require_dist_cjs29();
-    var PutObjectCommand2 = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutObjectAclCommand, "PutObjectAclCommand");
+    var PutObjectAclCommand = _PutObjectAclCommand;
+    var import_middleware_sdk_s354 = require_dist_cjs29();
+    var _PutObjectCommand = class _PutObjectCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -56379,20 +55943,20 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: false
         }),
-        (0, import_middleware_sdk_s355.getCheckContentLengthHeaderPlugin)(config),
-        (0, import_middleware_sdk_s355.getThrow200ExceptionsPlugin)(config),
+        (0, import_middleware_sdk_s354.getCheckContentLengthHeaderPlugin)(config),
+        (0, import_middleware_sdk_s354.getThrow200ExceptionsPlugin)(config),
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "PutObject", {}).n("S3Client", "PutObjectCommand").f(PutObjectRequestFilterSensitiveLog, PutObjectOutputFilterSensitiveLog).ser(se_PutObjectCommand).de(de_PutObjectCommand).build() {
-      static {
-        __name(this, "PutObjectCommand");
-      }
     };
-    var import_middleware_sdk_s356 = require_dist_cjs29();
-    var PutObjectLegalHoldCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutObjectCommand, "PutObjectCommand");
+    var PutObjectCommand2 = _PutObjectCommand;
+    var import_middleware_sdk_s355 = require_dist_cjs29();
+    var _PutObjectLegalHoldCommand = class _PutObjectLegalHoldCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -56400,18 +55964,37 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
+          requestChecksumRequired: true
+        }),
+        (0, import_middleware_sdk_s355.getThrow200ExceptionsPlugin)(config)
+      ];
+    }).s("AmazonS3", "PutObjectLegalHold", {}).n("S3Client", "PutObjectLegalHoldCommand").f(void 0, void 0).ser(se_PutObjectLegalHoldCommand).de(de_PutObjectLegalHoldCommand).build() {
+    };
+    __name(_PutObjectLegalHoldCommand, "PutObjectLegalHoldCommand");
+    var PutObjectLegalHoldCommand = _PutObjectLegalHoldCommand;
+    var import_middleware_sdk_s356 = require_dist_cjs29();
+    var _PutObjectLockConfigurationCommand = class _PutObjectLockConfigurationCommand extends import_smithy_client4.Command.classBuilder().ep({
+      ...commonParams,
+      Bucket: { type: "contextParams", name: "Bucket" }
+    }).m(function(Command, cs, config, o) {
+      return [
+        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
+        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
+        (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         }),
         (0, import_middleware_sdk_s356.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "PutObjectLegalHold", {}).n("S3Client", "PutObjectLegalHoldCommand").f(void 0, void 0).ser(se_PutObjectLegalHoldCommand).de(de_PutObjectLegalHoldCommand).build() {
-      static {
-        __name(this, "PutObjectLegalHoldCommand");
-      }
+    }).s("AmazonS3", "PutObjectLockConfiguration", {}).n("S3Client", "PutObjectLockConfigurationCommand").f(void 0, void 0).ser(se_PutObjectLockConfigurationCommand).de(de_PutObjectLockConfigurationCommand).build() {
     };
+    __name(_PutObjectLockConfigurationCommand, "PutObjectLockConfigurationCommand");
+    var PutObjectLockConfigurationCommand = _PutObjectLockConfigurationCommand;
     var import_middleware_sdk_s357 = require_dist_cjs29();
-    var PutObjectLockConfigurationCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _PutObjectRetentionCommand = class _PutObjectRetentionCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -56419,18 +56002,18 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         }),
         (0, import_middleware_sdk_s357.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "PutObjectLockConfiguration", {}).n("S3Client", "PutObjectLockConfigurationCommand").f(void 0, void 0).ser(se_PutObjectLockConfigurationCommand).de(de_PutObjectLockConfigurationCommand).build() {
-      static {
-        __name(this, "PutObjectLockConfigurationCommand");
-      }
+    }).s("AmazonS3", "PutObjectRetention", {}).n("S3Client", "PutObjectRetentionCommand").f(void 0, void 0).ser(se_PutObjectRetentionCommand).de(de_PutObjectRetentionCommand).build() {
     };
+    __name(_PutObjectRetentionCommand, "PutObjectRetentionCommand");
+    var PutObjectRetentionCommand = _PutObjectRetentionCommand;
     var import_middleware_sdk_s358 = require_dist_cjs29();
-    var PutObjectRetentionCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    var _PutObjectTaggingCommand = class _PutObjectTaggingCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -56438,36 +56021,17 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         }),
         (0, import_middleware_sdk_s358.getThrow200ExceptionsPlugin)(config)
       ];
-    }).s("AmazonS3", "PutObjectRetention", {}).n("S3Client", "PutObjectRetentionCommand").f(void 0, void 0).ser(se_PutObjectRetentionCommand).de(de_PutObjectRetentionCommand).build() {
-      static {
-        __name(this, "PutObjectRetentionCommand");
-      }
-    };
-    var import_middleware_sdk_s359 = require_dist_cjs29();
-    var PutObjectTaggingCommand = class extends import_smithy_client4.Command.classBuilder().ep({
-      ...commonParams,
-      Bucket: { type: "contextParams", name: "Bucket" }
-    }).m(function(Command, cs, config, o) {
-      return [
-        (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
-        (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
-          requestChecksumRequired: true
-        }),
-        (0, import_middleware_sdk_s359.getThrow200ExceptionsPlugin)(config)
-      ];
     }).s("AmazonS3", "PutObjectTagging", {}).n("S3Client", "PutObjectTaggingCommand").f(void 0, void 0).ser(se_PutObjectTaggingCommand).de(de_PutObjectTaggingCommand).build() {
-      static {
-        __name(this, "PutObjectTaggingCommand");
-      }
     };
-    var PutPublicAccessBlockCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutObjectTaggingCommand, "PutObjectTaggingCommand");
+    var PutObjectTaggingCommand = _PutObjectTaggingCommand;
+    var _PutPublicAccessBlockCommand = class _PutPublicAccessBlockCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseS3ExpressControlEndpoint: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56476,17 +56040,17 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: true
         })
       ];
     }).s("AmazonS3", "PutPublicAccessBlock", {}).n("S3Client", "PutPublicAccessBlockCommand").f(void 0, void 0).ser(se_PutPublicAccessBlockCommand).de(de_PutPublicAccessBlockCommand).build() {
-      static {
-        __name(this, "PutPublicAccessBlockCommand");
-      }
     };
-    var import_middleware_sdk_s360 = require_dist_cjs29();
-    var RestoreObjectCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_PutPublicAccessBlockCommand, "PutPublicAccessBlockCommand");
+    var PutPublicAccessBlockCommand = _PutPublicAccessBlockCommand;
+    var import_middleware_sdk_s359 = require_dist_cjs29();
+    var _RestoreObjectCommand = class _RestoreObjectCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
@@ -56494,25 +56058,25 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: false
         }),
-        (0, import_middleware_sdk_s360.getThrow200ExceptionsPlugin)(config)
+        (0, import_middleware_sdk_s359.getThrow200ExceptionsPlugin)(config)
       ];
     }).s("AmazonS3", "RestoreObject", {}).n("S3Client", "RestoreObjectCommand").f(RestoreObjectRequestFilterSensitiveLog, void 0).ser(se_RestoreObjectCommand).de(de_RestoreObjectCommand).build() {
-      static {
-        __name(this, "RestoreObjectCommand");
-      }
     };
-    var import_middleware_sdk_s361 = require_dist_cjs29();
-    var SelectObjectContentCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_RestoreObjectCommand, "RestoreObjectCommand");
+    var RestoreObjectCommand = _RestoreObjectCommand;
+    var import_middleware_sdk_s360 = require_dist_cjs29();
+    var _SelectObjectContentCommand = class _SelectObjectContentCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" }
     }).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s361.getThrow200ExceptionsPlugin)(config),
+        (0, import_middleware_sdk_s360.getThrow200ExceptionsPlugin)(config),
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "SelectObjectContent", {
@@ -56523,12 +56087,11 @@ var require_dist_cjs71 = __commonJS({
         output: true
       }
     }).n("S3Client", "SelectObjectContentCommand").f(SelectObjectContentRequestFilterSensitiveLog, SelectObjectContentOutputFilterSensitiveLog).ser(se_SelectObjectContentCommand).de(de_SelectObjectContentCommand).build() {
-      static {
-        __name(this, "SelectObjectContentCommand");
-      }
     };
-    var import_middleware_sdk_s362 = require_dist_cjs29();
-    var UploadPartCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_SelectObjectContentCommand, "SelectObjectContentCommand");
+    var SelectObjectContentCommand = _SelectObjectContentCommand;
+    var import_middleware_sdk_s361 = require_dist_cjs29();
+    var _UploadPartCommand = class _UploadPartCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -56537,19 +56100,19 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
         (0, import_middleware_flexible_checksums.getFlexibleChecksumsPlugin)(config, {
-          requestAlgorithmMember: { httpHeader: "x-amz-sdk-checksum-algorithm", name: "ChecksumAlgorithm" },
+          requestAlgorithmMember: "ChecksumAlgorithm",
+          requestAlgorithmMemberHttpHeader: "x-amz-sdk-checksum-algorithm",
           requestChecksumRequired: false
         }),
-        (0, import_middleware_sdk_s362.getThrow200ExceptionsPlugin)(config),
+        (0, import_middleware_sdk_s361.getThrow200ExceptionsPlugin)(config),
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "UploadPart", {}).n("S3Client", "UploadPartCommand").f(UploadPartRequestFilterSensitiveLog, UploadPartOutputFilterSensitiveLog).ser(se_UploadPartCommand).de(de_UploadPartCommand).build() {
-      static {
-        __name(this, "UploadPartCommand");
-      }
     };
-    var import_middleware_sdk_s363 = require_dist_cjs29();
-    var UploadPartCopyCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_UploadPartCommand, "UploadPartCommand");
+    var UploadPartCommand = _UploadPartCommand;
+    var import_middleware_sdk_s362 = require_dist_cjs29();
+    var _UploadPartCopyCommand = class _UploadPartCopyCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       DisableS3ExpressSessionAuth: { type: "staticContextParams", value: true },
       Bucket: { type: "contextParams", name: "Bucket" }
@@ -56557,15 +56120,14 @@ var require_dist_cjs71 = __commonJS({
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions()),
-        (0, import_middleware_sdk_s363.getThrow200ExceptionsPlugin)(config),
+        (0, import_middleware_sdk_s362.getThrow200ExceptionsPlugin)(config),
         (0, import_middleware_ssec.getSsecPlugin)(config)
       ];
     }).s("AmazonS3", "UploadPartCopy", {}).n("S3Client", "UploadPartCopyCommand").f(UploadPartCopyRequestFilterSensitiveLog, UploadPartCopyOutputFilterSensitiveLog).ser(se_UploadPartCopyCommand).de(de_UploadPartCopyCommand).build() {
-      static {
-        __name(this, "UploadPartCopyCommand");
-      }
     };
-    var WriteGetObjectResponseCommand = class extends import_smithy_client4.Command.classBuilder().ep({
+    __name(_UploadPartCopyCommand, "UploadPartCopyCommand");
+    var UploadPartCopyCommand = _UploadPartCopyCommand;
+    var _WriteGetObjectResponseCommand = class _WriteGetObjectResponseCommand extends import_smithy_client4.Command.classBuilder().ep({
       ...commonParams,
       UseObjectLambdaEndpoint: { type: "staticContextParams", value: true }
     }).m(function(Command, cs, config, o) {
@@ -56574,16 +56136,14 @@ var require_dist_cjs71 = __commonJS({
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AmazonS3", "WriteGetObjectResponse", {}).n("S3Client", "WriteGetObjectResponseCommand").f(WriteGetObjectResponseRequestFilterSensitiveLog, void 0).ser(se_WriteGetObjectResponseCommand).de(de_WriteGetObjectResponseCommand).build() {
-      static {
-        __name(this, "WriteGetObjectResponseCommand");
-      }
     };
+    __name(_WriteGetObjectResponseCommand, "WriteGetObjectResponseCommand");
+    var WriteGetObjectResponseCommand = _WriteGetObjectResponseCommand;
     var commands = {
       AbortMultipartUploadCommand,
       CompleteMultipartUploadCommand,
       CopyObjectCommand,
       CreateBucketCommand,
-      CreateBucketMetadataTableConfigurationCommand,
       CreateMultipartUploadCommand,
       CreateSessionCommand,
       DeleteBucketCommand,
@@ -56593,7 +56153,6 @@ var require_dist_cjs71 = __commonJS({
       DeleteBucketIntelligentTieringConfigurationCommand,
       DeleteBucketInventoryConfigurationCommand,
       DeleteBucketLifecycleCommand,
-      DeleteBucketMetadataTableConfigurationCommand,
       DeleteBucketMetricsConfigurationCommand,
       DeleteBucketOwnershipControlsCommand,
       DeleteBucketPolicyCommand,
@@ -56614,7 +56173,6 @@ var require_dist_cjs71 = __commonJS({
       GetBucketLifecycleConfigurationCommand,
       GetBucketLocationCommand,
       GetBucketLoggingCommand,
-      GetBucketMetadataTableConfigurationCommand,
       GetBucketMetricsConfigurationCommand,
       GetBucketNotificationConfigurationCommand,
       GetBucketOwnershipControlsCommand,
@@ -56678,11 +56236,10 @@ var require_dist_cjs71 = __commonJS({
       UploadPartCopyCommand,
       WriteGetObjectResponseCommand
     };
-    var S3 = class extends S3Client2 {
-      static {
-        __name(this, "S3");
-      }
+    var _S3 = class _S3 extends S3Client2 {
     };
+    __name(_S3, "S3");
+    var S3 = _S3;
     (0, import_smithy_client4.createAggregatedClient)(commands, S3);
     var import_core42 = (init_dist_es(), __toCommonJS(dist_es_exports));
     var paginateListBuckets = (0, import_core42.createPaginator)(S3Client2, ListBucketsCommand, "ContinuationToken", "ContinuationToken", "MaxBuckets");
@@ -56791,12 +56348,12 @@ var require_createCredentialChain = __commonJS({
   "node_modules/@aws-sdk/credential-providers/dist-cjs/createCredentialChain.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    exports2.propertyProviderChain = exports2.createCredentialChain = void 0;
+    exports2.createCredentialChain = void 0;
     var property_provider_1 = require_dist_cjs16();
     var createCredentialChain = (...credentialProviders) => {
       let expireAfter = -1;
-      const baseFunction = async (awsIdentityProperties) => {
-        const credentials = await (0, exports2.propertyProviderChain)(...credentialProviders)(awsIdentityProperties);
+      const baseFunction = async () => {
+        const credentials = await (0, property_provider_1.chain)(...credentialProviders)();
         if (!credentials.expiration && expireAfter !== -1) {
           credentials.expiration = new Date(Date.now() + expireAfter);
         }
@@ -56814,26 +56371,6 @@ var require_createCredentialChain = __commonJS({
       return withOptions;
     };
     exports2.createCredentialChain = createCredentialChain;
-    var propertyProviderChain = (...providers) => async (awsIdentityProperties) => {
-      if (providers.length === 0) {
-        throw new property_provider_1.ProviderError("No providers in chain");
-      }
-      let lastProviderError;
-      for (const provider of providers) {
-        try {
-          const credentials = await provider(awsIdentityProperties);
-          return credentials;
-        } catch (err) {
-          lastProviderError = err;
-          if (err?.tryNextLink) {
-            continue;
-          }
-          throw err;
-        }
-      }
-      throw lastProviderError;
-    };
-    exports2.propertyProviderChain = propertyProviderChain;
   }
 });
 
@@ -56916,7 +56453,7 @@ var require_package5 = __commonJS({
     module2.exports = {
       name: "@aws-sdk/client-cognito-identity",
       description: "AWS SDK for JavaScript Cognito Identity Client for Node.js, Browser and React Native",
-      version: "3.723.0",
+      version: "3.699.0",
       scripts: {
         build: "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
         "build:cjs": "node ../../scripts/compilation/inline client-cognito-identity",
@@ -56937,58 +56474,58 @@ var require_package5 = __commonJS({
       dependencies: {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.723.0",
-        "@aws-sdk/client-sts": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/client-sts": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         tslib: "^2.6.2"
       },
       devDependencies: {
-        "@aws-sdk/client-iam": "3.723.0",
-        "@tsconfig/node18": "18.2.4",
+        "@aws-sdk/client-iam": "3.699.0",
+        "@tsconfig/node16": "16.1.3",
         "@types/chai": "^4.2.11",
-        "@types/node": "^18.19.69",
+        "@types/node": "^16.18.96",
         concurrently: "7.0.0",
         "downlevel-dts": "0.10.1",
         rimraf: "3.0.2",
-        typescript: "~5.2.2"
+        typescript: "~4.9.5"
       },
       engines: {
-        node: ">=18.0.0"
+        node: ">=16.0.0"
       },
       typesVersions: {
         "<4.0": {
@@ -57152,7 +56689,6 @@ var require_runtimeConfig5 = __commonJS({
       const defaultConfigProvider = () => defaultsMode().then(smithy_client_1.loadConfigsForDefaultMode);
       const clientSharedValues = (0, runtimeConfig_shared_1.getRuntimeConfig)(config);
       (0, core_1.emitWarningIfUnsupportedVersion)(process.version);
-      const profileConfig = { profile: config?.profile };
       return {
         ...clientSharedValues,
         ...config,
@@ -57161,18 +56697,18 @@ var require_runtimeConfig5 = __commonJS({
         bodyLengthChecker: config?.bodyLengthChecker ?? util_body_length_node_1.calculateBodyLength,
         credentialDefaultProvider: config?.credentialDefaultProvider ?? credential_provider_node_1.defaultProvider,
         defaultUserAgentProvider: config?.defaultUserAgentProvider ?? (0, util_user_agent_node_1.createDefaultUserAgentProvider)({ serviceId: clientSharedValues.serviceId, clientVersion: package_json_1.default.version }),
-        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS, config),
-        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, { ...config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS, ...profileConfig }),
+        maxAttempts: config?.maxAttempts ?? (0, node_config_provider_1.loadConfig)(middleware_retry_1.NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
+        region: config?.region ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_REGION_CONFIG_OPTIONS, config_resolver_1.NODE_REGION_CONFIG_FILE_OPTIONS),
         requestHandler: node_http_handler_1.NodeHttpHandler.create(config?.requestHandler ?? defaultConfigProvider),
         retryMode: config?.retryMode ?? (0, node_config_provider_1.loadConfig)({
           ...middleware_retry_1.NODE_RETRY_MODE_CONFIG_OPTIONS,
           default: async () => (await defaultConfigProvider()).retryMode || util_retry_1.DEFAULT_RETRY_MODE
-        }, config),
+        }),
         sha256: config?.sha256 ?? hash_node_1.Hash.bind(null, "sha256"),
         streamCollector: config?.streamCollector ?? node_http_handler_1.streamCollector,
-        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS, profileConfig),
-        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS, profileConfig)
+        useDualstackEndpoint: config?.useDualstackEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),
+        useFipsEndpoint: config?.useFipsEndpoint ?? (0, node_config_provider_1.loadConfig)(config_resolver_1.NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS),
+        userAgentAppId: config?.userAgentAppId ?? (0, node_config_provider_1.loadConfig)(util_user_agent_node_1.NODE_APP_ID_CONFIG_OPTIONS)
       };
     };
     exports2.getRuntimeConfig = getRuntimeConfig;
@@ -57339,14 +56875,7 @@ var require_dist_cjs72 = __commonJS({
         ...resolveHttpAuthRuntimeConfig(extensionConfiguration)
       };
     }, "resolveRuntimeExtensions");
-    var CognitoIdentityClient = class extends import_smithy_client4.Client {
-      static {
-        __name(this, "CognitoIdentityClient");
-      }
-      /**
-       * The resolved configuration of CognitoIdentityClient class. This is resolved and normalized from the {@link CognitoIdentityClientConfig | constructor configuration interface}.
-       */
-      config;
+    var _CognitoIdentityClient = class _CognitoIdentityClient extends import_smithy_client4.Client {
       constructor(...[configuration]) {
         const _config_0 = (0, import_runtimeConfig.getRuntimeConfig)(configuration || {});
         const _config_1 = resolveClientEndpointParameters(_config_0);
@@ -57356,7 +56885,7 @@ var require_dist_cjs72 = __commonJS({
         const _config_5 = (0, import_middleware_host_header.resolveHostHeaderConfig)(_config_4);
         const _config_6 = (0, import_middleware_endpoint.resolveEndpointConfig)(_config_5);
         const _config_7 = (0, import_httpAuthSchemeProvider.resolveHttpAuthSchemeConfig)(_config_6);
-        const _config_8 = resolveRuntimeExtensions(_config_7, configuration?.extensions || []);
+        const _config_8 = resolveRuntimeExtensions(_config_7, (configuration == null ? void 0 : configuration.extensions) || []);
         super(_config_8);
         this.config = _config_8;
         this.middlewareStack.use((0, import_middleware_user_agent.getUserAgentPlugin)(this.config));
@@ -57384,30 +56913,26 @@ var require_dist_cjs72 = __commonJS({
         super.destroy();
       }
     };
+    __name(_CognitoIdentityClient, "CognitoIdentityClient");
+    var CognitoIdentityClient = _CognitoIdentityClient;
     var import_middleware_serde2 = require_dist_cjs5();
     var import_core22 = (init_dist_es2(), __toCommonJS(dist_es_exports2));
-    var CognitoIdentityServiceException = class _CognitoIdentityServiceException extends import_smithy_client4.ServiceException {
-      static {
-        __name(this, "CognitoIdentityServiceException");
-      }
+    var _CognitoIdentityServiceException = class _CognitoIdentityServiceException2 extends import_smithy_client4.ServiceException {
       /**
        * @internal
        */
       constructor(options) {
         super(options);
-        Object.setPrototypeOf(this, _CognitoIdentityServiceException.prototype);
+        Object.setPrototypeOf(this, _CognitoIdentityServiceException2.prototype);
       }
     };
+    __name(_CognitoIdentityServiceException, "CognitoIdentityServiceException");
+    var CognitoIdentityServiceException = _CognitoIdentityServiceException;
     var AmbiguousRoleResolutionType = {
       AUTHENTICATED_ROLE: "AuthenticatedRole",
       DENY: "Deny"
     };
-    var InternalErrorException = class _InternalErrorException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "InternalErrorException");
-      }
-      name = "InternalErrorException";
-      $fault = "server";
+    var _InternalErrorException = class _InternalErrorException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57417,15 +56942,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "server",
           ...opts
         });
-        Object.setPrototypeOf(this, _InternalErrorException.prototype);
+        this.name = "InternalErrorException";
+        this.$fault = "server";
+        Object.setPrototypeOf(this, _InternalErrorException2.prototype);
       }
     };
-    var InvalidParameterException = class _InvalidParameterException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "InvalidParameterException");
-      }
-      name = "InvalidParameterException";
-      $fault = "client";
+    __name(_InternalErrorException, "InternalErrorException");
+    var InternalErrorException = _InternalErrorException;
+    var _InvalidParameterException = class _InvalidParameterException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57435,15 +56959,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidParameterException.prototype);
+        this.name = "InvalidParameterException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidParameterException2.prototype);
       }
     };
-    var LimitExceededException = class _LimitExceededException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "LimitExceededException");
-      }
-      name = "LimitExceededException";
-      $fault = "client";
+    __name(_InvalidParameterException, "InvalidParameterException");
+    var InvalidParameterException = _InvalidParameterException;
+    var _LimitExceededException = class _LimitExceededException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57453,15 +56976,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _LimitExceededException.prototype);
+        this.name = "LimitExceededException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _LimitExceededException2.prototype);
       }
     };
-    var NotAuthorizedException = class _NotAuthorizedException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "NotAuthorizedException");
-      }
-      name = "NotAuthorizedException";
-      $fault = "client";
+    __name(_LimitExceededException, "LimitExceededException");
+    var LimitExceededException = _LimitExceededException;
+    var _NotAuthorizedException = class _NotAuthorizedException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57471,15 +56993,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _NotAuthorizedException.prototype);
+        this.name = "NotAuthorizedException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _NotAuthorizedException2.prototype);
       }
     };
-    var ResourceConflictException = class _ResourceConflictException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "ResourceConflictException");
-      }
-      name = "ResourceConflictException";
-      $fault = "client";
+    __name(_NotAuthorizedException, "NotAuthorizedException");
+    var NotAuthorizedException = _NotAuthorizedException;
+    var _ResourceConflictException = class _ResourceConflictException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57489,15 +57010,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ResourceConflictException.prototype);
+        this.name = "ResourceConflictException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ResourceConflictException2.prototype);
       }
     };
-    var TooManyRequestsException = class _TooManyRequestsException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "TooManyRequestsException");
-      }
-      name = "TooManyRequestsException";
-      $fault = "client";
+    __name(_ResourceConflictException, "ResourceConflictException");
+    var ResourceConflictException = _ResourceConflictException;
+    var _TooManyRequestsException = class _TooManyRequestsException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57507,19 +57027,18 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _TooManyRequestsException.prototype);
+        this.name = "TooManyRequestsException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _TooManyRequestsException2.prototype);
       }
     };
+    __name(_TooManyRequestsException, "TooManyRequestsException");
+    var TooManyRequestsException = _TooManyRequestsException;
     var ErrorCode = {
       ACCESS_DENIED: "AccessDenied",
       INTERNAL_SERVER_ERROR: "InternalServerError"
     };
-    var ResourceNotFoundException = class _ResourceNotFoundException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "ResourceNotFoundException");
-      }
-      name = "ResourceNotFoundException";
-      $fault = "client";
+    var _ResourceNotFoundException = class _ResourceNotFoundException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57529,15 +57048,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ResourceNotFoundException.prototype);
+        this.name = "ResourceNotFoundException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ResourceNotFoundException2.prototype);
       }
     };
-    var ExternalServiceException = class _ExternalServiceException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "ExternalServiceException");
-      }
-      name = "ExternalServiceException";
-      $fault = "client";
+    __name(_ResourceNotFoundException, "ResourceNotFoundException");
+    var ResourceNotFoundException = _ResourceNotFoundException;
+    var _ExternalServiceException = class _ExternalServiceException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57547,15 +57065,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ExternalServiceException.prototype);
+        this.name = "ExternalServiceException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ExternalServiceException2.prototype);
       }
     };
-    var InvalidIdentityPoolConfigurationException = class _InvalidIdentityPoolConfigurationException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "InvalidIdentityPoolConfigurationException");
-      }
-      name = "InvalidIdentityPoolConfigurationException";
-      $fault = "client";
+    __name(_ExternalServiceException, "ExternalServiceException");
+    var ExternalServiceException = _ExternalServiceException;
+    var _InvalidIdentityPoolConfigurationException = class _InvalidIdentityPoolConfigurationException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57565,9 +57082,13 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _InvalidIdentityPoolConfigurationException.prototype);
+        this.name = "InvalidIdentityPoolConfigurationException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _InvalidIdentityPoolConfigurationException2.prototype);
       }
     };
+    __name(_InvalidIdentityPoolConfigurationException, "InvalidIdentityPoolConfigurationException");
+    var InvalidIdentityPoolConfigurationException = _InvalidIdentityPoolConfigurationException;
     var MappingRuleMatchType = {
       CONTAINS: "Contains",
       EQUALS: "Equals",
@@ -57578,12 +57099,7 @@ var require_dist_cjs72 = __commonJS({
       RULES: "Rules",
       TOKEN: "Token"
     };
-    var DeveloperUserAlreadyRegisteredException = class _DeveloperUserAlreadyRegisteredException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "DeveloperUserAlreadyRegisteredException");
-      }
-      name = "DeveloperUserAlreadyRegisteredException";
-      $fault = "client";
+    var _DeveloperUserAlreadyRegisteredException = class _DeveloperUserAlreadyRegisteredException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57593,15 +57109,14 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _DeveloperUserAlreadyRegisteredException.prototype);
+        this.name = "DeveloperUserAlreadyRegisteredException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _DeveloperUserAlreadyRegisteredException2.prototype);
       }
     };
-    var ConcurrentModificationException = class _ConcurrentModificationException extends CognitoIdentityServiceException {
-      static {
-        __name(this, "ConcurrentModificationException");
-      }
-      name = "ConcurrentModificationException";
-      $fault = "client";
+    __name(_DeveloperUserAlreadyRegisteredException, "DeveloperUserAlreadyRegisteredException");
+    var DeveloperUserAlreadyRegisteredException = _DeveloperUserAlreadyRegisteredException;
+    var _ConcurrentModificationException = class _ConcurrentModificationException2 extends CognitoIdentityServiceException {
       /**
        * @internal
        */
@@ -57611,9 +57126,13 @@ var require_dist_cjs72 = __commonJS({
           $fault: "client",
           ...opts
         });
-        Object.setPrototypeOf(this, _ConcurrentModificationException.prototype);
+        this.name = "ConcurrentModificationException";
+        this.$fault = "client";
+        Object.setPrototypeOf(this, _ConcurrentModificationException2.prototype);
       }
     };
+    __name(_ConcurrentModificationException, "ConcurrentModificationException");
+    var ConcurrentModificationException = _ConcurrentModificationException;
     var GetCredentialsForIdentityInputFilterSensitiveLog = /* @__PURE__ */ __name((obj) => ({
       ...obj,
       ...obj.Logins && { Logins: import_smithy_client4.SENSITIVE_STRING }
@@ -58290,97 +57809,88 @@ var require_dist_cjs72 = __commonJS({
       };
     }
     __name(sharedHeaders, "sharedHeaders");
-    var CreateIdentityPoolCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    var _CreateIdentityPoolCommand = class _CreateIdentityPoolCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "CreateIdentityPool", {}).n("CognitoIdentityClient", "CreateIdentityPoolCommand").f(void 0, void 0).ser(se_CreateIdentityPoolCommand).de(de_CreateIdentityPoolCommand).build() {
-      static {
-        __name(this, "CreateIdentityPoolCommand");
-      }
     };
-    var DeleteIdentitiesCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_CreateIdentityPoolCommand, "CreateIdentityPoolCommand");
+    var CreateIdentityPoolCommand = _CreateIdentityPoolCommand;
+    var _DeleteIdentitiesCommand = class _DeleteIdentitiesCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "DeleteIdentities", {}).n("CognitoIdentityClient", "DeleteIdentitiesCommand").f(void 0, void 0).ser(se_DeleteIdentitiesCommand).de(de_DeleteIdentitiesCommand).build() {
-      static {
-        __name(this, "DeleteIdentitiesCommand");
-      }
     };
-    var DeleteIdentityPoolCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_DeleteIdentitiesCommand, "DeleteIdentitiesCommand");
+    var DeleteIdentitiesCommand = _DeleteIdentitiesCommand;
+    var _DeleteIdentityPoolCommand = class _DeleteIdentityPoolCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "DeleteIdentityPool", {}).n("CognitoIdentityClient", "DeleteIdentityPoolCommand").f(void 0, void 0).ser(se_DeleteIdentityPoolCommand).de(de_DeleteIdentityPoolCommand).build() {
-      static {
-        __name(this, "DeleteIdentityPoolCommand");
-      }
     };
-    var DescribeIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_DeleteIdentityPoolCommand, "DeleteIdentityPoolCommand");
+    var DeleteIdentityPoolCommand = _DeleteIdentityPoolCommand;
+    var _DescribeIdentityCommand = class _DescribeIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "DescribeIdentity", {}).n("CognitoIdentityClient", "DescribeIdentityCommand").f(void 0, void 0).ser(se_DescribeIdentityCommand).de(de_DescribeIdentityCommand).build() {
-      static {
-        __name(this, "DescribeIdentityCommand");
-      }
     };
-    var DescribeIdentityPoolCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_DescribeIdentityCommand, "DescribeIdentityCommand");
+    var DescribeIdentityCommand = _DescribeIdentityCommand;
+    var _DescribeIdentityPoolCommand = class _DescribeIdentityPoolCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "DescribeIdentityPool", {}).n("CognitoIdentityClient", "DescribeIdentityPoolCommand").f(void 0, void 0).ser(se_DescribeIdentityPoolCommand).de(de_DescribeIdentityPoolCommand).build() {
-      static {
-        __name(this, "DescribeIdentityPoolCommand");
-      }
     };
-    var GetCredentialsForIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_DescribeIdentityPoolCommand, "DescribeIdentityPoolCommand");
+    var DescribeIdentityPoolCommand = _DescribeIdentityPoolCommand;
+    var _GetCredentialsForIdentityCommand = class _GetCredentialsForIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "GetCredentialsForIdentity", {}).n("CognitoIdentityClient", "GetCredentialsForIdentityCommand").f(GetCredentialsForIdentityInputFilterSensitiveLog, GetCredentialsForIdentityResponseFilterSensitiveLog).ser(se_GetCredentialsForIdentityCommand).de(de_GetCredentialsForIdentityCommand).build() {
-      static {
-        __name(this, "GetCredentialsForIdentityCommand");
-      }
     };
-    var GetIdCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_GetCredentialsForIdentityCommand, "GetCredentialsForIdentityCommand");
+    var GetCredentialsForIdentityCommand = _GetCredentialsForIdentityCommand;
+    var _GetIdCommand = class _GetIdCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "GetId", {}).n("CognitoIdentityClient", "GetIdCommand").f(GetIdInputFilterSensitiveLog, void 0).ser(se_GetIdCommand).de(de_GetIdCommand).build() {
-      static {
-        __name(this, "GetIdCommand");
-      }
     };
-    var GetIdentityPoolRolesCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_GetIdCommand, "GetIdCommand");
+    var GetIdCommand = _GetIdCommand;
+    var _GetIdentityPoolRolesCommand = class _GetIdentityPoolRolesCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "GetIdentityPoolRoles", {}).n("CognitoIdentityClient", "GetIdentityPoolRolesCommand").f(void 0, void 0).ser(se_GetIdentityPoolRolesCommand).de(de_GetIdentityPoolRolesCommand).build() {
-      static {
-        __name(this, "GetIdentityPoolRolesCommand");
-      }
     };
-    var GetOpenIdTokenCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_GetIdentityPoolRolesCommand, "GetIdentityPoolRolesCommand");
+    var GetIdentityPoolRolesCommand = _GetIdentityPoolRolesCommand;
+    var _GetOpenIdTokenCommand = class _GetOpenIdTokenCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "GetOpenIdToken", {}).n("CognitoIdentityClient", "GetOpenIdTokenCommand").f(GetOpenIdTokenInputFilterSensitiveLog, GetOpenIdTokenResponseFilterSensitiveLog).ser(se_GetOpenIdTokenCommand).de(de_GetOpenIdTokenCommand).build() {
-      static {
-        __name(this, "GetOpenIdTokenCommand");
-      }
     };
-    var GetOpenIdTokenForDeveloperIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_GetOpenIdTokenCommand, "GetOpenIdTokenCommand");
+    var GetOpenIdTokenCommand = _GetOpenIdTokenCommand;
+    var _GetOpenIdTokenForDeveloperIdentityCommand = class _GetOpenIdTokenForDeveloperIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
@@ -58389,140 +57899,126 @@ var require_dist_cjs72 = __commonJS({
       GetOpenIdTokenForDeveloperIdentityInputFilterSensitiveLog,
       GetOpenIdTokenForDeveloperIdentityResponseFilterSensitiveLog
     ).ser(se_GetOpenIdTokenForDeveloperIdentityCommand).de(de_GetOpenIdTokenForDeveloperIdentityCommand).build() {
-      static {
-        __name(this, "GetOpenIdTokenForDeveloperIdentityCommand");
-      }
     };
-    var GetPrincipalTagAttributeMapCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_GetOpenIdTokenForDeveloperIdentityCommand, "GetOpenIdTokenForDeveloperIdentityCommand");
+    var GetOpenIdTokenForDeveloperIdentityCommand = _GetOpenIdTokenForDeveloperIdentityCommand;
+    var _GetPrincipalTagAttributeMapCommand = class _GetPrincipalTagAttributeMapCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "GetPrincipalTagAttributeMap", {}).n("CognitoIdentityClient", "GetPrincipalTagAttributeMapCommand").f(void 0, void 0).ser(se_GetPrincipalTagAttributeMapCommand).de(de_GetPrincipalTagAttributeMapCommand).build() {
-      static {
-        __name(this, "GetPrincipalTagAttributeMapCommand");
-      }
     };
-    var ListIdentitiesCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_GetPrincipalTagAttributeMapCommand, "GetPrincipalTagAttributeMapCommand");
+    var GetPrincipalTagAttributeMapCommand = _GetPrincipalTagAttributeMapCommand;
+    var _ListIdentitiesCommand = class _ListIdentitiesCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "ListIdentities", {}).n("CognitoIdentityClient", "ListIdentitiesCommand").f(void 0, void 0).ser(se_ListIdentitiesCommand).de(de_ListIdentitiesCommand).build() {
-      static {
-        __name(this, "ListIdentitiesCommand");
-      }
     };
-    var ListIdentityPoolsCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_ListIdentitiesCommand, "ListIdentitiesCommand");
+    var ListIdentitiesCommand = _ListIdentitiesCommand;
+    var _ListIdentityPoolsCommand = class _ListIdentityPoolsCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "ListIdentityPools", {}).n("CognitoIdentityClient", "ListIdentityPoolsCommand").f(void 0, void 0).ser(se_ListIdentityPoolsCommand).de(de_ListIdentityPoolsCommand).build() {
-      static {
-        __name(this, "ListIdentityPoolsCommand");
-      }
     };
-    var ListTagsForResourceCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_ListIdentityPoolsCommand, "ListIdentityPoolsCommand");
+    var ListIdentityPoolsCommand = _ListIdentityPoolsCommand;
+    var _ListTagsForResourceCommand = class _ListTagsForResourceCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "ListTagsForResource", {}).n("CognitoIdentityClient", "ListTagsForResourceCommand").f(void 0, void 0).ser(se_ListTagsForResourceCommand).de(de_ListTagsForResourceCommand).build() {
-      static {
-        __name(this, "ListTagsForResourceCommand");
-      }
     };
-    var LookupDeveloperIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_ListTagsForResourceCommand, "ListTagsForResourceCommand");
+    var ListTagsForResourceCommand = _ListTagsForResourceCommand;
+    var _LookupDeveloperIdentityCommand = class _LookupDeveloperIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "LookupDeveloperIdentity", {}).n("CognitoIdentityClient", "LookupDeveloperIdentityCommand").f(void 0, void 0).ser(se_LookupDeveloperIdentityCommand).de(de_LookupDeveloperIdentityCommand).build() {
-      static {
-        __name(this, "LookupDeveloperIdentityCommand");
-      }
     };
-    var MergeDeveloperIdentitiesCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_LookupDeveloperIdentityCommand, "LookupDeveloperIdentityCommand");
+    var LookupDeveloperIdentityCommand = _LookupDeveloperIdentityCommand;
+    var _MergeDeveloperIdentitiesCommand = class _MergeDeveloperIdentitiesCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "MergeDeveloperIdentities", {}).n("CognitoIdentityClient", "MergeDeveloperIdentitiesCommand").f(void 0, void 0).ser(se_MergeDeveloperIdentitiesCommand).de(de_MergeDeveloperIdentitiesCommand).build() {
-      static {
-        __name(this, "MergeDeveloperIdentitiesCommand");
-      }
     };
-    var SetIdentityPoolRolesCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_MergeDeveloperIdentitiesCommand, "MergeDeveloperIdentitiesCommand");
+    var MergeDeveloperIdentitiesCommand = _MergeDeveloperIdentitiesCommand;
+    var _SetIdentityPoolRolesCommand = class _SetIdentityPoolRolesCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "SetIdentityPoolRoles", {}).n("CognitoIdentityClient", "SetIdentityPoolRolesCommand").f(void 0, void 0).ser(se_SetIdentityPoolRolesCommand).de(de_SetIdentityPoolRolesCommand).build() {
-      static {
-        __name(this, "SetIdentityPoolRolesCommand");
-      }
     };
-    var SetPrincipalTagAttributeMapCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_SetIdentityPoolRolesCommand, "SetIdentityPoolRolesCommand");
+    var SetIdentityPoolRolesCommand = _SetIdentityPoolRolesCommand;
+    var _SetPrincipalTagAttributeMapCommand = class _SetPrincipalTagAttributeMapCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "SetPrincipalTagAttributeMap", {}).n("CognitoIdentityClient", "SetPrincipalTagAttributeMapCommand").f(void 0, void 0).ser(se_SetPrincipalTagAttributeMapCommand).de(de_SetPrincipalTagAttributeMapCommand).build() {
-      static {
-        __name(this, "SetPrincipalTagAttributeMapCommand");
-      }
     };
-    var TagResourceCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_SetPrincipalTagAttributeMapCommand, "SetPrincipalTagAttributeMapCommand");
+    var SetPrincipalTagAttributeMapCommand = _SetPrincipalTagAttributeMapCommand;
+    var _TagResourceCommand = class _TagResourceCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "TagResource", {}).n("CognitoIdentityClient", "TagResourceCommand").f(void 0, void 0).ser(se_TagResourceCommand).de(de_TagResourceCommand).build() {
-      static {
-        __name(this, "TagResourceCommand");
-      }
     };
-    var UnlinkDeveloperIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_TagResourceCommand, "TagResourceCommand");
+    var TagResourceCommand = _TagResourceCommand;
+    var _UnlinkDeveloperIdentityCommand = class _UnlinkDeveloperIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "UnlinkDeveloperIdentity", {}).n("CognitoIdentityClient", "UnlinkDeveloperIdentityCommand").f(void 0, void 0).ser(se_UnlinkDeveloperIdentityCommand).de(de_UnlinkDeveloperIdentityCommand).build() {
-      static {
-        __name(this, "UnlinkDeveloperIdentityCommand");
-      }
     };
-    var UnlinkIdentityCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_UnlinkDeveloperIdentityCommand, "UnlinkDeveloperIdentityCommand");
+    var UnlinkDeveloperIdentityCommand = _UnlinkDeveloperIdentityCommand;
+    var _UnlinkIdentityCommand = class _UnlinkIdentityCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "UnlinkIdentity", {}).n("CognitoIdentityClient", "UnlinkIdentityCommand").f(UnlinkIdentityInputFilterSensitiveLog, void 0).ser(se_UnlinkIdentityCommand).de(de_UnlinkIdentityCommand).build() {
-      static {
-        __name(this, "UnlinkIdentityCommand");
-      }
     };
-    var UntagResourceCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_UnlinkIdentityCommand, "UnlinkIdentityCommand");
+    var UnlinkIdentityCommand = _UnlinkIdentityCommand;
+    var _UntagResourceCommand = class _UntagResourceCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "UntagResource", {}).n("CognitoIdentityClient", "UntagResourceCommand").f(void 0, void 0).ser(se_UntagResourceCommand).de(de_UntagResourceCommand).build() {
-      static {
-        __name(this, "UntagResourceCommand");
-      }
     };
-    var UpdateIdentityPoolCommand = class extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
+    __name(_UntagResourceCommand, "UntagResourceCommand");
+    var UntagResourceCommand = _UntagResourceCommand;
+    var _UpdateIdentityPoolCommand = class _UpdateIdentityPoolCommand extends import_smithy_client4.Command.classBuilder().ep(commonParams).m(function(Command, cs, config, o) {
       return [
         (0, import_middleware_serde2.getSerdePlugin)(config, this.serialize, this.deserialize),
         (0, import_middleware_endpoint.getEndpointPlugin)(config, Command.getEndpointParameterInstructions())
       ];
     }).s("AWSCognitoIdentityService", "UpdateIdentityPool", {}).n("CognitoIdentityClient", "UpdateIdentityPoolCommand").f(void 0, void 0).ser(se_UpdateIdentityPoolCommand).de(de_UpdateIdentityPoolCommand).build() {
-      static {
-        __name(this, "UpdateIdentityPoolCommand");
-      }
     };
+    __name(_UpdateIdentityPoolCommand, "UpdateIdentityPoolCommand");
+    var UpdateIdentityPoolCommand = _UpdateIdentityPoolCommand;
     var commands = {
       CreateIdentityPoolCommand,
       DeleteIdentitiesCommand,
@@ -58548,11 +58044,10 @@ var require_dist_cjs72 = __commonJS({
       UntagResourceCommand,
       UpdateIdentityPoolCommand
     };
-    var CognitoIdentity = class extends CognitoIdentityClient {
-      static {
-        __name(this, "CognitoIdentity");
-      }
+    var _CognitoIdentity = class _CognitoIdentity extends CognitoIdentityClient {
     };
+    __name(_CognitoIdentity, "CognitoIdentity");
+    var CognitoIdentity = _CognitoIdentity;
     (0, import_smithy_client4.createAggregatedClient)(commands, CognitoIdentity);
     var paginateListIdentityPools = (0, import_core4.createPaginator)(CognitoIdentityClient, ListIdentityPoolsCommand, "NextToken", "NextToken", "MaxResults");
   }
@@ -58623,10 +58118,10 @@ var require_dist_cjs73 = __commonJS({
     }
     __name(resolveLogins, "resolveLogins");
     function fromCognitoIdentity(parameters) {
-      return async (awsIdentityProperties) => {
-        parameters.logger?.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
+      return async () => {
+        var _a, _b, _c;
+        (_a = parameters.logger) == null ? void 0 : _a.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
         const { GetCredentialsForIdentityCommand: GetCredentialsForIdentityCommand2, CognitoIdentityClient: CognitoIdentityClient2 } = await Promise.resolve().then(() => (init_loadCognitoIdentity(), loadCognitoIdentity_exports));
-        const fromConfigs = /* @__PURE__ */ __name((property) => parameters.clientConfig?.[property] ?? parameters.parentClientConfig?.[property] ?? awsIdentityProperties?.callerClientConfig?.[property], "fromConfigs");
         const {
           Credentials: {
             AccessKeyId = throwOnMissingAccessKeyId(parameters.logger),
@@ -58636,8 +58131,7 @@ var require_dist_cjs73 = __commonJS({
           } = throwOnMissingCredentials(parameters.logger)
         } = await (parameters.client ?? new CognitoIdentityClient2(
           Object.assign({}, parameters.clientConfig ?? {}, {
-            region: fromConfigs("region"),
-            profile: fromConfigs("profile")
+            region: ((_b = parameters.clientConfig) == null ? void 0 : _b.region) ?? ((_c = parameters.parentClientConfig) == null ? void 0 : _c.region)
           })
         )).send(
           new GetCredentialsForIdentityCommand2({
@@ -58669,12 +58163,9 @@ var require_dist_cjs73 = __commonJS({
     }
     __name(throwOnMissingSecretKey, "throwOnMissingSecretKey");
     var STORE_NAME = "IdentityIds";
-    var IndexedDbStorage = class {
+    var _IndexedDbStorage = class _IndexedDbStorage {
       constructor(dbName = "aws:cognito-identity-ids") {
         this.dbName = dbName;
-      }
-      static {
-        __name(this, "IndexedDbStorage");
       }
       getItem(key) {
         return this.withObjectStore("readonly", (store) => {
@@ -58738,12 +58229,11 @@ var require_dist_cjs73 = __commonJS({
         });
       }
     };
-    var InMemoryStorage = class {
+    __name(_IndexedDbStorage, "IndexedDbStorage");
+    var IndexedDbStorage = _IndexedDbStorage;
+    var _InMemoryStorage = class _InMemoryStorage {
       constructor(store = {}) {
         this.store = store;
-      }
-      static {
-        __name(this, "InMemoryStorage");
       }
       getItem(key) {
         if (key in this.store) {
@@ -58758,6 +58248,8 @@ var require_dist_cjs73 = __commonJS({
         this.store[key] = value;
       }
     };
+    __name(_InMemoryStorage, "InMemoryStorage");
+    var InMemoryStorage = _InMemoryStorage;
     var inMemoryStorage = new InMemoryStorage();
     function localStorage() {
       if (typeof self === "object" && self.indexedDB) {
@@ -58781,16 +58273,12 @@ var require_dist_cjs73 = __commonJS({
       logger,
       parentClientConfig
     }) {
-      logger?.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
+      logger == null ? void 0 : logger.debug("@aws-sdk/credential-provider-cognito-identity - fromCognitoIdentity");
       const cacheKey = userIdentifier ? `aws:cognito-identity-credentials:${identityPoolId}:${userIdentifier}` : void 0;
-      let provider = /* @__PURE__ */ __name(async (awsIdentityProperties) => {
+      let provider = /* @__PURE__ */ __name(async () => {
         const { GetIdCommand: GetIdCommand2, CognitoIdentityClient: CognitoIdentityClient2 } = await Promise.resolve().then(() => (init_loadCognitoIdentity(), loadCognitoIdentity_exports));
-        const fromConfigs = /* @__PURE__ */ __name((property) => clientConfig?.[property] ?? parentClientConfig?.[property] ?? awsIdentityProperties?.callerClientConfig?.[property], "fromConfigs");
         const _client = client ?? new CognitoIdentityClient2(
-          Object.assign({}, clientConfig ?? {}, {
-            region: fromConfigs("region"),
-            profile: fromConfigs("profile")
-          })
+          Object.assign({}, clientConfig ?? {}, { region: (clientConfig == null ? void 0 : clientConfig.region) ?? (parentClientConfig == null ? void 0 : parentClientConfig.region) })
         );
         let identityId = cacheKey && await cache.getItem(cacheKey);
         if (!identityId) {
@@ -58813,9 +58301,9 @@ var require_dist_cjs73 = __commonJS({
           logins,
           identityId
         });
-        return provider(awsIdentityProperties);
+        return provider();
       }, "provider");
-      return (awsIdentityProperties) => provider(awsIdentityProperties).catch(async (err) => {
+      return () => provider().catch(async (err) => {
         if (cacheKey) {
           Promise.resolve(cache.removeItem(cacheKey)).catch(() => {
           });
@@ -62122,19 +61610,7 @@ var main = async (options) => {
       credentials: (0, import_credential_providers.fromWebToken)({
         roleArn,
         webIdentityToken: idToken
-      }),
-      /*
-            Increase the timeout. Since updating `@aws-sdk/client-s3` to v3.717.0 we've seen an increase of timeouts:
-            > RequestTimeout: Your socket connection to the server was not read from or written to within the timeout period. Idle connections will be closed.
-      
-            See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html
-             */
-      requestHandler: {
-        requestTimeout: 10 * 1e3
-        // 10 seconds
-      },
-      // Enable AWS SDK logging if the action is run in debug mode
-      ...core4.isDebug() && { logger: { ...console } }
+      })
     })
   );
   const keyPrefix = riffraffPrefix(mfest);
@@ -62193,14 +61669,6 @@ undici/lib/fetch/body.js:
 
 undici/lib/websocket/frame.js:
   (*! ws. MIT License. Einar Otto Stangvik <einaros@gmail.com> *)
-
-is-plain-object/dist/is-plain-object.js:
-  (*!
-   * is-plain-object <https://github.com/jonschlinkert/is-plain-object>
-   *
-   * Copyright (c) 2014-2017, Jon Schlinkert.
-   * Released under the MIT License.
-   *)
 
 js-yaml/dist/js-yaml.mjs:
   (*! js-yaml 4.1.0 https://github.com/nodeca/js-yaml @license MIT *)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
-        "@aws-sdk/client-s3": "^3.723.0",
-        "@aws-sdk/credential-providers": "^3.723.0",
+        "@aws-sdk/client-s3": "3.703.0",
+        "@aws-sdk/credential-providers": "3.699.0",
         "esbuild": "^0.24.2",
         "js-yaml": "^4.1.0"
       },
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
-      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -270,755 +270,755 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.723.0.tgz",
-      "integrity": "sha512-SEJGNcbfpLM7fqS5s0dLgj7jFCm2IBc1Qluehvpf4+lL1dymGwZAK7S4Ii6gPZhliEj0n48YE6Dg0UkxR2iRag==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.699.0.tgz",
+      "integrity": "sha512-9tFt+we6AIvj/f1+nrLHuCWcQmyfux5gcBSOy9d9+zIG56YxGEX7S9TaZnybogpVV8A0BYWml36WvIHS9QjIpA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.723.0",
-        "@aws-sdk/client-sts": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/client-sts": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.723.0.tgz",
-      "integrity": "sha512-uJkSBWeAbEORApCSc8ZlD8nmmJVZnklauSR+GLnG19ZiHQl3ib6IzT4zdnMHrrIXqVttwkyC8eT703ZUDVaacw==",
+      "version": "3.703.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.703.0.tgz",
+      "integrity": "sha512-4TSrIamzASTeRPKXrTLcEwo+viPTuOSGcbXh4HC1R0m/rXwK0BHJ4btJ0Q34nZNF+WzvM+FiemXVjNc8qTAxog==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.723.0",
-        "@aws-sdk/client-sts": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.723.0",
-        "@aws-sdk/middleware-expect-continue": "3.723.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-location-constraint": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-sdk-s3": "3.723.0",
-        "@aws-sdk/middleware-ssec": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/signature-v4-multi-region": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@aws-sdk/xml-builder": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/eventstream-serde-browser": "^4.0.0",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.0",
-        "@smithy/eventstream-serde-node": "^4.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-blob-browser": "^4.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/hash-stream-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/md5-js": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/client-sts": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.696.0",
+        "@aws-sdk/middleware-expect-continue": "3.696.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.701.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-location-constraint": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-sdk-s3": "3.696.0",
+        "@aws-sdk/middleware-ssec": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/signature-v4-multi-region": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@aws-sdk/xml-builder": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/eventstream-serde-browser": "^3.0.13",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.10",
+        "@smithy/eventstream-serde-node": "^3.0.12",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-blob-browser": "^3.1.9",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/hash-stream-node": "^3.1.9",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/md5-js": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.9",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.723.0.tgz",
-      "integrity": "sha512-r1ddZDb8yPmdofX1gQ4m8oqKozgkgVONLlAuSprGObbyMy8bYt1Psxu+GjnwMmgVu3vlF069PHyW1ndrBiL1zA==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.696.0.tgz",
+      "integrity": "sha512-q5TTkd08JS0DOkHfUL853tuArf7NrPeqoS5UOvqJho8ibV9Ak/a/HO4kNvy9Nj3cib/toHYHsQIEtecUPSUUrQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.723.0.tgz",
-      "integrity": "sha512-9IH90m4bnHogBctVna2FnXaIGVORncfdxcqeEIovOxjIJJyHDmEAtA7B91dAM4sruddTbVzOYnqfPVst3odCbA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.699.0.tgz",
+      "integrity": "sha512-u8a1GorY5D1l+4FQAf4XBUC1T10/t7neuwT21r0ymrtMFSK2a9QqVHKMoLkvavAwyhJnARSBM9/UQC797PFOFw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.723.0"
+        "@aws-sdk/client-sts": "^3.699.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.723.0.tgz",
-      "integrity": "sha512-YyN8x4MI/jMb4LpHsLf+VYqvbColMK8aZeGWVk2fTFsmt8lpTYGaGC1yybSwGX42mZ4W8ucu8SAYSbUraJZEjA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.699.0.tgz",
+      "integrity": "sha512-++lsn4x2YXsZPIzFVwv3fSUVM55ZT0WRFmPeNilYIhZClxHLmVAWKH4I55cY9ry60/aTKYjzOXkWwyBKGsGvQg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/client-sso-oidc": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
-      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.696.0.tgz",
+      "integrity": "sha512-3c9III1k03DgvRZWg8vhVmfIXPG6hAciN9MzQTzqGngzWAELZF/WONRTRQuDFixVtarQatmLHYVw/atGeA2Byw==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.723.0.tgz",
-      "integrity": "sha512-QsI3Y9isqJAttxtGiPgm/moa/SWJl4EaCfwBLDTI/gZpYdzYkqeYf6r52mhCZ0tQm2CHvXrt1eHiTqD9jINhEA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.699.0.tgz",
+      "integrity": "sha512-iuaTnudaBfEET+o444sDwf71Awe6UiZfH+ipUPmswAi2jZDwdFF1nxMKDEKL8/LV5WpXsdKSfwgS0RQeupURew==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/client-cognito-identity": "3.699.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.723.0.tgz",
-      "integrity": "sha512-OuH2yULYUHTVDUotBoP/9AEUIJPn81GQ/YBtZLoo2QyezRJ2QiO/1epVtbJlhNZRwXrToLEDmQGA2QfC8c7pbA==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.696.0.tgz",
+      "integrity": "sha512-T9iMFnJL7YTlESLpVFT3fg1Lkb1lD+oiaIC8KMpepb01gDUBIpj9+Y+pA/cgRWW0yRxmkDXNazAE2qQTVFGJzA==",
       "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.723.0.tgz",
-      "integrity": "sha512-DTsKC6xo/kz/ZSs1IcdbQMTgiYbpGTGEd83kngFc1bzmw7AmK92DBZKNZpumf8R/UfSpTcj9zzUUmrWz1kD0eQ==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.696.0.tgz",
+      "integrity": "sha512-GV6EbvPi2eq1+WgY/o2RFA3P7HGmnkIzCNmhwtALFlqMroLYWKE7PSeHw66Uh1dFQeVESn0/+hiUNhu1mB0emA==",
       "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.723.0.tgz",
-      "integrity": "sha512-fWRLksuSG851e7Iu+ltMrQTM7C/5iI9OkxAmCYblcCetAzjTRmMB2arku0Z83D8edIZEQtOJMt5oQ9KNg43pzg==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.699.0.tgz",
+      "integrity": "sha512-dXmCqjJnKmG37Q+nLjPVu22mNkrGHY8hYoOt3Jo9R2zr5MYV7s/NHsCHr+7E+BZ+tfZYLRPeB1wkpTeHiEcdRw==",
       "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-env": "3.723.0",
-        "@aws-sdk/credential-provider-http": "3.723.0",
-        "@aws-sdk/credential-provider-process": "3.723.0",
-        "@aws-sdk/credential-provider-sso": "3.723.0",
-        "@aws-sdk/credential-provider-web-identity": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/credential-provider-imds": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.723.0"
+        "@aws-sdk/client-sts": "^3.699.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.723.0.tgz",
-      "integrity": "sha512-OyLHt+aY+rkuRejigcxviS5RLUBcqbxhDTSNfP8dp9I+1SP610qRLpTIROvtKwXZssFcATpPfgikFtVYRrihXQ==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.699.0.tgz",
+      "integrity": "sha512-MmEmNDo1bBtTgRmdNfdQksXu4uXe66s0p1hi1YPrn1h59Q605eq/xiWbGL6/3KdkViH6eGUuABeV2ODld86ylg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.723.0",
-        "@aws-sdk/credential-provider-http": "3.723.0",
-        "@aws-sdk/credential-provider-ini": "3.723.0",
-        "@aws-sdk/credential-provider-process": "3.723.0",
-        "@aws-sdk/credential-provider-sso": "3.723.0",
-        "@aws-sdk/credential-provider-web-identity": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/credential-provider-imds": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.723.0.tgz",
-      "integrity": "sha512-fgupvUjz1+jeoCBA7GMv0L6xEk92IN6VdF4YcFhsgRHlHvNgm7ayaoKQg7pz2JAAhG/3jPX6fp0ASNy+xOhmPA==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.696.0.tgz",
+      "integrity": "sha512-mL1RcFDe9sfmyU5K1nuFkO8UiJXXxLX4JO1gVaDIOvPqwStpUAwi3A1BoeZhWZZNQsiKI810RnYGo0E0WB/hUA==",
       "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.723.0.tgz",
-      "integrity": "sha512-laCnxrk0pgUegU+ib6rj1/Uv51wei+cH8crvBJddybc8EDn7Qht61tCvBwf3o33qUDC+ZWZZewlpSebf+J+tBw==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.699.0.tgz",
+      "integrity": "sha512-Ekp2cZG4pl9D8+uKWm4qO1xcm8/MeiI8f+dnlZm8aQzizeC+aXYy9GyoclSf6daK8KfRPiRfM7ZHBBL5dAfdMA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/token-providers": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/client-sso": "3.696.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/token-providers": "3.699.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.723.0.tgz",
-      "integrity": "sha512-tl7pojbFbr3qLcOE6xWaNCf1zEfZrIdSJtOPeSXfV/thFMMAvIjgf3YN6Zo1a6cxGee8zrV/C8PgOH33n+Ev/A==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.696.0.tgz",
+      "integrity": "sha512-XJ/CVlWChM0VCoc259vWguFUjJDn/QwDqHwbx+K9cg3v6yrqXfK5ai+p/6lx0nQpnk4JzPVeYYxWRpaTsGC9rg==",
       "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.723.0"
+        "@aws-sdk/client-sts": "^3.696.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.723.0.tgz",
-      "integrity": "sha512-poDyQ5/O8fdhVP+Nr3nNYS9jBpmrwy9G7ipMYceHbztiBrAmFBsB3dyFKytRM1+z5Gz3icOHamv5ZinDhyBWsA==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.699.0.tgz",
+      "integrity": "sha512-jBjOntl9zN9Nvb0jmbMGRbiTzemDz64ij7W6BDavxBJRZpRoNeN0QCz6RolkCyXnyUJjo5mF2unY2wnv00A+LQ==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.723.0",
-        "@aws-sdk/client-sso": "3.723.0",
-        "@aws-sdk/client-sts": "3.723.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.723.0",
-        "@aws-sdk/credential-provider-env": "3.723.0",
-        "@aws-sdk/credential-provider-http": "3.723.0",
-        "@aws-sdk/credential-provider-ini": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.723.0",
-        "@aws-sdk/credential-provider-process": "3.723.0",
-        "@aws-sdk/credential-provider-sso": "3.723.0",
-        "@aws-sdk/credential-provider-web-identity": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/credential-provider-imds": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/client-cognito-identity": "3.699.0",
+        "@aws-sdk/client-sso": "3.696.0",
+        "@aws-sdk/client-sts": "3.699.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.699.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.699.0",
+        "@aws-sdk/credential-provider-node": "3.699.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.699.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.723.0.tgz",
-      "integrity": "sha512-OmKSXwSlXyW+zg+xq4hUf7V4VF5/fa4LHu1JzeBlomrKX3/NnqhnJn7760GXoDr16AT+dP7nvv35Ofp91umEAg==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.696.0.tgz",
+      "integrity": "sha512-V07jishKHUS5heRNGFpCWCSTjRJyQLynS/ncUeE8ZYtG66StOOQWftTwDfFOSoXlIqrXgb4oT9atryzXq7Z4LQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-arn-parser": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-arn-parser": "3.693.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.723.0.tgz",
-      "integrity": "sha512-w/O0EkIzkiqvGu7U8Ke7tue0V0HYM5dZQrz6nVU+R8T2LddWJ+njEIHU4Wh8aHPLQXdZA5NQumv0xLPdEutykw==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.696.0.tgz",
+      "integrity": "sha512-vpVukqY3U2pb+ULeX0shs6L0aadNep6kKzjme/MyulPjtUDJpD3AekHsXRrCCGLmOqSKqRgQn5zhV9pQhHsb6Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.723.0.tgz",
-      "integrity": "sha512-JY76mrUCLa0FHeMZp8X9+KK6uEuZaRZaQrlgq6zkXX/3udukH0T3YdFC+Y9uw5ddbiwZ5+KwgmlhnPpiXKfP4g==",
+      "version": "3.701.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.701.0.tgz",
+      "integrity": "sha512-adNaPCyTT+CiVM0ufDiO1Fe7nlRmJdI9Hcgj0M9S6zR7Dw70Ra5z8Lslkd7syAccYvZaqxLklGjPQH/7GNxwTA==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
-      "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.696.0.tgz",
+      "integrity": "sha512-zELJp9Ta2zkX7ELggMN9qMCgekqZhFC5V2rOr4hJDEb/Tte7gpfKSObAnw/3AYiVqt36sjHKfdkoTsuwGdEoDg==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.723.0.tgz",
-      "integrity": "sha512-inp9tyrdRWjGOMu1rzli8i2gTo0P4X6L7nNRXNTKfyPNZcBimZ4H0H1B671JofSI5isaklVy5r4pvv2VjjLSHw==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.696.0.tgz",
+      "integrity": "sha512-FgH12OB0q+DtTrP2aiDBddDKwL4BPOrm7w3VV9BJrSdkqQCNBPz8S1lb0y5eVH4tBG+2j7gKPlOv1wde4jF/iw==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
-      "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.696.0.tgz",
+      "integrity": "sha512-KhkHt+8AjCxcR/5Zp3++YPJPpFQzxpr+jmONiT/Jw2yqnSngZ0Yspm5wGoRx2hS1HJbyZNuaOWEGuJoxLeBKfA==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
-      "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.696.0.tgz",
+      "integrity": "sha512-si/maV3Z0hH7qa99f9ru2xpS5HlfSVcasRlNUXKSDm611i7jFMWwGNLUOXFAOLhXotPX5G3Z6BLwL34oDeBMug==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.723.0.tgz",
-      "integrity": "sha512-wfjOvNJVp8LDWhq4wO5jtSMb8Vgf4tNlR7QTEQfoYc6AGU3WlK5xyUQcpfcpwytEhQTN9u0cJLQpSyXDO+qSCw==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.696.0.tgz",
+      "integrity": "sha512-M7fEiAiN7DBMHflzOFzh1I2MNSlLpbiH2ubs87bdRc2wZsDPSbs4l3v6h3WLhxoQK0bq6vcfroudrLBgvCuX3Q==",
       "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-arn-parser": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-arn-parser": "3.693.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.723.0.tgz",
-      "integrity": "sha512-Bs+8RAeSMik6ZYCGSDJzJieGsDDh2fRbh1HQG94T8kpwBXVxMYihm6e9Xp2cyl+w9fyyCnh0IdCKChP/DvrdhA==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.696.0.tgz",
+      "integrity": "sha512-w/d6O7AOZ7Pg3w2d3BxnX5RmGNWb5X4RNxF19rJqcgu/xqxxE/QwZTNd5a7eTsqLXAUIfbbR8hh0czVfC1pJLA==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.723.0.tgz",
-      "integrity": "sha512-AY5H2vD3IRElplBO4DCyRMNnOG/4/cb0tsHyLe1HJy0hdUF6eY5z/VVjKJoKbbDk7ui9euyOBWslXxDyLmyPWg==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.696.0.tgz",
+      "integrity": "sha512-Lvyj8CTyxrHI6GHd2YVZKIRI5Fmnugt3cpJo0VrKKEgK5zMySwEZ1n4dqPK6czYRWKd5+WnYHYAuU+Wdk6Jsjw==",
       "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
-      "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.696.0.tgz",
+      "integrity": "sha512-7EuH142lBXjI8yH6dVS/CZeiK/WZsmb/8zP6bQbVYpMrppSTgB3MzZZdxVZGzL5r8zPQOU10wLC4kIMy0qdBVQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.723.0.tgz",
-      "integrity": "sha512-lJlVAa5Sl589qO8lwMLVUtnlF1Q7I+6k1Iomv2goY9d1bRl4q2N5Pit2qJVr2AMW0sceQXeh23i2a/CKOqVAdg==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.696.0.tgz",
+      "integrity": "sha512-ijPkoLjXuPtgxAYlDoYls8UaG/VKigROn9ebbvPL/orEY5umedd3iZTcS9T+uAf4Ur3GELLxMQiERZpfDKaz3g==",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/middleware-sdk-s3": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.723.0.tgz",
-      "integrity": "sha512-hniWi1x4JHVwKElANh9afKIMUhAutHVBRD8zo6usr0PAoj+Waf220+1ULS74GXtLXAPCiNXl5Og+PHA7xT8ElQ==",
+      "version": "3.699.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.699.0.tgz",
+      "integrity": "sha512-kuiEW9DWs7fNos/SM+y58HCPhcIzm1nEZLhe2/7/6+TvAYLuEWURYsbK48gzsxXlaJ2k/jGY3nIsA7RptbMOwA==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.723.0"
+        "@aws-sdk/client-sso-oidc": "^3.699.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
+      "integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.723.0.tgz",
-      "integrity": "sha512-ZhEfvUwNliOQROcAk34WJWVYTlTa4694kSVhDSjW6lE1bMataPnIN8A0ycukEzBXmd8ZSoBcQLn6lKGl7XIJ5w==",
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.693.0.tgz",
+      "integrity": "sha512-WC8x6ca+NRrtpAH64rWu+ryDZI3HuLwlEr8EU6/dbC/pt+r/zC0PBoC15VEygUaBA+isppCikQpGyEDu0Yj7gQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.723.0.tgz",
-      "integrity": "sha512-vR1ZfAUvrTtdA1Q78QxgR8TFgi2gzk+N4EmNjbyR5hHmeOXuaKRdhbNQAzLPYVe1aNUpoiy9cl8mWkg9SrNHBw==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.696.0.tgz",
+      "integrity": "sha512-T5s0IlBVX+gkb9g/I6CLt4yAZVzMSiGnbUqWihWsHvQR1WOoIcndQy/Oz/IJXT9T2ipoy7a80gzV6a5mglrioA==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-endpoints": "^2.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
+      "integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
-      "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.696.0.tgz",
+      "integrity": "sha512-Z5rVNDdmPOe6ELoM5AhF/ja5tSjbe6ctSctDPb0JdDf4dT0v2MfwhJKzXju2RzX8Es/77Glh7MlaXLE0kCB9+Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.723.0.tgz",
-      "integrity": "sha512-uCtW5sGq8jCwA9w57TvVRIwNnPbSDD1lJaTIgotf7Jit2bTrYR64thgMy/drL5yU5aHOdFIQljqn/5aDXLtTJw==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.696.0.tgz",
+      "integrity": "sha512-KhKqcfyXIB0SCCt+qsu4eJjsfiOrNzK5dCV7RAW2YIpp+msxGUUX0NdRE9rkzjiv+3EMktgJm3eEIS+yxtlVdQ==",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1030,15 +1030,15 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.723.0.tgz",
-      "integrity": "sha512-5xK2SqGU1mzzsOeemy7cy3fGKxR1sEpUs4pEiIjaT0OIvU+fZaDVUEYWOqsgns6wI90XZEQJlXtI8uAHX/do5Q==",
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.696.0.tgz",
+      "integrity": "sha512-dn1mX+EeqivoLYnY7p2qLrir0waPnCgS/0YdRCAVU2x14FgfUYCH6Im3w3oi2dMwhxfKY5lYVB5NKvZu7uI9lQ==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1104,13 +1104,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.26.2",
-        "@babel/types": "^7.26.0",
+        "@babel/parser": "^7.26.3",
+        "@babel/types": "^7.26.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -1224,12 +1224,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1475,16 +1475,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+      "version": "7.26.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.3",
+        "@babel/parser": "^7.26.3",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/types": "^7.26.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1502,9 +1502,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -1900,7 +1900,6 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
       "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -1919,7 +1918,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1932,7 +1930,6 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -1942,7 +1939,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1962,12 +1958,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1981,7 +1987,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -1995,21 +2000,33 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
       }
@@ -2070,7 +2087,6 @@
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
-      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
@@ -2081,12 +2097,35 @@
         "node": ">=10.10.0"
       }
     },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
-      "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": ">=12.22"
@@ -2102,7 +2141,6 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2492,9 +2530,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -2544,7 +2582,6 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -2558,7 +2595,6 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2568,7 +2604,6 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -2586,15 +2621,15 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.1.tgz",
-      "integrity": "sha512-lyeeeZyESFo+ffI801SaBKmCfsvarO+dgV8/0gD8u1d87clbEdWsP5yC+dSj3zLhb2eIf5SJrn6vDz9AheETHw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.0.0",
-        "@octokit/request": "^8.0.2",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -2603,12 +2638,11 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.2.tgz",
-      "integrity": "sha512-qhKW8YLIi+Kmc92FQUFGr++DYtkx/1fBv+Thua6baqnjnOsgBYJDCvWZR1YcINuHGOEQt416WOfE+A/oG60NBQ==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
       "dependencies": {
-        "@octokit/types": "^12.0.0",
-        "is-plain-object": "^5.0.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -2616,12 +2650,12 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
-      "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
       "dependencies": {
-        "@octokit/request": "^8.0.1",
-        "@octokit/types": "^12.0.0",
+        "@octokit/request": "^8.3.0",
+        "@octokit/types": "^13.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -2629,47 +2663,72 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.2.tgz",
-      "integrity": "sha512-8li32fUDUeml/ACRp/njCWTsk5t17cfTM1jp9n08pBrqs5cDFJubtjsSnuz56r5Tad6jdEPJld7LxNp9dNcyjQ=="
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.4.tgz",
-      "integrity": "sha512-MvZx4WvfhBnt7PtH5XE7HORsO7bBk4er1FgRIUr1qJ89NR2I6bWjGyKsxk8z42FPQ34hFQm0Baanh4gzdZR4gQ==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
+      "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
       "dependencies": {
-        "@octokit/types": "^12.3.0"
+        "@octokit/types": "^12.6.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=5"
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.1.5.tgz",
-      "integrity": "sha512-LMEdsMV8TTMjMTqVoqMzV95XTbv0ZsWxCxQtjAunQOCdwoDH4BVF/Ke5JMSZEVCWGI2kzxnUNbFnK/MxwV7NjA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
       "dependencies": {
-        "@octokit/types": "^12.3.0"
+        "@octokit/types": "^12.6.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=5"
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.5.tgz",
-      "integrity": "sha512-zVKbNbX1xUluD9ZR4/tPs1yuYrK9xeh5fGZUXA6u04XGsTvomg0YO8/ZUC0FqAd49hAOEMFPAVUTh+2lBhOhLA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
       "dependencies": {
-        "@octokit/endpoint": "^9.0.0",
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0",
-        "is-plain-object": "^5.0.0",
+        "@octokit/endpoint": "^9.0.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -2677,11 +2736,11 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-      "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       },
@@ -2690,11 +2749,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.3.0.tgz",
-      "integrity": "sha512-nJ8X2HRr234q3w/FcovDlA+ttUU4m1eJAourvfUUtwAWeqL8AsyRqfnLvVnYn3NFbUnsmzQCzLNdFerPwdmcDQ==",
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.2.tgz",
+      "integrity": "sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==",
       "dependencies": {
-        "@octokit/openapi-types": "^19.0.2"
+        "@octokit/openapi-types": "^22.2.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -2722,670 +2781,643 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.0.tgz",
-      "integrity": "sha512-xFNL1ZfluscKiVI0qlPEnu7pL1UgNNIzQdjTPkaO7JCJtIkbArPYNtqbxohuNaQdksJ01Tn1wLbDA5oIp62P8w==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
-      "integrity": "sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
       "dependencies": {
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
-      "integrity": "sha512-R9wM2yPmfEMsUmlMlIgSzOyICs0x9uu7UTHoccMyt7BWw8shcGM8HqB355+BZCPBcySvbTYMs62EgEQkNxz2ig==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
       "dependencies": {
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.0.tgz",
-      "integrity": "sha512-29pIDlUY/a9+ChJPAarPiD9cU8fBtBh0wFnmnhj7j5AhgMzc+uyXdfzmziH6xx2jzw54waSP3HfnFkTANZuPYA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-pKaas7RWvPljJ8uByCeBa10rtbVJCy4N/Fr7OSPxFezcyG0SQuXWnESZqzXj7m2+A+kPzG6fKyP4wrKidl2Ikg==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.7.tgz",
+      "integrity": "sha512-8olpW6mKCa0v+ibCjoCzgZHQx1SQmZuW/WkrdZo73wiTprTH6qhmskT60QLFdT9DRa5mXxjz89kQPZ7ZSsoqqg==",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.4",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.0.tgz",
-      "integrity": "sha512-+hTShyZHiq2AVFOxJja3k6O17DKU6TaZbwr2y1OH5HQtUw2a+7O3mMR+10LVmc39ef72SAj+uFX0IW9rJGaLQQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.0.tgz",
-      "integrity": "sha512-YvKUUOo3qehqOxNrkax3YKXF1v0ff475FhDgbBmF8Bo0oOOpsXZyltjQnwBzIeTYo446ZPV85KM3kY4YoxUNOg==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.10.tgz",
+      "integrity": "sha512-323B8YckSbUH0nMIpXn7HZsAVKHYHFUODa8gG9cHo0ySvA1fr5iWaNT+iIL0UCqUzG6QPHA3BSsBtRQou4mMqQ==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.0.tgz",
-      "integrity": "sha512-YRwsVPJU/DN1VshH8tKs4CxY66HLhmDSw6oZDM2LVIgHODsqpJBcRdEfcnb97ULmgyFrWxTjL9UXpyKPuJXQRA==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.14.tgz",
+      "integrity": "sha512-kbrt0vjOIihW3V7Cqj1SXQvAI5BR8SnyQYsandva0AOR307cXAc+IhPngxIPslxTLfxwDpNu0HzCAq6g42kCPg==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.0.tgz",
-      "integrity": "sha512-OZ/aK9LHsZch0VZ6bnf+dPD80kJripnZnkc36QNymnej49VkHJLSNJxsM0pwt53FA6+fUYYMMT0DVDTH1Msq2g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.11.tgz",
+      "integrity": "sha512-P2pnEp4n75O+QHjyO7cbw/vsw5l93K/8EWyjNCAAybYwUmj3M+hjSQZ9P5TVdUgEG08ueMAP5R4FkuSkElZ5tQ==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.0.tgz",
-      "integrity": "sha512-10b4F+zXbzxZHKuP+m2st/C+rEGK7FUut1dNSRw6DQCCfaTUecJGCoHPCmk2CRvuMTzunVpS1BKLMk839318VQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.13.tgz",
+      "integrity": "sha512-zqy/9iwbj8Wysmvi7Lq7XFLeDgjRpTbCfwBhJa8WbrylTAHiAu6oQTwdY7iu2lxigbc9YYr9vPv5SzYny5tCXQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.0.tgz",
-      "integrity": "sha512-HEhZpf731J3oFYJtaKO3dnV6stIjA+lJwXuXGu/WbSgicDWGAOITUwTt9ynldEFsnFkNu9b/C4ebXnJA16xSCA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.13.tgz",
+      "integrity": "sha512-L1Ib66+gg9uTnqp/18Gz4MDpJPKRE44geOjOQ2SVc0eiaO5l255ADziATZgjQjqumC7yPtp1XnjHlF1srcwjKw==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/eventstream-codec": "^3.1.10",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.0.tgz",
-      "integrity": "sha512-jUEq+4056uqsDLRqQb1fm48rrSMBYcBxVvODfiP37ORcV5n9xWJQsINWcIffyYxWTM5K0Y/GOfhSQGDtWpAPpQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz",
+      "integrity": "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/querystring-builder": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.0.tgz",
-      "integrity": "sha512-JBXNC2YCDlm9uqP/eQJbK6auahAaq4HndJC2PURxWPRUDjbXDRJS5Npfi+7zSxKOSOWxXCG/3dLE5D8znI9l/w==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.10.tgz",
+      "integrity": "sha512-elwslXOoNunmfS0fh55jHggyhccobFkexLYC1ZeZ1xP2BTSrcIBaHV2b4xUQOdctrSNOpMqOZH1r2XzWTEhyfA==",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.0.0",
-        "@smithy/chunked-blob-reader-native": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.0.tgz",
-      "integrity": "sha512-25OxGYGnG3JPEOTk4iFE03bfmoC6GXUQ4L13z4cNdsS3mkncH22AGSDRfKwwEqutNUxXQZWVy9f72Fm59C9qlg==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.0.0.tgz",
-      "integrity": "sha512-MRgYnr9atik1c02mdgjjJkNK5A8IvRRlpa/zOdA8PxmQtBCwjODKzobyI166uamxrL20wg7vuKoVSAjQU4IXfw==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.10.tgz",
+      "integrity": "sha512-olomK/jZQ93OMayW1zfTHwcbwBdhcZOHsyWyiZ9h9IXvc1mCD/VuvzbLb3Gy/qNJwI4MANPLctTp2BucV2oU/Q==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.0.tgz",
-      "integrity": "sha512-0GTyet02HX/sPctEhOExY+3HI7hwkVwOoJg0XnItTJ+Xw7JMuL9FOxALTmKVIV6+wg0kF6veLeg72hVSbD9UCw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.0.0.tgz",
-      "integrity": "sha512-NUjbK+M1RNd0J/mM3eh4Yw5SfUrJBsIAea/H5dvc8tirxWFHFDUHJ/CK40/vtY3niiYnygWjZZ+ISydray6Raw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.11.tgz",
+      "integrity": "sha512-3NM0L3i2Zm4bbgG6Ymi9NBcxXhryi3uE8fIfHJZIOfZVxOkGdjdgjR9A06SFIZCfnEIWKXZdm6Yq5/aPXFFhsQ==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.0.tgz",
-      "integrity": "sha512-nM1RJqLwkSCidumGK8WwNEZ0a0D/4LkwqdPna+QmHrdPoAK6WGLyZFosdMpsAW1OIbDLWGa+r37Mo4Vth4S4kQ==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.0.tgz",
-      "integrity": "sha512-/f6z5SqUurmqemhBZNhM0c+C7QW0AY/zJpic//sbdu26q98HSPAI/xvzStjYq+UhtWeAe/jaX6gamdL/2r3W1g==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.8.tgz",
+      "integrity": "sha512-OEJZKVUEhMOqMs3ktrTWp7UvvluMJEvD5XgQwRePSbDg1VvBaL8pX8mwPltFn6wk1GySbcVwwyldL8S+iqnrEQ==",
       "dependencies": {
-        "@smithy/core": "^3.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.0.tgz",
-      "integrity": "sha512-K6tsFp3Ik44H3694a+LWoXLV8mqy8zn6/vTw2feU72MaIzi51EHMVNNxxpL6e2GI6oxw8FFRGWgGn8+wQRrHZQ==",
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.34.tgz",
+      "integrity": "sha512-yVRr/AAtPZlUvwEkrq7S3x7Z8/xCd97m2hLDaqdz6ucP2RKHsBjEqaUA2ebNv2SsZoPEi+ZD0dZbOB1u37tGCA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/service-error-classification": "^4.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.0.tgz",
-      "integrity": "sha512-aW4Zo8Cm988RCvhysErzqrQ4YPKgZFhajvgPoZnsWIDaZfT419J17Ahr13Lul3kqGad2dCz7YOrXd7r+UAEj/w==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.0.tgz",
-      "integrity": "sha512-4NFaX88RmgVrCyJv/3RsSdqMwxzI/EQa8nvhUDVxmLUMRS2JUdHnliD6IwKuqIwIzz+E1aZK3EhSHUM4HXp3ww==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.0.tgz",
-      "integrity": "sha512-Crp9rg1ewjqgM2i7pWSpNhfbBa0usyKGDVQLEXTOpu6trFqq3BFLLCgbCE1S18h6mxqKnOqUONq3nWOxUk75XA==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.0.tgz",
-      "integrity": "sha512-WvumtEaFyxaI95zmj6eYlF/vCFCKNyru3P/UUHCUS9BjvajUtNckH2cY3bBfi+qqMPX5gha4g26lcOlE/wPz/Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
+      "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/querystring-builder": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.0.tgz",
-      "integrity": "sha512-AJSvY1k3SdM0stGrIjL8/FIjXO7X9I7KkznXDmr76RGz+yvaDHLsLm2hSHyzAlmwEQnHaafSU2dwaV0JcnR/4w==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.0.tgz",
-      "integrity": "sha512-laAcIHWq9GQ5VdAS71DUrCj5HUHZ/89Ee+HRTLhFR5/E3toBlnZfPG+kqBajwfEB5aSdRuKslfzl5Dzrn3pr8A==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.0.tgz",
-      "integrity": "sha512-kMqPDRf+/hwm+Dmk8AQCaYTJxNWWpNdJJteeMm0jwDbmRDqSqHQ7oLEVzvOnbWJu1poVtOhv6v7jsbyx9JASsw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.0.tgz",
-      "integrity": "sha512-SbogL1PNEmm28ya0eK2S0EZEbYwe0qpaqSGrODm+uYS6dQ7pekPLVNXjBRuuLIAT26ZF2wTsp6X7AVRBNZd8qw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.0.tgz",
-      "integrity": "sha512-hIZreT6aXSG0PK/psT1S+kfeGTnYnRRlf7rU3yDmH/crSVjTbS/5h5w2J7eO2ODrQb3xfhJcYxQBREdwsZk6TA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
       "dependencies": {
-        "@smithy/types": "^4.0.0"
+        "@smithy/types": "^3.7.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.0.tgz",
-      "integrity": "sha512-Ktupe8msp2GPaKKVfiz3NNUNnslJiGGRoVh3BDpm/RChkQ5INQpqmTc2taE0XChNYumNynLfb3keekIPaiaZeg==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.0.tgz",
-      "integrity": "sha512-zqcOR1sZTuoA6K3PBNwzu4YgT1pmIwz47tYpgaJjBTfGUIMtcjUaXKtuSKEScdv+0wx45/PbXz0//hk80fky3w==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+      "integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.0.0.tgz",
-      "integrity": "sha512-AgcZ6B+JuqArYioAbaYrCpTCjYsD3/1hPSXntbN2ipsfc4hE+72RFZevUPYgsKxpy3G+QxuLfqm11i3+oX4oSA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.7.0.tgz",
+      "integrity": "sha512-9wYrjAZFlqWhgVo3C4y/9kpc68jgiSsKUnsFPzr/MSiRL93+QRDafGTfhhKAb2wsr69Ru87WTiqSfQusSmWipA==",
       "dependencies": {
-        "@smithy/core": "^3.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
+        "@smithy/core": "^2.5.7",
+        "@smithy/middleware-endpoint": "^3.2.8",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.0.0.tgz",
-      "integrity": "sha512-aNwIGSOgDOhtTRY/rrn2aeuQeKw/IFrQ998yK5l6Ah853WeWIEmFPs/EO4OpfADEdcK+igWnZytm/oUgkLgUYg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.0.tgz",
-      "integrity": "sha512-2iPpuLoH0hCKpLtqVgilHtpPKsmHihbkwBm3h3RPuEctdmuiOlFRZ2ZI8IHSwl0o4ff5IdyyJ0yu/2tS9KpUug==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
       "dependencies": {
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/is-array-buffer": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.0.tgz",
-      "integrity": "sha512-7wqsXkzaJkpSqV+Ca95pN9yQutXvhaKeCxGGmjWnRGXY1fW/yR7wr1ouNnUYCJuTS8MvmB61xp5Qdj8YMgIA2Q==",
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.34.tgz",
+      "integrity": "sha512-FumjjF631lR521cX+svMLBj3SwSDh9VdtyynTYDAiBDEf8YPP5xORNXKQ9j0105o5+ARAGnOOP/RqSl40uXddA==",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.0.tgz",
-      "integrity": "sha512-P8VK885kiRT6TEtvcQvz+L/+xIhrDhCmM664ToUtrshFSBhwGYaJWlQNAH9fXlMhwnNvR+tmh1KngKJIgQP6bw==",
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.34.tgz",
+      "integrity": "sha512-vN6aHfzW9dVVzkI0wcZoUXvfjkl4CSbM9nE//08lmUMyf00S75uuCpTrqF9uD4bD9eldIXlt53colrlwKAT8Gw==",
       "dependencies": {
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/credential-provider-imds": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.7.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.0.tgz",
-      "integrity": "sha512-kyOKbkg77lsIVN2jC08uEWm3s16eK1YdVDyi/nKeBDbUnjR30dmTEga79E5tiu5OEgTAdngNswA9V+L6xa65sA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.0.tgz",
-      "integrity": "sha512-ncuvK6ekpDqtASHg7jx3d3nrkD2BsTzUmeVgvtepuHGxtySY8qUlb4SiNRdxHYcv3pL2SwdXs70RwKBU0edW5w==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
       "dependencies": {
-        "@smithy/types": "^4.0.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.0.tgz",
-      "integrity": "sha512-64WFoC19NVuHh3HQO2QbGw+n6GzQ6VH/drxwXLOU3GDLKxUUzIR9XNm9aTVqh8/7R+y+DgITiv5LpX5XdOy73A==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.0.0.tgz",
-      "integrity": "sha512-ctcLq8Ogi2FQuGy2RxJXGGrozhFEb4p9FawB5SpTNAkNQWbNHcwrGcVSVI3FtdQtkNAINLiEdMnrx+UN/mafvw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.4.tgz",
+      "integrity": "sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/fetch-http-handler": "^4.1.3",
+        "@smithy/node-http-handler": "^3.3.3",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.0.tgz",
-      "integrity": "sha512-C8dSfGmZH0ecrmnJOw4aDXJ47krihnUtee8eDZ2fA+28wTjD4TVM3L/bBQYnBBlDVWcYzldLV7loPRsPc1kERg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.2.0.tgz",
+      "integrity": "sha512-PpjSboaDUE6yl+1qlg3Si57++e84oXdWGbuFUSAciXsVfEZJJJupR2Nb0QuXHiunt2vGR+1PTizOMvnUPaG2Qg==",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.0",
-        "@smithy/types": "^4.0.0",
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
@@ -3393,7 +3425,6 @@
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.6.2.tgz",
       "integrity": "sha512-Ic5oFNM/25iuagob6LiIBkSI/A2y45TsyKtDtODXHRZDy52WfPfeexI6r+OH5+aWN9QGob2Bw+4JRM9/4areWw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@stylistic/eslint-plugin-js": "2.6.2",
         "@stylistic/eslint-plugin-jsx": "2.6.2",
@@ -3413,7 +3444,6 @@
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.6.2.tgz",
       "integrity": "sha512-wCr/kVctAPayMU3pcOI1MKR7MoKIh6VKZU89lPklAqtJoxT+Em6RueiiARbpznUYG5eg3LymiU+aMD+aIZXdqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/eslint": "^9.6.0",
         "acorn": "^8.12.1",
@@ -3432,7 +3462,6 @@
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.6.2.tgz",
       "integrity": "sha512-dSXK/fSPA938J1fBi10QmhzLKtZ/2TuyVNHQMk8jUhWfKJDleAogaSqcWNAbN8fwcoe9UWmt/3StiIf2oYC1aQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@stylistic/eslint-plugin-js": "^2.6.2",
         "@types/eslint": "^9.6.0",
@@ -3446,25 +3475,11 @@
         "eslint": ">=8.40.0"
       }
     },
-    "node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@stylistic/eslint-plugin-plus": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.6.2.tgz",
       "integrity": "sha512-cANcPASfRvq3VTbbQCrSIXq+2AI0IW68PNYaZoXXS0ENlp7HDB8dmrsJnOgWCcoEvdCB8z/eWcG/eq/v5Qcl+Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/eslint": "^9.6.0",
         "@typescript-eslint/utils": "^8.0.0"
@@ -3478,7 +3493,6 @@
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.6.2.tgz",
       "integrity": "sha512-6OEN3VtUNxjgOvWPavnC10MByr1H4zsgwNND3rQXr5lDFv93MLUnTsH+/SH15OkuqdyJgrQILI6b9lYecb1vIg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@stylistic/eslint-plugin-js": "2.6.2",
         "@types/eslint": "^9.6.0",
@@ -3537,7 +3551,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3547,8 +3560,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -3603,15 +3615,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "22.10.5",
@@ -3648,7 +3658,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.1.0.tgz",
       "integrity": "sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.1.0",
@@ -3682,7 +3691,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
       "integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@typescript-eslint/scope-manager": "8.1.0",
@@ -3705,7 +3713,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.1.0.tgz",
       "integrity": "sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.1.0",
         "@typescript-eslint/types": "8.1.0",
@@ -3734,7 +3741,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.1.0.tgz",
       "integrity": "sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.1.0",
         "@typescript-eslint/visitor-keys": "8.1.0"
@@ -3752,7 +3758,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.1.0.tgz",
       "integrity": "sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "8.1.0",
         "@typescript-eslint/utils": "8.1.0",
@@ -3777,7 +3782,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
       "integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@typescript-eslint/scope-manager": "8.1.0",
@@ -3800,7 +3804,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.1.0.tgz",
       "integrity": "sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3814,7 +3817,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz",
       "integrity": "sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "8.1.0",
         "@typescript-eslint/visitor-keys": "8.1.0",
@@ -3838,43 +3840,16 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.16.0.tgz",
-      "integrity": "sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.1.tgz",
+      "integrity": "sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.16.0",
-        "@typescript-eslint/types": "8.16.0",
-        "@typescript-eslint/typescript-estree": "8.16.0"
+        "@typescript-eslint/scope-manager": "8.19.1",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.19.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3884,23 +3859,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.16.0.tgz",
-      "integrity": "sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
+      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.16.0",
-        "@typescript-eslint/visitor-keys": "8.16.0"
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3911,11 +3881,10 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.16.0.tgz",
-      "integrity": "sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
+      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3925,20 +3894,19 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.16.0.tgz",
-      "integrity": "sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
+      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.16.0",
-        "@typescript-eslint/visitor-keys": "8.16.0",
+        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/visitor-keys": "8.19.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
+        "ts-api-utils": "^2.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3947,20 +3915,17 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.16.0.tgz",
-      "integrity": "sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
+      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.16.0",
+        "@typescript-eslint/types": "8.19.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -3971,30 +3936,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+    "node_modules/@typescript-eslint/utils/node_modules/ts-api-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
+      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=18.12"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -4002,7 +3953,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.1.0.tgz",
       "integrity": "sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.1.0",
         "eslint-visitor-keys": "^3.4.3"
@@ -4020,7 +3970,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -4029,11 +3978,10 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
+      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
       "dev": true,
-      "license": "ISC",
       "peer": true
     },
     "node_modules/acorn": {
@@ -4041,7 +3989,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4054,7 +4001,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -4064,7 +4010,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4141,20 +4086,31 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4168,7 +4124,6 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
       "integrity": "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -4189,7 +4144,6 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4199,7 +4153,6 @@
       "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
       "integrity": "sha512-zfETvRFA8o7EiNn++N5f/kaCw221hrpGsDmcpndVupkPzEc1Wuf3VgC0qby1BbHs7f5DVYjgtEU2LLh5bqeGfQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -4216,16 +4169,15 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4235,16 +4187,15 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4254,20 +4205,18 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.3",
-        "es-errors": "^1.2.1",
-        "get-intrinsic": "^1.2.3",
-        "is-array-buffer": "^3.0.4",
-        "is-shared-array-buffer": "^1.0.2"
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4287,7 +4236,6 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -4434,13 +4382,12 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -4456,9 +4403,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
       "dev": true,
       "funding": [
         {
@@ -4475,9 +4422,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.1"
       },
       "bin": {
@@ -4515,17 +4462,44 @@
       "dev": true
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4553,9 +4527,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001686",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001686.tgz",
-      "integrity": "sha512-Y7deg0Aergpa24M3qLC5xjNklnKnhsmSyR/V89dLZ1n0ucJIFNs7PgR2Yfa/Zf6W79SbBicgtGxZr2juHkEUIA==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "dev": true,
       "funding": [
         {
@@ -4700,9 +4674,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4714,15 +4688,14 @@
       }
     },
     "node_modules/data-view-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4732,31 +4705,29 @@
       }
     },
     "node_modules/data-view-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/inspect-js"
       }
     },
     "node_modules/data-view-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       },
@@ -4768,12 +4739,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4803,7 +4774,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/deepmerge": {
@@ -4820,7 +4790,6 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -4838,7 +4807,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -4879,7 +4847,6 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -4892,13 +4859,26 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
-      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ejs": {
@@ -4917,9 +4897,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.68",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.68.tgz",
-      "integrity": "sha512-FgMdJlma0OzUYlbrtZ4AeXjKxKPk6KT8WOP8BjcqxWtlg8qyJQjRzPJzUtUn5GBg1oQ26hFs7HOOHJMYiJRnvQ==",
+      "version": "1.5.78",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.78.tgz",
+      "integrity": "sha512-UmwIt7HRKN1rsJfddG5UG7rCTCTAKoS9JeOy/R0zSenAyaZ8SU3RuXlwcratxhdxGRNpk03iq8O7BA3W7ibLVw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4941,11 +4921,10 @@
       "dev": true
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -4964,58 +4943,62 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
-      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+      "version": "1.23.9",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "arraybuffer.prototype.slice": "^1.0.3",
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "data-view-buffer": "^1.0.1",
-        "data-view-byte-length": "^1.0.1",
-        "data-view-byte-offset": "^1.0.0",
-        "es-define-property": "^1.0.0",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.0.3",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.4",
-        "get-symbol-description": "^1.0.2",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.0",
+        "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.0.3",
-        "has-symbols": "^1.0.3",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "internal-slot": "^1.0.7",
-        "is-array-buffer": "^3.0.4",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.1",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.3",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.0.2",
+        "is-data-view": "^1.0.2",
+        "is-regex": "^1.2.1",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.0",
+        "math-intrinsics": "^1.1.0",
         "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
         "regexp.prototype.flags": "^1.5.3",
-        "safe-array-concat": "^1.1.2",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.trim": "^1.2.9",
-        "string.prototype.trimend": "^1.0.8",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.2",
-        "typed-array-length": "^1.0.6",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.18"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5025,14 +5008,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -5042,7 +5021,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -5052,7 +5030,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -5061,15 +5038,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5080,7 +5057,6 @@
       "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
       "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.0"
       }
@@ -5090,7 +5066,6 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
         "is-date-object": "^1.0.5",
@@ -5156,7 +5131,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -5171,7 +5145,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -5228,7 +5201,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5241,7 +5213,6 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
       "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
         "is-core-module": "^2.13.0",
@@ -5253,7 +5224,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -5263,7 +5233,6 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
       "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",
         "enhanced-resolve": "^5.12.0",
@@ -5289,7 +5258,6 @@
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
       "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7"
       },
@@ -5307,7 +5275,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -5317,7 +5284,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
       "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5",
         "ignore": "^5.0.5"
@@ -5337,7 +5303,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -5347,7 +5312,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -5374,12 +5338,21 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -5389,7 +5362,6 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -5397,12 +5369,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5412,7 +5395,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -5430,7 +5412,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5438,12 +5419,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5457,7 +5448,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -5471,12 +5461,24 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/espree": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
@@ -5507,7 +5509,6 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -5521,7 +5522,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -5535,7 +5535,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -5602,21 +5601,19 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -5627,7 +5624,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -5646,7 +5642,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/fast-xml-parser": {
@@ -5671,11 +5666,10 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -5694,7 +5688,6 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -5710,15 +5703,6 @@
       "dev": true,
       "dependencies": {
         "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -5750,7 +5734,6 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -5768,7 +5751,6 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
@@ -5784,7 +5766,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
-      "license": "ISC",
       "peer": true
     },
     "node_modules/for-each": {
@@ -5792,7 +5773,6 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -5822,22 +5802,22 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5851,7 +5831,6 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5875,17 +5854,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5903,6 +5886,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -5916,15 +5912,14 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4"
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5938,7 +5933,6 @@
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
       "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -5950,6 +5944,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5971,7 +5966,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
-      "license": "ISC",
       "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5980,12 +5974,33 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -6002,7 +6017,6 @@
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -6019,7 +6033,6 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -6036,14 +6049,10 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.1.0.tgz",
-      "integrity": "sha512-FQoVQnqcdk4hVM4JN1eromaun4iuS34oStkdlLENLdpULsuQcTyXj8w7ayhuUfPwEYZ1ZOooOTT6fdA9Vmx/RA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -6061,15 +6070,16 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6088,7 +6098,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -6097,11 +6106,13 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -6110,11 +6121,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6127,7 +6137,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -6143,7 +6152,6 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -6171,7 +6179,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -6181,7 +6188,6 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -6226,6 +6232,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -6239,29 +6246,28 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6277,13 +6283,15 @@
       "dev": true
     },
     "node_modules/is-async-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6293,27 +6301,28 @@
       }
     },
     "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-bigints": "^1.0.1"
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6327,7 +6336,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6336,11 +6344,10 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -6352,12 +6359,13 @@
       }
     },
     "node_modules/is-data-view": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
         "is-typed-array": "^1.1.13"
       },
       "engines": {
@@ -6368,13 +6376,13 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6388,19 +6396,17 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-finalizationregistry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
-      "integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6428,13 +6434,15 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6448,7 +6456,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6461,20 +6468,6 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6492,13 +6485,13 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6512,29 +6505,19 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-regex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.0.tgz",
-      "integrity": "sha512-B6ohK4ZmoftlUe+uvenXSbPJFo6U37BH7oO1B3nQH8f/7h27N56s85MhUtbFJAziz5dcmuR3i8ovUl35zp8pFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "gopd": "^1.1.0",
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
       },
@@ -6550,7 +6533,6 @@
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6559,13 +6541,12 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6587,13 +6568,13 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6603,13 +6584,14 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6619,13 +6601,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6639,7 +6620,6 @@
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6648,27 +6628,28 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bound": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6681,8 +6662,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6772,6 +6752,28 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jest": {
@@ -7251,6 +7253,18 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -7347,9 +7361,9 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
@@ -7363,7 +7377,6 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/json-parse-even-better-errors": {
@@ -7377,7 +7390,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -7385,7 +7397,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/json5": {
@@ -7405,7 +7416,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -7434,7 +7444,6 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -7455,7 +7464,6 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -7478,7 +7486,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/lru-cache": {
@@ -7520,6 +7527,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7531,22 +7547,33 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mimic-fn": {
@@ -7559,15 +7586,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -7575,15 +7605,14 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -7599,9 +7628,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -7630,7 +7659,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
       "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7643,21 +7671,21 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -7672,7 +7700,6 @@
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
       "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -7691,7 +7718,6 @@
       "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
       "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -7702,13 +7728,13 @@
       }
     },
     "node_modules/object.values": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
-      "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
       },
@@ -7747,7 +7773,6 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -7761,12 +7786,28 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -7782,7 +7823,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -7808,7 +7848,6 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
@@ -7873,7 +7912,6 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7885,12 +7923,12 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -7974,7 +8012,6 @@
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -7984,16 +8021,15 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -8046,9 +8082,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -8089,8 +8125,7 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -8099,19 +8134,19 @@
       "dev": true
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.7.tgz",
-      "integrity": "sha512-bMvFGIUKlc/eSfXNX+aZ+EL95/EgZzuwA0OBPTbZZDEJw/0AkentjMuM1oiRfwHrshqk4RzdgiTg5CcDalXN5g==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "which-builtin-type": "^1.1.4"
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8121,15 +8156,16 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
       },
       "engines": {
@@ -8149,17 +8185,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-      "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8191,7 +8230,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -8202,7 +8240,6 @@
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -8221,7 +8258,6 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -8231,6 +8267,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -8262,21 +8299,20 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4",
-        "has-symbols": "^1.0.3",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
       "engines": {
@@ -8286,16 +8322,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
-        "is-regex": "^1.1.4"
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8309,7 +8360,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8322,7 +8372,6 @@
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -8340,12 +8389,25 @@
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8373,16 +8435,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8486,16 +8601,18 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.0",
-        "es-object-atoms": "^1.0.0"
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8505,15 +8622,18 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8524,7 +8644,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -8613,7 +8732,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8632,12 +8750,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
-      "license": "MIT",
       "peer": true
     },
     "node_modules/tmpl": {
@@ -8663,7 +8802,6 @@
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
       "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -8724,7 +8862,6 @@
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -8737,7 +8874,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -8750,15 +8886,14 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -8773,7 +8908,6 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -8796,7 +8930,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -8806,32 +8939,30 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8841,19 +8972,18 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
-      "integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13",
-        "reflect.getprototypeof": "^1.0.6"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8867,7 +8997,6 @@
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -8897,16 +9026,18 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8927,8 +9058,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -8970,7 +9100,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
@@ -9027,42 +9156,43 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-builtin-type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
-      "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.2",
         "function.prototype.name": "^1.1.6",
         "has-tostringtag": "^1.0.2",
         "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
+        "is-date-object": "^1.1.0",
         "is-finalizationregistry": "^1.1.0",
         "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
+        "is-regex": "^1.2.1",
         "is-weakref": "^1.0.2",
         "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
+        "which-boxed-primitive": "^1.1.0",
         "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.15"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9076,7 +9206,6 @@
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -9091,16 +9220,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
-      "integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -9115,7 +9244,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9203,7 +9331,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
-    "@aws-sdk/client-s3": "^3.723.0",
-    "@aws-sdk/credential-providers": "^3.723.0",
+    "@aws-sdk/client-s3": "3.703.0",
+    "@aws-sdk/credential-providers": "3.699.0",
     "esbuild": "^0.24.2",
     "js-yaml": "^4.1.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,19 +115,6 @@ export const main = async (options: Options): Promise<void> => {
 				roleArn: roleArn,
 				webIdentityToken: idToken,
 			}),
-
-			/*
-      Increase the timeout. Since updating `@aws-sdk/client-s3` to v3.717.0 we've seen an increase of timeouts:
-      > RequestTimeout: Your socket connection to the server was not read from or written to within the timeout period. Idle connections will be closed.
-
-      See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html
-       */
-			requestHandler: {
-				requestTimeout: 10 * 1000, // 10 seconds
-			},
-
-			// Enable AWS SDK logging if the action is run in debug mode
-			...(core.isDebug() && { logger: { ...console } }),
 		}),
 	);
 	const keyPrefix = riffraffPrefix(mfest);


### PR DESCRIPTION
> [!WARNING]
> This change configures Dependabot to ignore AWS SDK libraries. This has a potential risk of making it more difficult to update in the future as there'll be a bigger jump. This action is the interface between GitHub and Riff-Raff; we're favouring reliability here.

## What does this change?
Since the upgrade, we've experienced `RequestTimeout` errors in the build of a `guardian/dotcom-rendering`. We patched this in https://github.com/guardian/actions-riff-raff/releases/tag/v4.1.4.

Today, we started seeing `guardian/ophan` experience the same issues. This means the randomly chosen 10 second timeout applied in https://github.com/guardian/actions-riff-raff/pull/191 doesn't work for all cases.

<details><summary>S3 upload failure from `guardian/ophan`</summary>
<p>

<img width="1338" alt="image" src="https://github.com/user-attachments/assets/ccf40b34-f73b-4a52-b269-1f0ba15fdda2" />

</p>
</details> 

Rather than increase the timeout to another randomly selected value, this change "reverts" the `@aws-sdk/client-s3` and `@aws-sdk/credential-providers` libraries back to known working versions. Essentially reverting to v4.1.2.

We should implement more automated testing before we re-enable Dependabot to catch similar regressions at CI time. This should be a separate change.

> [!NOTE]
> - This is not a revert in the git sense as the relevant commits are interleaved with others.
> - We're now pinning the version number, whereas previously it was ranged. The meaningful diff can be seen here - https://github.com/guardian/actions-riff-raff/compare/v4.1.2...363ffd961dbe42f6e6f743084d48adc396ced65c.

## How can we measure success?
This action is more reliable!