### PR TITLE
fix: Only annotate a pull request

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61406,7 +61406,8 @@ function defaultS3ErrorMessage(projectName) {
   );
 }
 async function handleS3UploadError(thrownError, octokit, branchName2, projectName) {
-  if (thrownError instanceof import_client_s3.S3ServiceException && thrownError.name === "AccessDenied") {
+  if (import_github.context.eventName === "pull_request" && // Annotations can only be seen in a PR.
+  thrownError instanceof import_client_s3.S3ServiceException && thrownError.name === "AccessDenied") {
     const workflow = envOrUndefined("GITHUB_WORKFLOW_REF") ?? "";
     const regex = /^.+\/.+\/(?<filename>\.github\/workflows\/\w+\.(yaml|yml)).*$/;
     const { filename } = regex.exec(workflow)?.groups ?? {};

--- a/dist/index.js
+++ b/dist/index.js
@@ -61554,7 +61554,7 @@ async function getPullRequestNumber(octokit) {
 }
 
 // src/riffraff.ts
-var manifest = (projectName, buildNumber, branch, vcsURL2, revision, buildTool) => {
+var getManifest = (projectName, buildNumber, branch, vcsURL2, revision, buildTool) => {
   return {
     branch,
     vcsURL: vcsURL2,
@@ -61633,7 +61633,7 @@ var main = async (options) => {
     githubToken: githubToken2
   } = config;
   const octokit = (0, import_github3.getOctokit)(githubToken2);
-  const mfest = manifest(
+  const manifest = getManifest(
     projectName,
     buildNumber,
     branchName2,
@@ -61641,7 +61641,7 @@ var main = async (options) => {
     revision,
     "guardian/actions-riff-raff"
   );
-  const manifestJSON = JSON.stringify(mfest);
+  const manifestJSON = JSON.stringify(manifest);
   const stagingDir = stagingDirInput ?? fs3.mkdtempSync("staging-");
   core5.info("writing rr yaml...");
   write(`${stagingDir}/riff-raff.yaml`, dump(riffRaffYaml));
@@ -61663,7 +61663,7 @@ var main = async (options) => {
       })
     })
   );
-  const keyPrefix = riffraffPrefix(mfest);
+  const keyPrefix = riffraffPrefix(manifest);
   core5.info(`S3 prefix: ${keyPrefix}`);
   try {
     await sync(store, stagingDir, "riffraff-artifact", keyPrefix);

--- a/dist/index.js
+++ b/dist/index.js
@@ -61599,12 +61599,6 @@ var sync = async (store, dir, bucket, keyPrefix) => {
 
 // src/index.ts
 var GITHUB_OIDC_AUDIENCE = "sts.amazonaws.com";
-var RiffRaffUploadError = class extends Error {
-  constructor(message) {
-    super(message);
-    this.name = "RiffRaffUploadError";
-  }
-};
 function validateTopics(topics) {
   const deployableTopics = ["production", "hackday", "prototype", "learning"];
   const hasValidTopic = topics.some(
@@ -61612,7 +61606,7 @@ function validateTopics(topics) {
   );
   if (!hasValidTopic) {
     const topicList = deployableTopics.join(", ");
-    throw new RiffRaffUploadError(
+    throw new Error(
       `No valid repository topic found. Add one of ${topicList}. See https://github.com/guardian/recommendations/blob/main/github.md#topics`
     );
   } else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -61674,15 +61674,15 @@ var main = async (options) => {
       keyPrefix + "/build.json"
     );
     core5.info("Upload complete.");
-    if (options.WithSummary) {
-      await core5.summary.addHeading("Riff-Raff").addTable([
-        ["Project name", projectName],
-        ["Build number", buildNumber]
-      ]).write();
-    }
   } catch (err) {
     await handleS3UploadError(err, octokit, branchName2, projectName);
     throw err;
+  }
+  if (options.WithSummary) {
+    await core5.summary.addHeading("Riff-Raff").addTable([
+      ["Project name", projectName],
+      ["Build number", buildNumber]
+    ]).write();
   }
   if (pullRequestComment.commentingEnabled) {
     try {

--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -35,6 +35,7 @@ export async function handleS3UploadError(
 	projectName: string,
 ) {
 	if (
+		context.eventName === 'pull_request' && // Annotations can only be seen in a PR.
 		thrownError instanceof S3ServiceException &&
 		thrownError.name === 'AccessDenied'
 	) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { handleS3UploadError } from './error-handling';
 import { cp, printDir, write } from './file';
 import { commentOnPullRequest, getPullRequestNumber } from './pr-comment';
 import type { Deployment } from './riffraff';
-import { manifest, riffraffPrefix } from './riffraff';
+import { getManifest, riffraffPrefix } from './riffraff';
 import { S3Store, sync } from './s3';
 import type { Octokit } from './types';
 
@@ -67,7 +67,7 @@ export const main = async (options: Options): Promise<void> => {
 
 	const octokit: Octokit = getOctokit(githubToken);
 
-	const mfest = manifest(
+	const manifest = getManifest(
 		projectName,
 		buildNumber,
 		branchName,
@@ -75,7 +75,7 @@ export const main = async (options: Options): Promise<void> => {
 		revision,
 		'guardian/actions-riff-raff',
 	);
-	const manifestJSON = JSON.stringify(mfest);
+	const manifestJSON = JSON.stringify(manifest);
 
 	// Ensure unique name as multiple steps may run using this action within the
 	// same workflow (this has happened!).
@@ -105,7 +105,7 @@ export const main = async (options: Options): Promise<void> => {
 			}),
 		}),
 	);
-	const keyPrefix = riffraffPrefix(mfest);
+	const keyPrefix = riffraffPrefix(manifest);
 
 	core.info(`S3 prefix: ${keyPrefix}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,13 +22,6 @@ interface Options {
 	WithSummary: boolean; // Use to disable summary when running locally.
 }
 
-class RiffRaffUploadError extends Error {
-	constructor(message: string) {
-		super(message);
-		this.name = 'RiffRaffUploadError';
-	}
-}
-
 function validateTopics(topics: string[]): void {
 	const deployableTopics = ['production', 'hackday', 'prototype', 'learning'];
 	const hasValidTopic = topics.some((topic) =>
@@ -36,7 +29,7 @@ function validateTopics(topics: string[]): void {
 	);
 	if (!hasValidTopic) {
 		const topicList = deployableTopics.join(', ');
-		throw new RiffRaffUploadError(
+		throw new Error(
 			`No valid repository topic found. Add one of ${topicList}. See https://github.com/guardian/recommendations/blob/main/github.md#topics`,
 		);
 	} else {

--- a/src/riffraff.ts
+++ b/src/riffraff.ts
@@ -8,7 +8,7 @@ export type Manifest = {
 	buildTool: string;
 };
 
-export const manifest = (
+export const getManifest = (
 	projectName: string,
 	buildNumber: string,
 	branch: string,


### PR DESCRIPTION
## What does this change?
An update to #227, annotating only when the action was invoked by a pull request as that's the only place annotations appear.

I've also added some refactors. These could be split into their own PRs TBH, they are in their own commits though.