### PR TITLE
Fix local tests

### DIFF
--- a/fixtures/github-event.json
+++ b/fixtures/github-event.json
@@ -1,0 +1,6 @@
+{
+  "repository": {
+    "topics": ["production"],
+    "full_name": "guardian/actions-riff-raff"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "prettier": "@guardian/prettier",
   "jest": {
     "preset": "ts-jest/presets/default-esm",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "setupFiles": ["./src/jest.setup.ts"]
   }
 }

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -1,0 +1,6 @@
+import * as path from 'path';
+
+process.env.GITHUB_EVENT_PATH ??= path.resolve(
+	import.meta.dirname,
+	'../fixtures/github-event.json',
+);


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Tests fail to run locally because we try to validate the topics of a repository, which are in a data structure made available by `@actions/github`, which is assembles from be a json payload placed at `GITHUB_EVENT_PATH`. The error is

```
 FAIL  src/index.test.ts
  ● action › should generate expected file structure

    TypeError: Cannot read properties of undefined (reading 'some')

      25 | function validateTopics(topics: string[]): void {
      26 |      const deployableTopics = ['production', 'hackday', 'prototype', 'learning'];
    > 27 |      const hasValidTopic = topics.some((topic) =>
         |                                   ^
      28 |              deployableTopics.includes(topic),
      29 |      );
      30 |      if (!hasValidTopic) {

      at validateTopics (src/index.ts:27:31)
      at main (src/index.ts:49:2)
      at Object.<anonymous> (src/index.test.ts:53:9)
```


This change adds a mock payload with a valid topic so tests pass.

Implemented with copilot and using Opus 4.5

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Ran locally
```
npm test

> @guardian/actions-riff-raff@0.0.0 test
> NODE_OPTIONS='--experimental-vm-modules' jest

(node:7501) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/riffraff.test.ts
(node:7500) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/file.test.ts
(node:7499) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/index.test.ts

Test Suites: 3 passed, 3 total
Tests:       3 passed, 3 total
Snapshots:   0 total
```
