### PR TITLE
Support artifacts >2gb using multipart upload

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31820,126 +31820,126 @@ var require_fxp = __commonJS({
   "node_modules/fast-xml-parser/lib/fxp.cjs"(exports2, module2) {
     (() => {
       "use strict";
-      var t4 = { d: (e5, n5) => {
-        for (var i5 in n5) t4.o(n5, i5) && !t4.o(e5, i5) && Object.defineProperty(e5, i5, { enumerable: true, get: n5[i5] });
+      var t4 = { d: (e5, i5) => {
+        for (var n5 in i5) t4.o(i5, n5) && !t4.o(e5, n5) && Object.defineProperty(e5, n5, { enumerable: true, get: i5[n5] });
       }, o: (t5, e5) => Object.prototype.hasOwnProperty.call(t5, e5), r: (t5) => {
         "undefined" != typeof Symbol && Symbol.toStringTag && Object.defineProperty(t5, Symbol.toStringTag, { value: "Module" }), Object.defineProperty(t5, "__esModule", { value: true });
       } }, e4 = {};
-      t4.r(e4), t4.d(e4, { XMLBuilder: () => dt, XMLParser: () => it, XMLValidator: () => gt });
-      const n4 = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD", i4 = new RegExp("^[" + n4 + "][" + n4 + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");
+      t4.r(e4), t4.d(e4, { XMLBuilder: () => $t, XMLParser: () => gt, XMLValidator: () => It });
+      const i4 = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD", n4 = new RegExp("^[" + i4 + "][" + i4 + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$");
       function s4(t5, e5) {
-        const n5 = [];
-        let i5 = e5.exec(t5);
-        for (; i5; ) {
+        const i5 = [];
+        let n5 = e5.exec(t5);
+        for (; n5; ) {
           const s5 = [];
-          s5.startIndex = e5.lastIndex - i5[0].length;
-          const r5 = i5.length;
-          for (let t6 = 0; t6 < r5; t6++) s5.push(i5[t6]);
-          n5.push(s5), i5 = e5.exec(t5);
+          s5.startIndex = e5.lastIndex - n5[0].length;
+          const r5 = n5.length;
+          for (let t6 = 0; t6 < r5; t6++) s5.push(n5[t6]);
+          i5.push(s5), n5 = e5.exec(t5);
         }
-        return n5;
+        return i5;
       }
       const r4 = function(t5) {
-        return !(null == i4.exec(t5));
-      }, o4 = { allowBooleanAttributes: false, unpairedTags: [] };
-      function a4(t5, e5) {
-        e5 = Object.assign({}, o4, e5);
-        const n5 = [];
-        let i5 = false, s5 = false;
+        return !(null == n4.exec(t5));
+      }, o4 = ["hasOwnProperty", "toString", "valueOf", "__defineGetter__", "__defineSetter__", "__lookupGetter__", "__lookupSetter__"], a4 = ["__proto__", "constructor", "prototype"], h4 = { allowBooleanAttributes: false, unpairedTags: [] };
+      function l4(t5, e5) {
+        e5 = Object.assign({}, h4, e5);
+        const i5 = [];
+        let n5 = false, s5 = false;
         "\uFEFF" === t5[0] && (t5 = t5.substr(1));
-        for (let o5 = 0; o5 < t5.length; o5++) if ("<" === t5[o5] && "?" === t5[o5 + 1]) {
-          if (o5 += 2, o5 = u4(t5, o5), o5.err) return o5;
+        for (let r5 = 0; r5 < t5.length; r5++) if ("<" === t5[r5] && "?" === t5[r5 + 1]) {
+          if (r5 += 2, r5 = u4(t5, r5), r5.err) return r5;
         } else {
-          if ("<" !== t5[o5]) {
-            if (l4(t5[o5])) continue;
-            return m4("InvalidChar", "char '" + t5[o5] + "' is not expected.", b4(t5, o5));
+          if ("<" !== t5[r5]) {
+            if (p4(t5[r5])) continue;
+            return b4("InvalidChar", "char '" + t5[r5] + "' is not expected.", w4(t5, r5));
           }
           {
-            let a5 = o5;
-            if (o5++, "!" === t5[o5]) {
-              o5 = h4(t5, o5);
+            let o5 = r5;
+            if (r5++, "!" === t5[r5]) {
+              r5 = c4(t5, r5);
               continue;
             }
             {
-              let d5 = false;
-              "/" === t5[o5] && (d5 = true, o5++);
-              let p5 = "";
-              for (; o5 < t5.length && ">" !== t5[o5] && " " !== t5[o5] && "	" !== t5[o5] && "\n" !== t5[o5] && "\r" !== t5[o5]; o5++) p5 += t5[o5];
-              if (p5 = p5.trim(), "/" === p5[p5.length - 1] && (p5 = p5.substring(0, p5.length - 1), o5--), !r4(p5)) {
+              let a5 = false;
+              "/" === t5[r5] && (a5 = true, r5++);
+              let h5 = "";
+              for (; r5 < t5.length && ">" !== t5[r5] && " " !== t5[r5] && "	" !== t5[r5] && "\n" !== t5[r5] && "\r" !== t5[r5]; r5++) h5 += t5[r5];
+              if (h5 = h5.trim(), "/" === h5[h5.length - 1] && (h5 = h5.substring(0, h5.length - 1), r5--), !y2(h5)) {
                 let e6;
-                return e6 = 0 === p5.trim().length ? "Invalid space after '<'." : "Tag '" + p5 + "' is an invalid name.", m4("InvalidTag", e6, b4(t5, o5));
+                return e6 = 0 === h5.trim().length ? "Invalid space after '<'." : "Tag '" + h5 + "' is an invalid name.", b4("InvalidTag", e6, w4(t5, r5));
               }
-              const c5 = f4(t5, o5);
-              if (false === c5) return m4("InvalidAttr", "Attributes for '" + p5 + "' have open quote.", b4(t5, o5));
-              let E3 = c5.value;
-              if (o5 = c5.index, "/" === E3[E3.length - 1]) {
-                const n6 = o5 - E3.length;
-                E3 = E3.substring(0, E3.length - 1);
-                const s6 = g4(E3, e5);
-                if (true !== s6) return m4(s6.err.code, s6.err.msg, b4(t5, n6 + s6.err.line));
-                i5 = true;
-              } else if (d5) {
-                if (!c5.tagClosed) return m4("InvalidTag", "Closing tag '" + p5 + "' doesn't have proper closing.", b4(t5, o5));
-                if (E3.trim().length > 0) return m4("InvalidTag", "Closing tag '" + p5 + "' can't have attributes or invalid starting.", b4(t5, a5));
-                if (0 === n5.length) return m4("InvalidTag", "Closing tag '" + p5 + "' has not been opened.", b4(t5, a5));
+              const l5 = g4(t5, r5);
+              if (false === l5) return b4("InvalidAttr", "Attributes for '" + h5 + "' have open quote.", w4(t5, r5));
+              let d5 = l5.value;
+              if (r5 = l5.index, "/" === d5[d5.length - 1]) {
+                const i6 = r5 - d5.length;
+                d5 = d5.substring(0, d5.length - 1);
+                const s6 = x4(d5, e5);
+                if (true !== s6) return b4(s6.err.code, s6.err.msg, w4(t5, i6 + s6.err.line));
+                n5 = true;
+              } else if (a5) {
+                if (!l5.tagClosed) return b4("InvalidTag", "Closing tag '" + h5 + "' doesn't have proper closing.", w4(t5, r5));
+                if (d5.trim().length > 0) return b4("InvalidTag", "Closing tag '" + h5 + "' can't have attributes or invalid starting.", w4(t5, o5));
+                if (0 === i5.length) return b4("InvalidTag", "Closing tag '" + h5 + "' has not been opened.", w4(t5, o5));
                 {
-                  const e6 = n5.pop();
-                  if (p5 !== e6.tagName) {
-                    let n6 = b4(t5, e6.tagStartPos);
-                    return m4("InvalidTag", "Expected closing tag '" + e6.tagName + "' (opened in line " + n6.line + ", col " + n6.col + ") instead of closing tag '" + p5 + "'.", b4(t5, a5));
+                  const e6 = i5.pop();
+                  if (h5 !== e6.tagName) {
+                    let i6 = w4(t5, e6.tagStartPos);
+                    return b4("InvalidTag", "Expected closing tag '" + e6.tagName + "' (opened in line " + i6.line + ", col " + i6.col + ") instead of closing tag '" + h5 + "'.", w4(t5, o5));
                   }
-                  0 == n5.length && (s5 = true);
+                  0 == i5.length && (s5 = true);
                 }
               } else {
-                const r5 = g4(E3, e5);
-                if (true !== r5) return m4(r5.err.code, r5.err.msg, b4(t5, o5 - E3.length + r5.err.line));
-                if (true === s5) return m4("InvalidXml", "Multiple possible root nodes found.", b4(t5, o5));
-                -1 !== e5.unpairedTags.indexOf(p5) || n5.push({ tagName: p5, tagStartPos: a5 }), i5 = true;
+                const a6 = x4(d5, e5);
+                if (true !== a6) return b4(a6.err.code, a6.err.msg, w4(t5, r5 - d5.length + a6.err.line));
+                if (true === s5) return b4("InvalidXml", "Multiple possible root nodes found.", w4(t5, r5));
+                -1 !== e5.unpairedTags.indexOf(h5) || i5.push({ tagName: h5, tagStartPos: o5 }), n5 = true;
               }
-              for (o5++; o5 < t5.length; o5++) if ("<" === t5[o5]) {
-                if ("!" === t5[o5 + 1]) {
-                  o5++, o5 = h4(t5, o5);
+              for (r5++; r5 < t5.length; r5++) if ("<" === t5[r5]) {
+                if ("!" === t5[r5 + 1]) {
+                  r5++, r5 = c4(t5, r5);
                   continue;
                 }
-                if ("?" !== t5[o5 + 1]) break;
-                if (o5 = u4(t5, ++o5), o5.err) return o5;
-              } else if ("&" === t5[o5]) {
-                const e6 = x4(t5, o5);
-                if (-1 == e6) return m4("InvalidChar", "char '&' is not expected.", b4(t5, o5));
-                o5 = e6;
-              } else if (true === s5 && !l4(t5[o5])) return m4("InvalidXml", "Extra text at the end", b4(t5, o5));
-              "<" === t5[o5] && o5--;
+                if ("?" !== t5[r5 + 1]) break;
+                if (r5 = u4(t5, ++r5), r5.err) return r5;
+              } else if ("&" === t5[r5]) {
+                const e6 = N(t5, r5);
+                if (-1 == e6) return b4("InvalidChar", "char '&' is not expected.", w4(t5, r5));
+                r5 = e6;
+              } else if (true === s5 && !p4(t5[r5])) return b4("InvalidXml", "Extra text at the end", w4(t5, r5));
+              "<" === t5[r5] && r5--;
             }
           }
         }
-        return i5 ? 1 == n5.length ? m4("InvalidTag", "Unclosed tag '" + n5[0].tagName + "'.", b4(t5, n5[0].tagStartPos)) : !(n5.length > 0) || m4("InvalidXml", "Invalid '" + JSON.stringify(n5.map(((t6) => t6.tagName)), null, 4).replace(/\r?\n/g, "") + "' found.", { line: 1, col: 1 }) : m4("InvalidXml", "Start tag expected.", 1);
+        return n5 ? 1 == i5.length ? b4("InvalidTag", "Unclosed tag '" + i5[0].tagName + "'.", w4(t5, i5[0].tagStartPos)) : !(i5.length > 0) || b4("InvalidXml", "Invalid '" + JSON.stringify(i5.map((t6) => t6.tagName), null, 4).replace(/\r?\n/g, "") + "' found.", { line: 1, col: 1 }) : b4("InvalidXml", "Start tag expected.", 1);
       }
-      function l4(t5) {
+      function p4(t5) {
         return " " === t5 || "	" === t5 || "\n" === t5 || "\r" === t5;
       }
       function u4(t5, e5) {
-        const n5 = e5;
-        for (; e5 < t5.length; e5++) if ("?" != t5[e5] && " " != t5[e5]) ;
-        else {
-          const i5 = t5.substr(n5, e5 - n5);
-          if (e5 > 5 && "xml" === i5) return m4("InvalidXml", "XML declaration allowed only at the start of the document.", b4(t5, e5));
+        const i5 = e5;
+        for (; e5 < t5.length; e5++) if ("?" == t5[e5] || " " == t5[e5]) {
+          const n5 = t5.substr(i5, e5 - i5);
+          if (e5 > 5 && "xml" === n5) return b4("InvalidXml", "XML declaration allowed only at the start of the document.", w4(t5, e5));
           if ("?" == t5[e5] && ">" == t5[e5 + 1]) {
             e5++;
             break;
           }
+          continue;
         }
         return e5;
       }
-      function h4(t5, e5) {
+      function c4(t5, e5) {
         if (t5.length > e5 + 5 && "-" === t5[e5 + 1] && "-" === t5[e5 + 2]) {
           for (e5 += 3; e5 < t5.length; e5++) if ("-" === t5[e5] && "-" === t5[e5 + 1] && ">" === t5[e5 + 2]) {
             e5 += 2;
             break;
           }
         } else if (t5.length > e5 + 8 && "D" === t5[e5 + 1] && "O" === t5[e5 + 2] && "C" === t5[e5 + 3] && "T" === t5[e5 + 4] && "Y" === t5[e5 + 5] && "P" === t5[e5 + 6] && "E" === t5[e5 + 7]) {
-          let n5 = 1;
-          for (e5 += 8; e5 < t5.length; e5++) if ("<" === t5[e5]) n5++;
-          else if (">" === t5[e5] && (n5--, 0 === n5)) break;
+          let i5 = 1;
+          for (e5 += 8; e5 < t5.length; e5++) if ("<" === t5[e5]) i5++;
+          else if (">" === t5[e5] && (i5--, 0 === i5)) break;
         } else if (t5.length > e5 + 9 && "[" === t5[e5 + 1] && "C" === t5[e5 + 2] && "D" === t5[e5 + 3] && "A" === t5[e5 + 4] && "T" === t5[e5 + 5] && "A" === t5[e5 + 6] && "[" === t5[e5 + 7]) {
           for (e5 += 8; e5 < t5.length; e5++) if ("]" === t5[e5] && "]" === t5[e5 + 1] && ">" === t5[e5 + 2]) {
             e5 += 2;
@@ -31948,279 +31948,513 @@ var require_fxp = __commonJS({
         }
         return e5;
       }
-      const d4 = '"', p4 = "'";
-      function f4(t5, e5) {
-        let n5 = "", i5 = "", s5 = false;
+      const d4 = '"', f4 = "'";
+      function g4(t5, e5) {
+        let i5 = "", n5 = "", s5 = false;
         for (; e5 < t5.length; e5++) {
-          if (t5[e5] === d4 || t5[e5] === p4) "" === i5 ? i5 = t5[e5] : i5 !== t5[e5] || (i5 = "");
-          else if (">" === t5[e5] && "" === i5) {
+          if (t5[e5] === d4 || t5[e5] === f4) "" === n5 ? n5 = t5[e5] : n5 !== t5[e5] || (n5 = "");
+          else if (">" === t5[e5] && "" === n5) {
             s5 = true;
             break;
           }
-          n5 += t5[e5];
+          i5 += t5[e5];
         }
-        return "" === i5 && { value: n5, index: e5, tagClosed: s5 };
+        return "" === n5 && { value: i5, index: e5, tagClosed: s5 };
       }
-      const c4 = new RegExp(`(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['"])(([\\s\\S])*?)\\5)?`, "g");
-      function g4(t5, e5) {
-        const n5 = s4(t5, c4), i5 = {};
-        for (let t6 = 0; t6 < n5.length; t6++) {
-          if (0 === n5[t6][1].length) return m4("InvalidAttr", "Attribute '" + n5[t6][2] + "' has no space in starting.", N(n5[t6]));
-          if (void 0 !== n5[t6][3] && void 0 === n5[t6][4]) return m4("InvalidAttr", "Attribute '" + n5[t6][2] + "' is without value.", N(n5[t6]));
-          if (void 0 === n5[t6][3] && !e5.allowBooleanAttributes) return m4("InvalidAttr", "boolean attribute '" + n5[t6][2] + "' is not allowed.", N(n5[t6]));
-          const s5 = n5[t6][2];
-          if (!E2(s5)) return m4("InvalidAttr", "Attribute '" + s5 + "' is an invalid name.", N(n5[t6]));
-          if (i5.hasOwnProperty(s5)) return m4("InvalidAttr", "Attribute '" + s5 + "' is repeated.", N(n5[t6]));
-          i5[s5] = 1;
+      const m4 = new RegExp(`(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['"])(([\\s\\S])*?)\\5)?`, "g");
+      function x4(t5, e5) {
+        const i5 = s4(t5, m4), n5 = {};
+        for (let t6 = 0; t6 < i5.length; t6++) {
+          if (0 === i5[t6][1].length) return b4("InvalidAttr", "Attribute '" + i5[t6][2] + "' has no space in starting.", v4(i5[t6]));
+          if (void 0 !== i5[t6][3] && void 0 === i5[t6][4]) return b4("InvalidAttr", "Attribute '" + i5[t6][2] + "' is without value.", v4(i5[t6]));
+          if (void 0 === i5[t6][3] && !e5.allowBooleanAttributes) return b4("InvalidAttr", "boolean attribute '" + i5[t6][2] + "' is not allowed.", v4(i5[t6]));
+          const s5 = i5[t6][2];
+          if (!E2(s5)) return b4("InvalidAttr", "Attribute '" + s5 + "' is an invalid name.", v4(i5[t6]));
+          if (Object.prototype.hasOwnProperty.call(n5, s5)) return b4("InvalidAttr", "Attribute '" + s5 + "' is repeated.", v4(i5[t6]));
+          n5[s5] = 1;
         }
         return true;
       }
-      function x4(t5, e5) {
+      function N(t5, e5) {
         if (";" === t5[++e5]) return -1;
         if ("#" === t5[e5]) return (function(t6, e6) {
-          let n6 = /\d/;
-          for ("x" === t6[e6] && (e6++, n6 = /[\da-fA-F]/); e6 < t6.length; e6++) {
+          let i6 = /\d/;
+          for ("x" === t6[e6] && (e6++, i6 = /[\da-fA-F]/); e6 < t6.length; e6++) {
             if (";" === t6[e6]) return e6;
-            if (!t6[e6].match(n6)) break;
+            if (!t6[e6].match(i6)) break;
           }
           return -1;
         })(t5, ++e5);
-        let n5 = 0;
-        for (; e5 < t5.length; e5++, n5++) if (!(t5[e5].match(/\w/) && n5 < 20)) {
+        let i5 = 0;
+        for (; e5 < t5.length; e5++, i5++) if (!(t5[e5].match(/\w/) && i5 < 20)) {
           if (";" === t5[e5]) break;
           return -1;
         }
         return e5;
       }
-      function m4(t5, e5, n5) {
-        return { err: { code: t5, msg: e5, line: n5.line || n5, col: n5.col } };
+      function b4(t5, e5, i5) {
+        return { err: { code: t5, msg: e5, line: i5.line || i5, col: i5.col } };
       }
       function E2(t5) {
         return r4(t5);
       }
-      function b4(t5, e5) {
-        const n5 = t5.substring(0, e5).split(/\r?\n/);
-        return { line: n5.length, col: n5[n5.length - 1].length + 1 };
+      function y2(t5) {
+        return r4(t5);
       }
-      function N(t5) {
+      function w4(t5, e5) {
+        const i5 = t5.substring(0, e5).split(/\r?\n/);
+        return { line: i5.length, col: i5[i5.length - 1].length + 1 };
+      }
+      function v4(t5) {
         return t5.startIndex + t5[1].length;
       }
-      const y2 = { preserveOrder: false, attributeNamePrefix: "@_", attributesGroupName: false, textNodeName: "#text", ignoreAttributes: true, removeNSPrefix: false, allowBooleanAttributes: false, parseTagValue: true, parseAttributeValue: false, trimValues: true, cdataPropName: false, numberParseOptions: { hex: true, leadingZeros: true, eNotation: true }, tagValueProcessor: function(t5, e5) {
+      const T = (t5) => o4.includes(t5) ? "__" + t5 : t5, P = { preserveOrder: false, attributeNamePrefix: "@_", attributesGroupName: false, textNodeName: "#text", ignoreAttributes: true, removeNSPrefix: false, allowBooleanAttributes: false, parseTagValue: true, parseAttributeValue: false, trimValues: true, cdataPropName: false, numberParseOptions: { hex: true, leadingZeros: true, eNotation: true }, tagValueProcessor: function(t5, e5) {
         return e5;
       }, attributeValueProcessor: function(t5, e5) {
         return e5;
-      }, stopNodes: [], alwaysCreateTextNode: false, isArray: () => false, commentPropName: false, unpairedTags: [], processEntities: true, htmlEntities: false, ignoreDeclaration: false, ignorePiTags: false, transformTagName: false, transformAttributeName: false, updateTag: function(t5, e5, n5) {
+      }, stopNodes: [], alwaysCreateTextNode: false, isArray: () => false, commentPropName: false, unpairedTags: [], processEntities: true, htmlEntities: false, ignoreDeclaration: false, ignorePiTags: false, transformTagName: false, transformAttributeName: false, updateTag: function(t5, e5, i5) {
         return t5;
-      }, captureMetaData: false };
-      function T(t5) {
-        return "boolean" == typeof t5 ? { enabled: t5, maxEntitySize: 1e4, maxExpansionDepth: 10, maxTotalExpansions: 1e3, maxExpandedLength: 1e5, allowedTags: null, tagFilter: null } : "object" == typeof t5 && null !== t5 ? { enabled: false !== t5.enabled, maxEntitySize: t5.maxEntitySize ?? 1e4, maxExpansionDepth: t5.maxExpansionDepth ?? 10, maxTotalExpansions: t5.maxTotalExpansions ?? 1e3, maxExpandedLength: t5.maxExpandedLength ?? 1e5, allowedTags: t5.allowedTags ?? null, tagFilter: t5.tagFilter ?? null } : T(true);
+      }, captureMetaData: false, maxNestedTags: 100, strictReservedNames: true, jPath: true, onDangerousProperty: T };
+      function S(t5, e5) {
+        if ("string" != typeof t5) return;
+        const i5 = t5.toLowerCase();
+        if (o4.some((t6) => i5 === t6.toLowerCase())) throw new Error(`[SECURITY] Invalid ${e5}: "${t5}" is a reserved JavaScript keyword that could cause prototype pollution`);
+        if (a4.some((t6) => i5 === t6.toLowerCase())) throw new Error(`[SECURITY] Invalid ${e5}: "${t5}" is a reserved JavaScript keyword that could cause prototype pollution`);
       }
-      const w4 = function(t5) {
-        const e5 = Object.assign({}, y2, t5);
-        return e5.processEntities = T(e5.processEntities), e5;
+      function A2(t5) {
+        return "boolean" == typeof t5 ? { enabled: t5, maxEntitySize: 1e4, maxExpansionDepth: 10, maxTotalExpansions: 1e3, maxExpandedLength: 1e5, maxEntityCount: 100, allowedTags: null, tagFilter: null } : "object" == typeof t5 && null !== t5 ? { enabled: false !== t5.enabled, maxEntitySize: Math.max(1, t5.maxEntitySize ?? 1e4), maxExpansionDepth: Math.max(1, t5.maxExpansionDepth ?? 10), maxTotalExpansions: Math.max(1, t5.maxTotalExpansions ?? 1e3), maxExpandedLength: Math.max(1, t5.maxExpandedLength ?? 1e5), maxEntityCount: Math.max(1, t5.maxEntityCount ?? 100), allowedTags: t5.allowedTags ?? null, tagFilter: t5.tagFilter ?? null } : A2(true);
+      }
+      const O = function(t5) {
+        const e5 = Object.assign({}, P, t5), i5 = [{ value: e5.attributeNamePrefix, name: "attributeNamePrefix" }, { value: e5.attributesGroupName, name: "attributesGroupName" }, { value: e5.textNodeName, name: "textNodeName" }, { value: e5.cdataPropName, name: "cdataPropName" }, { value: e5.commentPropName, name: "commentPropName" }];
+        for (const { value: t6, name: e6 } of i5) t6 && S(t6, e6);
+        return null === e5.onDangerousProperty && (e5.onDangerousProperty = T), e5.processEntities = A2(e5.processEntities), e5.stopNodes && Array.isArray(e5.stopNodes) && (e5.stopNodes = e5.stopNodes.map((t6) => "string" == typeof t6 && t6.startsWith("*.") ? ".." + t6.substring(2) : t6)), e5;
       };
-      let v4;
-      v4 = "function" != typeof Symbol ? "@@xmlMetadata" : /* @__PURE__ */ Symbol("XML Node Metadata");
-      class I2 {
+      let C2;
+      C2 = "function" != typeof Symbol ? "@@xmlMetadata" : /* @__PURE__ */ Symbol("XML Node Metadata");
+      class $ {
         constructor(t5) {
-          this.tagname = t5, this.child = [], this[":@"] = {};
+          this.tagname = t5, this.child = [], this[":@"] = /* @__PURE__ */ Object.create(null);
         }
         add(t5, e5) {
           "__proto__" === t5 && (t5 = "#__proto__"), this.child.push({ [t5]: e5 });
         }
         addChild(t5, e5) {
-          "__proto__" === t5.tagname && (t5.tagname = "#__proto__"), t5[":@"] && Object.keys(t5[":@"]).length > 0 ? this.child.push({ [t5.tagname]: t5.child, ":@": t5[":@"] }) : this.child.push({ [t5.tagname]: t5.child }), void 0 !== e5 && (this.child[this.child.length - 1][v4] = { startIndex: e5 });
+          "__proto__" === t5.tagname && (t5.tagname = "#__proto__"), t5[":@"] && Object.keys(t5[":@"]).length > 0 ? this.child.push({ [t5.tagname]: t5.child, ":@": t5[":@"] }) : this.child.push({ [t5.tagname]: t5.child }), void 0 !== e5 && (this.child[this.child.length - 1][C2] = { startIndex: e5 });
         }
         static getMetaDataSymbol() {
-          return v4;
+          return C2;
         }
       }
-      class O {
+      class I2 {
         constructor(t5) {
           this.suppressValidationErr = !t5, this.options = t5;
         }
         readDocType(t5, e5) {
-          const n5 = {};
+          const i5 = /* @__PURE__ */ Object.create(null);
+          let n5 = 0;
           if ("O" !== t5[e5 + 3] || "C" !== t5[e5 + 4] || "T" !== t5[e5 + 5] || "Y" !== t5[e5 + 6] || "P" !== t5[e5 + 7] || "E" !== t5[e5 + 8]) throw new Error("Invalid Tag instead of DOCTYPE");
           {
             e5 += 9;
-            let i5 = 1, s5 = false, r5 = false, o5 = "";
-            for (; e5 < t5.length; e5++) if ("<" !== t5[e5] || r5) if (">" === t5[e5]) {
-              if (r5 ? "-" === t5[e5 - 1] && "-" === t5[e5 - 2] && (r5 = false, i5--) : i5--, 0 === i5) break;
-            } else "[" === t5[e5] ? s5 = true : o5 += t5[e5];
+            let s5 = 1, r5 = false, o5 = false, a5 = "";
+            for (; e5 < t5.length; e5++) if ("<" !== t5[e5] || o5) if (">" === t5[e5]) {
+              if (o5 ? "-" === t5[e5 - 1] && "-" === t5[e5 - 2] && (o5 = false, s5--) : s5--, 0 === s5) break;
+            } else "[" === t5[e5] ? r5 = true : a5 += t5[e5];
             else {
-              if (s5 && A2(t5, "!ENTITY", e5)) {
-                let i6, s6;
-                if (e5 += 7, [i6, s6, e5] = this.readEntityExp(t5, e5 + 1, this.suppressValidationErr), -1 === s6.indexOf("&")) {
-                  const t6 = i6.replace(/[.\-+*:]/g, "\\.");
-                  n5[i6] = { regx: RegExp(`&${t6};`, "g"), val: s6 };
+              if (r5 && M(t5, "!ENTITY", e5)) {
+                let s6, r6;
+                if (e5 += 7, [s6, r6, e5] = this.readEntityExp(t5, e5 + 1, this.suppressValidationErr), -1 === r6.indexOf("&")) {
+                  if (false !== this.options.enabled && null != this.options.maxEntityCount && n5 >= this.options.maxEntityCount) throw new Error(`Entity count (${n5 + 1}) exceeds maximum allowed (${this.options.maxEntityCount})`);
+                  const t6 = s6.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                  i5[s6] = { regx: RegExp(`&${t6};`, "g"), val: r6 }, n5++;
                 }
-              } else if (s5 && A2(t5, "!ELEMENT", e5)) {
+              } else if (r5 && M(t5, "!ELEMENT", e5)) {
                 e5 += 8;
-                const { index: n6 } = this.readElementExp(t5, e5 + 1);
-                e5 = n6;
-              } else if (s5 && A2(t5, "!ATTLIST", e5)) e5 += 8;
-              else if (s5 && A2(t5, "!NOTATION", e5)) {
+                const { index: i6 } = this.readElementExp(t5, e5 + 1);
+                e5 = i6;
+              } else if (r5 && M(t5, "!ATTLIST", e5)) e5 += 8;
+              else if (r5 && M(t5, "!NOTATION", e5)) {
                 e5 += 9;
-                const { index: n6 } = this.readNotationExp(t5, e5 + 1, this.suppressValidationErr);
-                e5 = n6;
+                const { index: i6 } = this.readNotationExp(t5, e5 + 1, this.suppressValidationErr);
+                e5 = i6;
               } else {
-                if (!A2(t5, "!--", e5)) throw new Error("Invalid DOCTYPE");
-                r5 = true;
+                if (!M(t5, "!--", e5)) throw new Error("Invalid DOCTYPE");
+                o5 = true;
               }
-              i5++, o5 = "";
+              s5++, a5 = "";
             }
-            if (0 !== i5) throw new Error("Unclosed DOCTYPE");
+            if (0 !== s5) throw new Error("Unclosed DOCTYPE");
           }
-          return { entities: n5, i: e5 };
+          return { entities: i5, i: e5 };
         }
         readEntityExp(t5, e5) {
-          e5 = P(t5, e5);
-          let n5 = "";
-          for (; e5 < t5.length && !/\s/.test(t5[e5]) && '"' !== t5[e5] && "'" !== t5[e5]; ) n5 += t5[e5], e5++;
-          if (S(n5), e5 = P(t5, e5), !this.suppressValidationErr) {
+          const i5 = e5 = j4(t5, e5);
+          for (; e5 < t5.length && !/\s/.test(t5[e5]) && '"' !== t5[e5] && "'" !== t5[e5]; ) e5++;
+          let n5 = t5.substring(i5, e5);
+          if (_(n5), e5 = j4(t5, e5), !this.suppressValidationErr) {
             if ("SYSTEM" === t5.substring(e5, e5 + 6).toUpperCase()) throw new Error("External entities are not supported");
             if ("%" === t5[e5]) throw new Error("Parameter entities are not supported");
           }
-          let i5 = "";
-          if ([e5, i5] = this.readIdentifierVal(t5, e5, "entity"), false !== this.options.enabled && this.options.maxEntitySize && i5.length > this.options.maxEntitySize) throw new Error(`Entity "${n5}" size (${i5.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);
-          return [n5, i5, --e5];
+          let s5 = "";
+          if ([e5, s5] = this.readIdentifierVal(t5, e5, "entity"), false !== this.options.enabled && null != this.options.maxEntitySize && s5.length > this.options.maxEntitySize) throw new Error(`Entity "${n5}" size (${s5.length}) exceeds maximum allowed size (${this.options.maxEntitySize})`);
+          return [n5, s5, --e5];
         }
         readNotationExp(t5, e5) {
-          e5 = P(t5, e5);
-          let n5 = "";
-          for (; e5 < t5.length && !/\s/.test(t5[e5]); ) n5 += t5[e5], e5++;
-          !this.suppressValidationErr && S(n5), e5 = P(t5, e5);
-          const i5 = t5.substring(e5, e5 + 6).toUpperCase();
-          if (!this.suppressValidationErr && "SYSTEM" !== i5 && "PUBLIC" !== i5) throw new Error(`Expected SYSTEM or PUBLIC, found "${i5}"`);
-          e5 += i5.length, e5 = P(t5, e5);
-          let s5 = null, r5 = null;
-          if ("PUBLIC" === i5) [e5, s5] = this.readIdentifierVal(t5, e5, "publicIdentifier"), '"' !== t5[e5 = P(t5, e5)] && "'" !== t5[e5] || ([e5, r5] = this.readIdentifierVal(t5, e5, "systemIdentifier"));
-          else if ("SYSTEM" === i5 && ([e5, r5] = this.readIdentifierVal(t5, e5, "systemIdentifier"), !this.suppressValidationErr && !r5)) throw new Error("Missing mandatory system identifier for SYSTEM notation");
-          return { notationName: n5, publicIdentifier: s5, systemIdentifier: r5, index: --e5 };
+          const i5 = e5 = j4(t5, e5);
+          for (; e5 < t5.length && !/\s/.test(t5[e5]); ) e5++;
+          let n5 = t5.substring(i5, e5);
+          !this.suppressValidationErr && _(n5), e5 = j4(t5, e5);
+          const s5 = t5.substring(e5, e5 + 6).toUpperCase();
+          if (!this.suppressValidationErr && "SYSTEM" !== s5 && "PUBLIC" !== s5) throw new Error(`Expected SYSTEM or PUBLIC, found "${s5}"`);
+          e5 += s5.length, e5 = j4(t5, e5);
+          let r5 = null, o5 = null;
+          if ("PUBLIC" === s5) [e5, r5] = this.readIdentifierVal(t5, e5, "publicIdentifier"), '"' !== t5[e5 = j4(t5, e5)] && "'" !== t5[e5] || ([e5, o5] = this.readIdentifierVal(t5, e5, "systemIdentifier"));
+          else if ("SYSTEM" === s5 && ([e5, o5] = this.readIdentifierVal(t5, e5, "systemIdentifier"), !this.suppressValidationErr && !o5)) throw new Error("Missing mandatory system identifier for SYSTEM notation");
+          return { notationName: n5, publicIdentifier: r5, systemIdentifier: o5, index: --e5 };
         }
-        readIdentifierVal(t5, e5, n5) {
-          let i5 = "";
+        readIdentifierVal(t5, e5, i5) {
+          let n5 = "";
           const s5 = t5[e5];
           if ('"' !== s5 && "'" !== s5) throw new Error(`Expected quoted string, found "${s5}"`);
-          for (e5++; e5 < t5.length && t5[e5] !== s5; ) i5 += t5[e5], e5++;
-          if (t5[e5] !== s5) throw new Error(`Unterminated ${n5} value`);
-          return [++e5, i5];
+          const r5 = ++e5;
+          for (; e5 < t5.length && t5[e5] !== s5; ) e5++;
+          if (n5 = t5.substring(r5, e5), t5[e5] !== s5) throw new Error(`Unterminated ${i5} value`);
+          return [++e5, n5];
         }
         readElementExp(t5, e5) {
-          e5 = P(t5, e5);
-          let n5 = "";
-          for (; e5 < t5.length && !/\s/.test(t5[e5]); ) n5 += t5[e5], e5++;
+          const i5 = e5 = j4(t5, e5);
+          for (; e5 < t5.length && !/\s/.test(t5[e5]); ) e5++;
+          let n5 = t5.substring(i5, e5);
           if (!this.suppressValidationErr && !r4(n5)) throw new Error(`Invalid element name: "${n5}"`);
-          let i5 = "";
-          if ("E" === t5[e5 = P(t5, e5)] && A2(t5, "MPTY", e5)) e5 += 4;
-          else if ("A" === t5[e5] && A2(t5, "NY", e5)) e5 += 2;
+          let s5 = "";
+          if ("E" === t5[e5 = j4(t5, e5)] && M(t5, "MPTY", e5)) e5 += 4;
+          else if ("A" === t5[e5] && M(t5, "NY", e5)) e5 += 2;
           else if ("(" === t5[e5]) {
-            for (e5++; e5 < t5.length && ")" !== t5[e5]; ) i5 += t5[e5], e5++;
-            if (")" !== t5[e5]) throw new Error("Unterminated content model");
+            const i6 = ++e5;
+            for (; e5 < t5.length && ")" !== t5[e5]; ) e5++;
+            if (s5 = t5.substring(i6, e5), ")" !== t5[e5]) throw new Error("Unterminated content model");
           } else if (!this.suppressValidationErr) throw new Error(`Invalid Element Expression, found "${t5[e5]}"`);
-          return { elementName: n5, contentModel: i5.trim(), index: e5 };
+          return { elementName: n5, contentModel: s5.trim(), index: e5 };
         }
         readAttlistExp(t5, e5) {
-          e5 = P(t5, e5);
-          let n5 = "";
-          for (; e5 < t5.length && !/\s/.test(t5[e5]); ) n5 += t5[e5], e5++;
-          S(n5), e5 = P(t5, e5);
-          let i5 = "";
-          for (; e5 < t5.length && !/\s/.test(t5[e5]); ) i5 += t5[e5], e5++;
-          if (!S(i5)) throw new Error(`Invalid attribute name: "${i5}"`);
-          e5 = P(t5, e5);
-          let s5 = "";
+          let i5 = e5 = j4(t5, e5);
+          for (; e5 < t5.length && !/\s/.test(t5[e5]); ) e5++;
+          let n5 = t5.substring(i5, e5);
+          for (_(n5), i5 = e5 = j4(t5, e5); e5 < t5.length && !/\s/.test(t5[e5]); ) e5++;
+          let s5 = t5.substring(i5, e5);
+          if (!_(s5)) throw new Error(`Invalid attribute name: "${s5}"`);
+          e5 = j4(t5, e5);
+          let r5 = "";
           if ("NOTATION" === t5.substring(e5, e5 + 8).toUpperCase()) {
-            if (s5 = "NOTATION", "(" !== t5[e5 = P(t5, e5 += 8)]) throw new Error(`Expected '(', found "${t5[e5]}"`);
+            if (r5 = "NOTATION", "(" !== t5[e5 = j4(t5, e5 += 8)]) throw new Error(`Expected '(', found "${t5[e5]}"`);
             e5++;
-            let n6 = [];
+            let i6 = [];
             for (; e5 < t5.length && ")" !== t5[e5]; ) {
-              let i6 = "";
-              for (; e5 < t5.length && "|" !== t5[e5] && ")" !== t5[e5]; ) i6 += t5[e5], e5++;
-              if (i6 = i6.trim(), !S(i6)) throw new Error(`Invalid notation name: "${i6}"`);
-              n6.push(i6), "|" === t5[e5] && (e5++, e5 = P(t5, e5));
+              const n6 = e5;
+              for (; e5 < t5.length && "|" !== t5[e5] && ")" !== t5[e5]; ) e5++;
+              let s6 = t5.substring(n6, e5);
+              if (s6 = s6.trim(), !_(s6)) throw new Error(`Invalid notation name: "${s6}"`);
+              i6.push(s6), "|" === t5[e5] && (e5++, e5 = j4(t5, e5));
             }
             if (")" !== t5[e5]) throw new Error("Unterminated list of notations");
-            e5++, s5 += " (" + n6.join("|") + ")";
+            e5++, r5 += " (" + i6.join("|") + ")";
           } else {
-            for (; e5 < t5.length && !/\s/.test(t5[e5]); ) s5 += t5[e5], e5++;
+            const i6 = e5;
+            for (; e5 < t5.length && !/\s/.test(t5[e5]); ) e5++;
+            r5 += t5.substring(i6, e5);
             const n6 = ["CDATA", "ID", "IDREF", "IDREFS", "ENTITY", "ENTITIES", "NMTOKEN", "NMTOKENS"];
-            if (!this.suppressValidationErr && !n6.includes(s5.toUpperCase())) throw new Error(`Invalid attribute type: "${s5}"`);
+            if (!this.suppressValidationErr && !n6.includes(r5.toUpperCase())) throw new Error(`Invalid attribute type: "${r5}"`);
           }
-          e5 = P(t5, e5);
-          let r5 = "";
-          return "#REQUIRED" === t5.substring(e5, e5 + 8).toUpperCase() ? (r5 = "#REQUIRED", e5 += 8) : "#IMPLIED" === t5.substring(e5, e5 + 7).toUpperCase() ? (r5 = "#IMPLIED", e5 += 7) : [e5, r5] = this.readIdentifierVal(t5, e5, "ATTLIST"), { elementName: n5, attributeName: i5, attributeType: s5, defaultValue: r5, index: e5 };
+          e5 = j4(t5, e5);
+          let o5 = "";
+          return "#REQUIRED" === t5.substring(e5, e5 + 8).toUpperCase() ? (o5 = "#REQUIRED", e5 += 8) : "#IMPLIED" === t5.substring(e5, e5 + 7).toUpperCase() ? (o5 = "#IMPLIED", e5 += 7) : [e5, o5] = this.readIdentifierVal(t5, e5, "ATTLIST"), { elementName: n5, attributeName: s5, attributeType: r5, defaultValue: o5, index: e5 };
         }
       }
-      const P = (t5, e5) => {
+      const j4 = (t5, e5) => {
         for (; e5 < t5.length && /\s/.test(t5[e5]); ) e5++;
         return e5;
       };
-      function A2(t5, e5, n5) {
-        for (let i5 = 0; i5 < e5.length; i5++) if (e5[i5] !== t5[n5 + i5 + 1]) return false;
+      function M(t5, e5, i5) {
+        for (let n5 = 0; n5 < e5.length; n5++) if (e5[n5] !== t5[i5 + n5 + 1]) return false;
         return true;
       }
-      function S(t5) {
+      function _(t5) {
         if (r4(t5)) return t5;
         throw new Error(`Invalid entity name ${t5}`);
       }
-      const C2 = /^[-+]?0x[a-fA-F0-9]+$/, $ = /^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/, V = { hex: true, leadingZeros: true, decimalPoint: ".", eNotation: true };
-      const D2 = /^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/;
-      function L(t5) {
-        return "function" == typeof t5 ? t5 : Array.isArray(t5) ? (e5) => {
-          for (const n5 of t5) {
-            if ("string" == typeof n5 && e5 === n5) return true;
-            if (n5 instanceof RegExp && n5.test(e5)) return true;
+      const D2 = /^[-+]?0x[a-fA-F0-9]+$/, V = /^([\-\+])?(0*)([0-9]*(\.[0-9]*)?)$/, k4 = { hex: true, leadingZeros: true, decimalPoint: ".", eNotation: true, infinity: "original" };
+      const F2 = /^([-+])?(0*)(\d*(\.\d*)?[eE][-\+]?\d+)$/, L = /* @__PURE__ */ new Set(["push", "pop", "reset", "updateCurrent", "restore"]);
+      class G2 {
+        constructor(t5 = {}) {
+          this.separator = t5.separator || ".", this.path = [], this.siblingStacks = [];
+        }
+        push(t5, e5 = null, i5 = null) {
+          this.path.length > 0 && (this.path[this.path.length - 1].values = void 0);
+          const n5 = this.path.length;
+          this.siblingStacks[n5] || (this.siblingStacks[n5] = /* @__PURE__ */ new Map());
+          const s5 = this.siblingStacks[n5], r5 = i5 ? `${i5}:${t5}` : t5, o5 = s5.get(r5) || 0;
+          let a5 = 0;
+          for (const t6 of s5.values()) a5 += t6;
+          s5.set(r5, o5 + 1);
+          const h5 = { tag: t5, position: a5, counter: o5 };
+          null != i5 && (h5.namespace = i5), null != e5 && (h5.values = e5), this.path.push(h5);
+        }
+        pop() {
+          if (0 === this.path.length) return;
+          const t5 = this.path.pop();
+          return this.siblingStacks.length > this.path.length + 1 && (this.siblingStacks.length = this.path.length + 1), t5;
+        }
+        updateCurrent(t5) {
+          if (this.path.length > 0) {
+            const e5 = this.path[this.path.length - 1];
+            null != t5 && (e5.values = t5);
           }
-        } : () => false;
+        }
+        getCurrentTag() {
+          return this.path.length > 0 ? this.path[this.path.length - 1].tag : void 0;
+        }
+        getCurrentNamespace() {
+          return this.path.length > 0 ? this.path[this.path.length - 1].namespace : void 0;
+        }
+        getAttrValue(t5) {
+          if (0 === this.path.length) return;
+          const e5 = this.path[this.path.length - 1];
+          return e5.values?.[t5];
+        }
+        hasAttr(t5) {
+          if (0 === this.path.length) return false;
+          const e5 = this.path[this.path.length - 1];
+          return void 0 !== e5.values && t5 in e5.values;
+        }
+        getPosition() {
+          return 0 === this.path.length ? -1 : this.path[this.path.length - 1].position ?? 0;
+        }
+        getCounter() {
+          return 0 === this.path.length ? -1 : this.path[this.path.length - 1].counter ?? 0;
+        }
+        getIndex() {
+          return this.getPosition();
+        }
+        getDepth() {
+          return this.path.length;
+        }
+        toString(t5, e5 = true) {
+          const i5 = t5 || this.separator;
+          return this.path.map((t6) => e5 && t6.namespace ? `${t6.namespace}:${t6.tag}` : t6.tag).join(i5);
+        }
+        toArray() {
+          return this.path.map((t5) => t5.tag);
+        }
+        reset() {
+          this.path = [], this.siblingStacks = [];
+        }
+        matches(t5) {
+          const e5 = t5.segments;
+          return 0 !== e5.length && (t5.hasDeepWildcard() ? this._matchWithDeepWildcard(e5) : this._matchSimple(e5));
+        }
+        _matchSimple(t5) {
+          if (this.path.length !== t5.length) return false;
+          for (let e5 = 0; e5 < t5.length; e5++) {
+            const i5 = t5[e5], n5 = this.path[e5], s5 = e5 === this.path.length - 1;
+            if (!this._matchSegment(i5, n5, s5)) return false;
+          }
+          return true;
+        }
+        _matchWithDeepWildcard(t5) {
+          let e5 = this.path.length - 1, i5 = t5.length - 1;
+          for (; i5 >= 0 && e5 >= 0; ) {
+            const n5 = t5[i5];
+            if ("deep-wildcard" === n5.type) {
+              if (i5--, i5 < 0) return true;
+              const n6 = t5[i5];
+              let s5 = false;
+              for (let t6 = e5; t6 >= 0; t6--) {
+                const r5 = t6 === this.path.length - 1;
+                if (this._matchSegment(n6, this.path[t6], r5)) {
+                  e5 = t6 - 1, i5--, s5 = true;
+                  break;
+                }
+              }
+              if (!s5) return false;
+            } else {
+              const t6 = e5 === this.path.length - 1;
+              if (!this._matchSegment(n5, this.path[e5], t6)) return false;
+              e5--, i5--;
+            }
+          }
+          return i5 < 0;
+        }
+        _matchSegment(t5, e5, i5) {
+          if ("*" !== t5.tag && t5.tag !== e5.tag) return false;
+          if (void 0 !== t5.namespace && "*" !== t5.namespace && t5.namespace !== e5.namespace) return false;
+          if (void 0 !== t5.attrName) {
+            if (!i5) return false;
+            if (!e5.values || !(t5.attrName in e5.values)) return false;
+            if (void 0 !== t5.attrValue) {
+              const i6 = e5.values[t5.attrName];
+              if (String(i6) !== String(t5.attrValue)) return false;
+            }
+          }
+          if (void 0 !== t5.position) {
+            if (!i5) return false;
+            const n5 = e5.counter ?? 0;
+            if ("first" === t5.position && 0 !== n5) return false;
+            if ("odd" === t5.position && n5 % 2 != 1) return false;
+            if ("even" === t5.position && n5 % 2 != 0) return false;
+            if ("nth" === t5.position && n5 !== t5.positionValue) return false;
+          }
+          return true;
+        }
+        snapshot() {
+          return { path: this.path.map((t5) => ({ ...t5 })), siblingStacks: this.siblingStacks.map((t5) => new Map(t5)) };
+        }
+        restore(t5) {
+          this.path = t5.path.map((t6) => ({ ...t6 })), this.siblingStacks = t5.siblingStacks.map((t6) => new Map(t6));
+        }
+        readOnly() {
+          return new Proxy(this, { get(t5, e5, i5) {
+            if (L.has(e5)) return () => {
+              throw new TypeError(`Cannot call '${e5}' on a read-only Matcher. Obtain a writable instance to mutate state.`);
+            };
+            const n5 = Reflect.get(t5, e5, i5);
+            return "path" === e5 || "siblingStacks" === e5 ? Object.freeze(Array.isArray(n5) ? n5.map((t6) => t6 instanceof Map ? Object.freeze(new Map(t6)) : Object.freeze({ ...t6 })) : n5) : "function" == typeof n5 ? n5.bind(t5) : n5;
+          }, set(t5, e5) {
+            throw new TypeError(`Cannot set property '${String(e5)}' on a read-only Matcher.`);
+          }, deleteProperty(t5, e5) {
+            throw new TypeError(`Cannot delete property '${String(e5)}' from a read-only Matcher.`);
+          } });
+        }
       }
-      class F2 {
+      class R {
+        constructor(t5, e5 = {}) {
+          this.pattern = t5, this.separator = e5.separator || ".", this.segments = this._parse(t5), this._hasDeepWildcard = this.segments.some((t6) => "deep-wildcard" === t6.type), this._hasAttributeCondition = this.segments.some((t6) => void 0 !== t6.attrName), this._hasPositionSelector = this.segments.some((t6) => void 0 !== t6.position);
+        }
+        _parse(t5) {
+          const e5 = [];
+          let i5 = 0, n5 = "";
+          for (; i5 < t5.length; ) t5[i5] === this.separator ? i5 + 1 < t5.length && t5[i5 + 1] === this.separator ? (n5.trim() && (e5.push(this._parseSegment(n5.trim())), n5 = ""), e5.push({ type: "deep-wildcard" }), i5 += 2) : (n5.trim() && e5.push(this._parseSegment(n5.trim())), n5 = "", i5++) : (n5 += t5[i5], i5++);
+          return n5.trim() && e5.push(this._parseSegment(n5.trim())), e5;
+        }
+        _parseSegment(t5) {
+          const e5 = { type: "tag" };
+          let i5 = null, n5 = t5;
+          const s5 = t5.match(/^([^\[]+)(\[[^\]]*\])(.*)$/);
+          if (s5 && (n5 = s5[1] + s5[3], s5[2])) {
+            const t6 = s5[2].slice(1, -1);
+            t6 && (i5 = t6);
+          }
+          let r5, o5, a5 = n5;
+          if (n5.includes("::")) {
+            const e6 = n5.indexOf("::");
+            if (r5 = n5.substring(0, e6).trim(), a5 = n5.substring(e6 + 2).trim(), !r5) throw new Error(`Invalid namespace in pattern: ${t5}`);
+          }
+          let h5 = null;
+          if (a5.includes(":")) {
+            const t6 = a5.lastIndexOf(":"), e6 = a5.substring(0, t6).trim(), i6 = a5.substring(t6 + 1).trim();
+            ["first", "last", "odd", "even"].includes(i6) || /^nth\(\d+\)$/.test(i6) ? (o5 = e6, h5 = i6) : o5 = a5;
+          } else o5 = a5;
+          if (!o5) throw new Error(`Invalid segment pattern: ${t5}`);
+          if (e5.tag = o5, r5 && (e5.namespace = r5), i5) if (i5.includes("=")) {
+            const t6 = i5.indexOf("=");
+            e5.attrName = i5.substring(0, t6).trim(), e5.attrValue = i5.substring(t6 + 1).trim();
+          } else e5.attrName = i5.trim();
+          if (h5) {
+            const t6 = h5.match(/^nth\((\d+)\)$/);
+            t6 ? (e5.position = "nth", e5.positionValue = parseInt(t6[1], 10)) : e5.position = h5;
+          }
+          return e5;
+        }
+        get length() {
+          return this.segments.length;
+        }
+        hasDeepWildcard() {
+          return this._hasDeepWildcard;
+        }
+        hasAttributeCondition() {
+          return this._hasAttributeCondition;
+        }
+        hasPositionSelector() {
+          return this._hasPositionSelector;
+        }
+        toString() {
+          return this.pattern;
+        }
+      }
+      function U(t5, e5) {
+        if (!t5) return {};
+        const i5 = e5.attributesGroupName ? t5[e5.attributesGroupName] : t5;
+        if (!i5) return {};
+        const n5 = {};
+        for (const t6 in i5) t6.startsWith(e5.attributeNamePrefix) ? n5[t6.substring(e5.attributeNamePrefix.length)] = i5[t6] : n5[t6] = i5[t6];
+        return n5;
+      }
+      function B2(t5) {
+        if (!t5 || "string" != typeof t5) return;
+        const e5 = t5.indexOf(":");
+        if (-1 !== e5 && e5 > 0) {
+          const i5 = t5.substring(0, e5);
+          if ("xmlns" !== i5) return i5;
+        }
+      }
+      class W {
         constructor(t5) {
-          if (this.options = t5, this.currentNode = null, this.tagsNodeStack = [], this.docTypeEntities = {}, this.lastEntities = { apos: { regex: /&(apos|#39|#x27);/g, val: "'" }, gt: { regex: /&(gt|#62|#x3E);/g, val: ">" }, lt: { regex: /&(lt|#60|#x3C);/g, val: "<" }, quot: { regex: /&(quot|#34|#x22);/g, val: '"' } }, this.ampEntity = { regex: /&(amp|#38|#x26);/g, val: "&" }, this.htmlEntities = { space: { regex: /&(nbsp|#160);/g, val: " " }, cent: { regex: /&(cent|#162);/g, val: "\xA2" }, pound: { regex: /&(pound|#163);/g, val: "\xA3" }, yen: { regex: /&(yen|#165);/g, val: "\xA5" }, euro: { regex: /&(euro|#8364);/g, val: "\u20AC" }, copyright: { regex: /&(copy|#169);/g, val: "\xA9" }, reg: { regex: /&(reg|#174);/g, val: "\xAE" }, inr: { regex: /&(inr|#8377);/g, val: "\u20B9" }, num_dec: { regex: /&#([0-9]{1,7});/g, val: (t6, e5) => K(e5, 10, "&#") }, num_hex: { regex: /&#x([0-9a-fA-F]{1,6});/g, val: (t6, e5) => K(e5, 16, "&#x") } }, this.addExternalEntities = j4, this.parseXml = B2, this.parseTextData = M, this.resolveNameSpace = _, this.buildAttributesMap = U, this.isItStopNode = X, this.replaceEntitiesValue = Y, this.readStopNodeData = q4, this.saveTextToParentTag = G2, this.addChild = R, this.ignoreAttributesFn = L(this.options.ignoreAttributes), this.entityExpansionCount = 0, this.currentExpandedLength = 0, this.options.stopNodes && this.options.stopNodes.length > 0) {
-            this.stopNodesExact = /* @__PURE__ */ new Set(), this.stopNodesWildcard = /* @__PURE__ */ new Set();
+          var e5;
+          if (this.options = t5, this.currentNode = null, this.tagsNodeStack = [], this.docTypeEntities = {}, this.lastEntities = { apos: { regex: /&(apos|#39|#x27);/g, val: "'" }, gt: { regex: /&(gt|#62|#x3E);/g, val: ">" }, lt: { regex: /&(lt|#60|#x3C);/g, val: "<" }, quot: { regex: /&(quot|#34|#x22);/g, val: '"' } }, this.ampEntity = { regex: /&(amp|#38|#x26);/g, val: "&" }, this.htmlEntities = { space: { regex: /&(nbsp|#160);/g, val: " " }, cent: { regex: /&(cent|#162);/g, val: "\xA2" }, pound: { regex: /&(pound|#163);/g, val: "\xA3" }, yen: { regex: /&(yen|#165);/g, val: "\xA5" }, euro: { regex: /&(euro|#8364);/g, val: "\u20AC" }, copyright: { regex: /&(copy|#169);/g, val: "\xA9" }, reg: { regex: /&(reg|#174);/g, val: "\xAE" }, inr: { regex: /&(inr|#8377);/g, val: "\u20B9" }, num_dec: { regex: /&#([0-9]{1,7});/g, val: (t6, e6) => rt(e6, 10, "&#") }, num_hex: { regex: /&#x([0-9a-fA-F]{1,6});/g, val: (t6, e6) => rt(e6, 16, "&#x") } }, this.addExternalEntities = Y, this.parseXml = J2, this.parseTextData = z2, this.resolveNameSpace = X, this.buildAttributesMap = Z, this.isItStopNode = tt, this.replaceEntitiesValue = Q, this.readStopNodeData = nt, this.saveTextToParentTag = H2, this.addChild = K, this.ignoreAttributesFn = "function" == typeof (e5 = this.options.ignoreAttributes) ? e5 : Array.isArray(e5) ? (t6) => {
+            for (const i5 of e5) {
+              if ("string" == typeof i5 && t6 === i5) return true;
+              if (i5 instanceof RegExp && i5.test(t6)) return true;
+            }
+          } : () => false, this.entityExpansionCount = 0, this.currentExpandedLength = 0, this.matcher = new G2(), this.readonlyMatcher = this.matcher.readOnly(), this.isCurrentNodeStopNode = false, this.options.stopNodes && this.options.stopNodes.length > 0) {
+            this.stopNodeExpressions = [];
             for (let t6 = 0; t6 < this.options.stopNodes.length; t6++) {
-              const e5 = this.options.stopNodes[t6];
-              "string" == typeof e5 && (e5.startsWith("*.") ? this.stopNodesWildcard.add(e5.substring(2)) : this.stopNodesExact.add(e5));
+              const e6 = this.options.stopNodes[t6];
+              "string" == typeof e6 ? this.stopNodeExpressions.push(new R(e6)) : e6 instanceof R && this.stopNodeExpressions.push(e6);
             }
           }
         }
       }
-      function j4(t5) {
+      function Y(t5) {
         const e5 = Object.keys(t5);
-        for (let n5 = 0; n5 < e5.length; n5++) {
-          const i5 = e5[n5], s5 = i5.replace(/[.\-+*:]/g, "\\.");
-          this.lastEntities[i5] = { regex: new RegExp("&" + s5 + ";", "g"), val: t5[i5] };
+        for (let i5 = 0; i5 < e5.length; i5++) {
+          const n5 = e5[i5], s5 = n5.replace(/[.\-+*:]/g, "\\.");
+          this.lastEntities[n5] = { regex: new RegExp("&" + s5 + ";", "g"), val: t5[n5] };
         }
       }
-      function M(t5, e5, n5, i5, s5, r5, o5) {
-        if (void 0 !== t5 && (this.options.trimValues && !i5 && (t5 = t5.trim()), t5.length > 0)) {
-          o5 || (t5 = this.replaceEntitiesValue(t5, e5, n5));
-          const i6 = this.options.tagValueProcessor(e5, t5, n5, s5, r5);
-          return null == i6 ? t5 : typeof i6 != typeof t5 || i6 !== t5 ? i6 : this.options.trimValues || t5.trim() === t5 ? Z(t5, this.options.parseTagValue, this.options.numberParseOptions) : t5;
+      function z2(t5, e5, i5, n5, s5, r5, o5) {
+        if (void 0 !== t5 && (this.options.trimValues && !n5 && (t5 = t5.trim()), t5.length > 0)) {
+          o5 || (t5 = this.replaceEntitiesValue(t5, e5, i5));
+          const n6 = this.options.jPath ? i5.toString() : i5, a5 = this.options.tagValueProcessor(e5, t5, n6, s5, r5);
+          return null == a5 ? t5 : typeof a5 != typeof t5 || a5 !== t5 ? a5 : this.options.trimValues || t5.trim() === t5 ? st(t5, this.options.parseTagValue, this.options.numberParseOptions) : t5;
         }
       }
-      function _(t5) {
+      function X(t5) {
         if (this.options.removeNSPrefix) {
-          const e5 = t5.split(":"), n5 = "/" === t5.charAt(0) ? "/" : "";
+          const e5 = t5.split(":"), i5 = "/" === t5.charAt(0) ? "/" : "";
           if ("xmlns" === e5[0]) return "";
-          2 === e5.length && (t5 = n5 + e5[1]);
+          2 === e5.length && (t5 = i5 + e5[1]);
         }
         return t5;
       }
-      const k4 = new RegExp(`([^\\s=]+)\\s*(=\\s*(['"])([\\s\\S]*?)\\3)?`, "gm");
-      function U(t5, e5, n5) {
+      const q4 = new RegExp(`([^\\s=]+)\\s*(=\\s*(['"])([\\s\\S]*?)\\3)?`, "gm");
+      function Z(t5, e5, i5) {
         if (true !== this.options.ignoreAttributes && "string" == typeof t5) {
-          const i5 = s4(t5, k4), r5 = i5.length, o5 = {};
+          const n5 = s4(t5, q4), r5 = n5.length, o5 = {}, a5 = {};
           for (let t6 = 0; t6 < r5; t6++) {
-            const s5 = this.resolveNameSpace(i5[t6][1]);
-            if (this.ignoreAttributesFn(s5, e5)) continue;
-            let r6 = i5[t6][4], a5 = this.options.attributeNamePrefix + s5;
-            if (s5.length) if (this.options.transformAttributeName && (a5 = this.options.transformAttributeName(a5)), "__proto__" === a5 && (a5 = "#__proto__"), void 0 !== r6) {
-              this.options.trimValues && (r6 = r6.trim()), r6 = this.replaceEntitiesValue(r6, n5, e5);
-              const t7 = this.options.attributeValueProcessor(s5, r6, e5);
-              o5[a5] = null == t7 ? r6 : typeof t7 != typeof r6 || t7 !== r6 ? t7 : Z(r6, this.options.parseAttributeValue, this.options.numberParseOptions);
-            } else this.options.allowBooleanAttributes && (o5[a5] = true);
+            const e6 = this.resolveNameSpace(n5[t6][1]), s5 = n5[t6][4];
+            if (e6.length && void 0 !== s5) {
+              let t7 = s5;
+              this.options.trimValues && (t7 = t7.trim()), t7 = this.replaceEntitiesValue(t7, i5, this.readonlyMatcher), a5[e6] = t7;
+            }
+          }
+          Object.keys(a5).length > 0 && "object" == typeof e5 && e5.updateCurrent && e5.updateCurrent(a5);
+          for (let t6 = 0; t6 < r5; t6++) {
+            const s5 = this.resolveNameSpace(n5[t6][1]), r6 = this.options.jPath ? e5.toString() : this.readonlyMatcher;
+            if (this.ignoreAttributesFn(s5, r6)) continue;
+            let a6 = n5[t6][4], h5 = this.options.attributeNamePrefix + s5;
+            if (s5.length) if (this.options.transformAttributeName && (h5 = this.options.transformAttributeName(h5)), h5 = at(h5, this.options), void 0 !== a6) {
+              this.options.trimValues && (a6 = a6.trim()), a6 = this.replaceEntitiesValue(a6, i5, this.readonlyMatcher);
+              const t7 = this.options.jPath ? e5.toString() : this.readonlyMatcher, n6 = this.options.attributeValueProcessor(s5, a6, t7);
+              o5[h5] = null == n6 ? a6 : typeof n6 != typeof a6 || n6 !== a6 ? n6 : st(a6, this.options.parseAttributeValue, this.options.numberParseOptions);
+            } else this.options.allowBooleanAttributes && (o5[h5] = true);
           }
           if (!Object.keys(o5).length) return;
           if (this.options.attributesGroupName) {
@@ -32230,281 +32464,340 @@ var require_fxp = __commonJS({
           return o5;
         }
       }
-      const B2 = function(t5) {
+      const J2 = function(t5) {
         t5 = t5.replace(/\r\n?/g, "\n");
-        const e5 = new I2("!xml");
-        let n5 = e5, i5 = "", s5 = "";
-        this.entityExpansionCount = 0, this.currentExpandedLength = 0;
-        const r5 = new O(this.options.processEntities);
-        for (let o5 = 0; o5 < t5.length; o5++) if ("<" === t5[o5]) if ("/" === t5[o5 + 1]) {
-          const e6 = z2(t5, ">", o5, "Closing Tag is not closed.");
-          let r6 = t5.substring(o5 + 2, e6).trim();
+        const e5 = new $("!xml");
+        let i5 = e5, n5 = "";
+        this.matcher.reset(), this.entityExpansionCount = 0, this.currentExpandedLength = 0;
+        const s5 = new I2(this.options.processEntities);
+        for (let r5 = 0; r5 < t5.length; r5++) if ("<" === t5[r5]) if ("/" === t5[r5 + 1]) {
+          const e6 = et(t5, ">", r5, "Closing Tag is not closed.");
+          let s6 = t5.substring(r5 + 2, e6).trim();
           if (this.options.removeNSPrefix) {
-            const t6 = r6.indexOf(":");
-            -1 !== t6 && (r6 = r6.substr(t6 + 1));
+            const t6 = s6.indexOf(":");
+            -1 !== t6 && (s6 = s6.substr(t6 + 1));
           }
-          this.options.transformTagName && (r6 = this.options.transformTagName(r6)), n5 && (i5 = this.saveTextToParentTag(i5, n5, s5));
-          const a5 = s5.substring(s5.lastIndexOf(".") + 1);
-          if (r6 && -1 !== this.options.unpairedTags.indexOf(r6)) throw new Error(`Unpaired tag can not be used as closing tag: </${r6}>`);
-          let l5 = 0;
-          a5 && -1 !== this.options.unpairedTags.indexOf(a5) ? (l5 = s5.lastIndexOf(".", s5.lastIndexOf(".") - 1), this.tagsNodeStack.pop()) : l5 = s5.lastIndexOf("."), s5 = s5.substring(0, l5), n5 = this.tagsNodeStack.pop(), i5 = "", o5 = e6;
-        } else if ("?" === t5[o5 + 1]) {
-          let e6 = W(t5, o5, false, "?>");
+          s6 = ot(this.options.transformTagName, s6, "", this.options).tagName, i5 && (n5 = this.saveTextToParentTag(n5, i5, this.readonlyMatcher));
+          const o5 = this.matcher.getCurrentTag();
+          if (s6 && -1 !== this.options.unpairedTags.indexOf(s6)) throw new Error(`Unpaired tag can not be used as closing tag: </${s6}>`);
+          o5 && -1 !== this.options.unpairedTags.indexOf(o5) && (this.matcher.pop(), this.tagsNodeStack.pop()), this.matcher.pop(), this.isCurrentNodeStopNode = false, i5 = this.tagsNodeStack.pop(), n5 = "", r5 = e6;
+        } else if ("?" === t5[r5 + 1]) {
+          let e6 = it(t5, r5, false, "?>");
           if (!e6) throw new Error("Pi Tag is not closed.");
-          if (i5 = this.saveTextToParentTag(i5, n5, s5), this.options.ignoreDeclaration && "?xml" === e6.tagName || this.options.ignorePiTags) ;
+          if (n5 = this.saveTextToParentTag(n5, i5, this.readonlyMatcher), this.options.ignoreDeclaration && "?xml" === e6.tagName || this.options.ignorePiTags) ;
           else {
-            const t6 = new I2(e6.tagName);
-            t6.add(this.options.textNodeName, ""), e6.tagName !== e6.tagExp && e6.attrExpPresent && (t6[":@"] = this.buildAttributesMap(e6.tagExp, s5, e6.tagName)), this.addChild(n5, t6, s5, o5);
+            const t6 = new $(e6.tagName);
+            t6.add(this.options.textNodeName, ""), e6.tagName !== e6.tagExp && e6.attrExpPresent && (t6[":@"] = this.buildAttributesMap(e6.tagExp, this.matcher, e6.tagName)), this.addChild(i5, t6, this.readonlyMatcher, r5);
           }
-          o5 = e6.closeIndex + 1;
-        } else if ("!--" === t5.substr(o5 + 1, 3)) {
-          const e6 = z2(t5, "-->", o5 + 4, "Comment is not closed.");
+          r5 = e6.closeIndex + 1;
+        } else if ("!--" === t5.substr(r5 + 1, 3)) {
+          const e6 = et(t5, "-->", r5 + 4, "Comment is not closed.");
           if (this.options.commentPropName) {
-            const r6 = t5.substring(o5 + 4, e6 - 2);
-            i5 = this.saveTextToParentTag(i5, n5, s5), n5.add(this.options.commentPropName, [{ [this.options.textNodeName]: r6 }]);
+            const s6 = t5.substring(r5 + 4, e6 - 2);
+            n5 = this.saveTextToParentTag(n5, i5, this.readonlyMatcher), i5.add(this.options.commentPropName, [{ [this.options.textNodeName]: s6 }]);
           }
-          o5 = e6;
-        } else if ("!D" === t5.substr(o5 + 1, 2)) {
-          const e6 = r5.readDocType(t5, o5);
-          this.docTypeEntities = e6.entities, o5 = e6.i;
-        } else if ("![" === t5.substr(o5 + 1, 2)) {
-          const e6 = z2(t5, "]]>", o5, "CDATA is not closed.") - 2, r6 = t5.substring(o5 + 9, e6);
-          i5 = this.saveTextToParentTag(i5, n5, s5);
-          let a5 = this.parseTextData(r6, n5.tagname, s5, true, false, true, true);
-          null == a5 && (a5 = ""), this.options.cdataPropName ? n5.add(this.options.cdataPropName, [{ [this.options.textNodeName]: r6 }]) : n5.add(this.options.textNodeName, a5), o5 = e6 + 2;
+          r5 = e6;
+        } else if ("!D" === t5.substr(r5 + 1, 2)) {
+          const e6 = s5.readDocType(t5, r5);
+          this.docTypeEntities = e6.entities, r5 = e6.i;
+        } else if ("![" === t5.substr(r5 + 1, 2)) {
+          const e6 = et(t5, "]]>", r5, "CDATA is not closed.") - 2, s6 = t5.substring(r5 + 9, e6);
+          n5 = this.saveTextToParentTag(n5, i5, this.readonlyMatcher);
+          let o5 = this.parseTextData(s6, i5.tagname, this.readonlyMatcher, true, false, true, true);
+          null == o5 && (o5 = ""), this.options.cdataPropName ? i5.add(this.options.cdataPropName, [{ [this.options.textNodeName]: s6 }]) : i5.add(this.options.textNodeName, o5), r5 = e6 + 2;
         } else {
-          let r6 = W(t5, o5, this.options.removeNSPrefix), a5 = r6.tagName;
-          const l5 = r6.rawTagName;
-          let u5 = r6.tagExp, h5 = r6.attrExpPresent, d5 = r6.closeIndex;
-          if (this.options.transformTagName) {
-            const t6 = this.options.transformTagName(a5);
-            u5 === a5 && (u5 = t6), a5 = t6;
+          let s6 = it(t5, r5, this.options.removeNSPrefix);
+          if (!s6) {
+            const e6 = t5.substring(Math.max(0, r5 - 50), Math.min(t5.length, r5 + 50));
+            throw new Error(`readTagExp returned undefined at position ${r5}. Context: "${e6}"`);
           }
-          n5 && i5 && "!xml" !== n5.tagname && (i5 = this.saveTextToParentTag(i5, n5, s5, false));
-          const p5 = n5;
-          p5 && -1 !== this.options.unpairedTags.indexOf(p5.tagname) && (n5 = this.tagsNodeStack.pop(), s5 = s5.substring(0, s5.lastIndexOf("."))), a5 !== e5.tagname && (s5 += s5 ? "." + a5 : a5);
-          const f5 = o5;
-          if (this.isItStopNode(this.stopNodesExact, this.stopNodesWildcard, s5, a5)) {
+          let o5 = s6.tagName;
+          const a5 = s6.rawTagName;
+          let h5 = s6.tagExp, l5 = s6.attrExpPresent, p5 = s6.closeIndex;
+          if ({ tagName: o5, tagExp: h5 } = ot(this.options.transformTagName, o5, h5, this.options), this.options.strictReservedNames && (o5 === this.options.commentPropName || o5 === this.options.cdataPropName || o5 === this.options.textNodeName || o5 === this.options.attributesGroupName)) throw new Error(`Invalid tag name: ${o5}`);
+          i5 && n5 && "!xml" !== i5.tagname && (n5 = this.saveTextToParentTag(n5, i5, this.readonlyMatcher, false));
+          const u5 = i5;
+          u5 && -1 !== this.options.unpairedTags.indexOf(u5.tagname) && (i5 = this.tagsNodeStack.pop(), this.matcher.pop());
+          let c5 = false;
+          h5.length > 0 && h5.lastIndexOf("/") === h5.length - 1 && (c5 = true, "/" === o5[o5.length - 1] ? (o5 = o5.substr(0, o5.length - 1), h5 = o5) : h5 = h5.substr(0, h5.length - 1), l5 = o5 !== h5);
+          let d5, f5 = null, g5 = {};
+          d5 = B2(a5), o5 !== e5.tagname && this.matcher.push(o5, {}, d5), o5 !== h5 && l5 && (f5 = this.buildAttributesMap(h5, this.matcher, o5), f5 && (g5 = U(f5, this.options))), o5 !== e5.tagname && (this.isCurrentNodeStopNode = this.isItStopNode(this.stopNodeExpressions, this.matcher));
+          const m5 = r5;
+          if (this.isCurrentNodeStopNode) {
             let e6 = "";
-            if (u5.length > 0 && u5.lastIndexOf("/") === u5.length - 1) "/" === a5[a5.length - 1] ? (a5 = a5.substr(0, a5.length - 1), s5 = s5.substr(0, s5.length - 1), u5 = a5) : u5 = u5.substr(0, u5.length - 1), o5 = r6.closeIndex;
-            else if (-1 !== this.options.unpairedTags.indexOf(a5)) o5 = r6.closeIndex;
+            if (c5) r5 = s6.closeIndex;
+            else if (-1 !== this.options.unpairedTags.indexOf(o5)) r5 = s6.closeIndex;
             else {
-              const n6 = this.readStopNodeData(t5, l5, d5 + 1);
-              if (!n6) throw new Error(`Unexpected end of ${l5}`);
-              o5 = n6.i, e6 = n6.tagContent;
+              const i6 = this.readStopNodeData(t5, a5, p5 + 1);
+              if (!i6) throw new Error(`Unexpected end of ${a5}`);
+              r5 = i6.i, e6 = i6.tagContent;
             }
-            const i6 = new I2(a5);
-            a5 !== u5 && h5 && (i6[":@"] = this.buildAttributesMap(u5, s5, a5)), e6 && (e6 = this.parseTextData(e6, a5, s5, true, h5, true, true)), s5 = s5.substr(0, s5.lastIndexOf(".")), i6.add(this.options.textNodeName, e6), this.addChild(n5, i6, s5, f5);
+            const n6 = new $(o5);
+            f5 && (n6[":@"] = f5), n6.add(this.options.textNodeName, e6), this.matcher.pop(), this.isCurrentNodeStopNode = false, this.addChild(i5, n6, this.readonlyMatcher, m5);
           } else {
-            if (u5.length > 0 && u5.lastIndexOf("/") === u5.length - 1) {
-              if ("/" === a5[a5.length - 1] ? (a5 = a5.substr(0, a5.length - 1), s5 = s5.substr(0, s5.length - 1), u5 = a5) : u5 = u5.substr(0, u5.length - 1), this.options.transformTagName) {
-                const t7 = this.options.transformTagName(a5);
-                u5 === a5 && (u5 = t7), a5 = t7;
-              }
-              const t6 = new I2(a5);
-              a5 !== u5 && h5 && (t6[":@"] = this.buildAttributesMap(u5, s5, a5)), this.addChild(n5, t6, s5, f5), s5 = s5.substr(0, s5.lastIndexOf("."));
+            if (c5) {
+              ({ tagName: o5, tagExp: h5 } = ot(this.options.transformTagName, o5, h5, this.options));
+              const t6 = new $(o5);
+              f5 && (t6[":@"] = f5), this.addChild(i5, t6, this.readonlyMatcher, m5), this.matcher.pop(), this.isCurrentNodeStopNode = false;
             } else {
-              const t6 = new I2(a5);
-              this.tagsNodeStack.push(n5), a5 !== u5 && h5 && (t6[":@"] = this.buildAttributesMap(u5, s5, a5)), this.addChild(n5, t6, s5, f5), n5 = t6;
+              if (-1 !== this.options.unpairedTags.indexOf(o5)) {
+                const t6 = new $(o5);
+                f5 && (t6[":@"] = f5), this.addChild(i5, t6, this.readonlyMatcher, m5), this.matcher.pop(), this.isCurrentNodeStopNode = false, r5 = s6.closeIndex;
+                continue;
+              }
+              {
+                const t6 = new $(o5);
+                if (this.tagsNodeStack.length > this.options.maxNestedTags) throw new Error("Maximum nested tags exceeded");
+                this.tagsNodeStack.push(i5), f5 && (t6[":@"] = f5), this.addChild(i5, t6, this.readonlyMatcher, m5), i5 = t6;
+              }
             }
-            i5 = "", o5 = d5;
+            n5 = "", r5 = p5;
           }
         }
-        else i5 += t5[o5];
+        else n5 += t5[r5];
         return e5.child;
       };
-      function R(t5, e5, n5, i5) {
-        this.options.captureMetaData || (i5 = void 0);
-        const s5 = this.options.updateTag(e5.tagname, n5, e5[":@"]);
-        false === s5 || ("string" == typeof s5 ? (e5.tagname = s5, t5.addChild(e5, i5)) : t5.addChild(e5, i5));
+      function K(t5, e5, i5, n5) {
+        this.options.captureMetaData || (n5 = void 0);
+        const s5 = this.options.jPath ? i5.toString() : i5, r5 = this.options.updateTag(e5.tagname, s5, e5[":@"]);
+        false === r5 || ("string" == typeof r5 ? (e5.tagname = r5, t5.addChild(e5, n5)) : t5.addChild(e5, n5));
       }
-      const Y = function(t5, e5, n5) {
-        if (-1 === t5.indexOf("&")) return t5;
-        const i5 = this.options.processEntities;
-        if (!i5.enabled) return t5;
-        if (i5.allowedTags && !i5.allowedTags.includes(e5)) return t5;
-        if (i5.tagFilter && !i5.tagFilter(e5, n5)) return t5;
-        for (let e6 in this.docTypeEntities) {
-          const n6 = this.docTypeEntities[e6], s5 = t5.match(n6.regx);
+      function Q(t5, e5, i5) {
+        const n5 = this.options.processEntities;
+        if (!n5 || !n5.enabled) return t5;
+        if (n5.allowedTags) {
+          const s5 = this.options.jPath ? i5.toString() : i5;
+          if (!(Array.isArray(n5.allowedTags) ? n5.allowedTags.includes(e5) : n5.allowedTags(e5, s5))) return t5;
+        }
+        if (n5.tagFilter) {
+          const s5 = this.options.jPath ? i5.toString() : i5;
+          if (!n5.tagFilter(e5, s5)) return t5;
+        }
+        for (const e6 of Object.keys(this.docTypeEntities)) {
+          const i6 = this.docTypeEntities[e6], s5 = t5.match(i6.regx);
           if (s5) {
-            if (this.entityExpansionCount += s5.length, i5.maxTotalExpansions && this.entityExpansionCount > i5.maxTotalExpansions) throw new Error(`Entity expansion limit exceeded: ${this.entityExpansionCount} > ${i5.maxTotalExpansions}`);
+            if (this.entityExpansionCount += s5.length, n5.maxTotalExpansions && this.entityExpansionCount > n5.maxTotalExpansions) throw new Error(`Entity expansion limit exceeded: ${this.entityExpansionCount} > ${n5.maxTotalExpansions}`);
             const e7 = t5.length;
-            if (t5 = t5.replace(n6.regx, n6.val), i5.maxExpandedLength && (this.currentExpandedLength += t5.length - e7, this.currentExpandedLength > i5.maxExpandedLength)) throw new Error(`Total expanded content size exceeded: ${this.currentExpandedLength} > ${i5.maxExpandedLength}`);
+            if (t5 = t5.replace(i6.regx, i6.val), n5.maxExpandedLength && (this.currentExpandedLength += t5.length - e7, this.currentExpandedLength > n5.maxExpandedLength)) throw new Error(`Total expanded content size exceeded: ${this.currentExpandedLength} > ${n5.maxExpandedLength}`);
           }
         }
-        if (-1 === t5.indexOf("&")) return t5;
-        for (let e6 in this.lastEntities) {
-          const n6 = this.lastEntities[e6];
-          t5 = t5.replace(n6.regex, n6.val);
+        for (const e6 of Object.keys(this.lastEntities)) {
+          const i6 = this.lastEntities[e6], s5 = t5.match(i6.regex);
+          if (s5 && (this.entityExpansionCount += s5.length, n5.maxTotalExpansions && this.entityExpansionCount > n5.maxTotalExpansions)) throw new Error(`Entity expansion limit exceeded: ${this.entityExpansionCount} > ${n5.maxTotalExpansions}`);
+          t5 = t5.replace(i6.regex, i6.val);
         }
         if (-1 === t5.indexOf("&")) return t5;
-        if (this.options.htmlEntities) for (let e6 in this.htmlEntities) {
-          const n6 = this.htmlEntities[e6];
-          t5 = t5.replace(n6.regex, n6.val);
+        if (this.options.htmlEntities) for (const e6 of Object.keys(this.htmlEntities)) {
+          const i6 = this.htmlEntities[e6], s5 = t5.match(i6.regex);
+          if (s5 && (this.entityExpansionCount += s5.length, n5.maxTotalExpansions && this.entityExpansionCount > n5.maxTotalExpansions)) throw new Error(`Entity expansion limit exceeded: ${this.entityExpansionCount} > ${n5.maxTotalExpansions}`);
+          t5 = t5.replace(i6.regex, i6.val);
         }
         return t5.replace(this.ampEntity.regex, this.ampEntity.val);
-      };
-      function G2(t5, e5, n5, i5) {
-        return t5 && (void 0 === i5 && (i5 = 0 === e5.child.length), void 0 !== (t5 = this.parseTextData(t5, e5.tagname, n5, false, !!e5[":@"] && 0 !== Object.keys(e5[":@"]).length, i5)) && "" !== t5 && e5.add(this.options.textNodeName, t5), t5 = ""), t5;
       }
-      function X(t5, e5, n5, i5) {
-        return !(!e5 || !e5.has(i5)) || !(!t5 || !t5.has(n5));
+      function H2(t5, e5, i5, n5) {
+        return t5 && (void 0 === n5 && (n5 = 0 === e5.child.length), void 0 !== (t5 = this.parseTextData(t5, e5.tagname, i5, false, !!e5[":@"] && 0 !== Object.keys(e5[":@"]).length, n5)) && "" !== t5 && e5.add(this.options.textNodeName, t5), t5 = ""), t5;
       }
-      function z2(t5, e5, n5, i5) {
-        const s5 = t5.indexOf(e5, n5);
-        if (-1 === s5) throw new Error(i5);
+      function tt(t5, e5) {
+        if (!t5 || 0 === t5.length) return false;
+        for (let i5 = 0; i5 < t5.length; i5++) if (e5.matches(t5[i5])) return true;
+        return false;
+      }
+      function et(t5, e5, i5, n5) {
+        const s5 = t5.indexOf(e5, i5);
+        if (-1 === s5) throw new Error(n5);
         return s5 + e5.length - 1;
       }
-      function W(t5, e5, n5, i5 = ">") {
-        const s5 = (function(t6, e6, n6 = ">") {
-          let i6, s6 = "";
+      function it(t5, e5, i5, n5 = ">") {
+        const s5 = (function(t6, e6, i6 = ">") {
+          let n6, s6 = "";
           for (let r6 = e6; r6 < t6.length; r6++) {
             let e7 = t6[r6];
-            if (i6) e7 === i6 && (i6 = "");
-            else if ('"' === e7 || "'" === e7) i6 = e7;
-            else if (e7 === n6[0]) {
-              if (!n6[1]) return { data: s6, index: r6 };
-              if (t6[r6 + 1] === n6[1]) return { data: s6, index: r6 };
+            if (n6) e7 === n6 && (n6 = "");
+            else if ('"' === e7 || "'" === e7) n6 = e7;
+            else if (e7 === i6[0]) {
+              if (!i6[1]) return { data: s6, index: r6 };
+              if (t6[r6 + 1] === i6[1]) return { data: s6, index: r6 };
             } else "	" === e7 && (e7 = " ");
             s6 += e7;
           }
-        })(t5, e5 + 1, i5);
+        })(t5, e5 + 1, n5);
         if (!s5) return;
         let r5 = s5.data;
         const o5 = s5.index, a5 = r5.search(/\s/);
-        let l5 = r5, u5 = true;
-        -1 !== a5 && (l5 = r5.substring(0, a5), r5 = r5.substring(a5 + 1).trimStart());
-        const h5 = l5;
-        if (n5) {
-          const t6 = l5.indexOf(":");
-          -1 !== t6 && (l5 = l5.substr(t6 + 1), u5 = l5 !== s5.data.substr(t6 + 1));
+        let h5 = r5, l5 = true;
+        -1 !== a5 && (h5 = r5.substring(0, a5), r5 = r5.substring(a5 + 1).trimStart());
+        const p5 = h5;
+        if (i5) {
+          const t6 = h5.indexOf(":");
+          -1 !== t6 && (h5 = h5.substr(t6 + 1), l5 = h5 !== s5.data.substr(t6 + 1));
         }
-        return { tagName: l5, tagExp: r5, closeIndex: o5, attrExpPresent: u5, rawTagName: h5 };
+        return { tagName: h5, tagExp: r5, closeIndex: o5, attrExpPresent: l5, rawTagName: p5 };
       }
-      function q4(t5, e5, n5) {
-        const i5 = n5;
+      function nt(t5, e5, i5) {
+        const n5 = i5;
         let s5 = 1;
-        for (; n5 < t5.length; n5++) if ("<" === t5[n5]) if ("/" === t5[n5 + 1]) {
-          const r5 = z2(t5, ">", n5, `${e5} is not closed`);
-          if (t5.substring(n5 + 2, r5).trim() === e5 && (s5--, 0 === s5)) return { tagContent: t5.substring(i5, n5), i: r5 };
-          n5 = r5;
-        } else if ("?" === t5[n5 + 1]) n5 = z2(t5, "?>", n5 + 1, "StopNode is not closed.");
-        else if ("!--" === t5.substr(n5 + 1, 3)) n5 = z2(t5, "-->", n5 + 3, "StopNode is not closed.");
-        else if ("![" === t5.substr(n5 + 1, 2)) n5 = z2(t5, "]]>", n5, "StopNode is not closed.") - 2;
+        for (; i5 < t5.length; i5++) if ("<" === t5[i5]) if ("/" === t5[i5 + 1]) {
+          const r5 = et(t5, ">", i5, `${e5} is not closed`);
+          if (t5.substring(i5 + 2, r5).trim() === e5 && (s5--, 0 === s5)) return { tagContent: t5.substring(n5, i5), i: r5 };
+          i5 = r5;
+        } else if ("?" === t5[i5 + 1]) i5 = et(t5, "?>", i5 + 1, "StopNode is not closed.");
+        else if ("!--" === t5.substr(i5 + 1, 3)) i5 = et(t5, "-->", i5 + 3, "StopNode is not closed.");
+        else if ("![" === t5.substr(i5 + 1, 2)) i5 = et(t5, "]]>", i5, "StopNode is not closed.") - 2;
         else {
-          const i6 = W(t5, n5, ">");
-          i6 && ((i6 && i6.tagName) === e5 && "/" !== i6.tagExp[i6.tagExp.length - 1] && s5++, n5 = i6.closeIndex);
+          const n6 = it(t5, i5, ">");
+          n6 && ((n6 && n6.tagName) === e5 && "/" !== n6.tagExp[n6.tagExp.length - 1] && s5++, i5 = n6.closeIndex);
         }
       }
-      function Z(t5, e5, n5) {
+      function st(t5, e5, i5) {
         if (e5 && "string" == typeof t5) {
           const e6 = t5.trim();
           return "true" === e6 || "false" !== e6 && (function(t6, e7 = {}) {
-            if (e7 = Object.assign({}, V, e7), !t6 || "string" != typeof t6) return t6;
-            let n6 = t6.trim();
-            if (void 0 !== e7.skipLike && e7.skipLike.test(n6)) return t6;
+            if (e7 = Object.assign({}, k4, e7), !t6 || "string" != typeof t6) return t6;
+            let i6 = t6.trim();
+            if (void 0 !== e7.skipLike && e7.skipLike.test(i6)) return t6;
             if ("0" === t6) return 0;
-            if (e7.hex && C2.test(n6)) return (function(t7) {
+            if (e7.hex && D2.test(i6)) return (function(t7) {
               if (parseInt) return parseInt(t7, 16);
               if (Number.parseInt) return Number.parseInt(t7, 16);
               if (window && window.parseInt) return window.parseInt(t7, 16);
               throw new Error("parseInt, Number.parseInt, window.parseInt are not supported");
-            })(n6);
-            if (-1 !== n6.search(/.+[eE].+/)) return (function(t7, e8, n7) {
-              if (!n7.eNotation) return t7;
-              const i6 = e8.match(D2);
-              if (i6) {
-                let s5 = i6[1] || "";
-                const r5 = -1 === i6[3].indexOf("e") ? "E" : "e", o5 = i6[2], a5 = s5 ? t7[o5.length + 1] === r5 : t7[o5.length] === r5;
-                return o5.length > 1 && a5 ? t7 : 1 !== o5.length || !i6[3].startsWith(`.${r5}`) && i6[3][0] !== r5 ? n7.leadingZeros && !a5 ? (e8 = (i6[1] || "") + i6[3], Number(e8)) : t7 : Number(e8);
-              }
-              return t7;
-            })(t6, n6, e7);
-            {
-              const s5 = $.exec(n6);
-              if (s5) {
-                const r5 = s5[1] || "", o5 = s5[2];
-                let a5 = (i5 = s5[3]) && -1 !== i5.indexOf(".") ? ("." === (i5 = i5.replace(/0+$/, "")) ? i5 = "0" : "." === i5[0] ? i5 = "0" + i5 : "." === i5[i5.length - 1] && (i5 = i5.substring(0, i5.length - 1)), i5) : i5;
-                const l5 = r5 ? "." === t6[o5.length + 1] : "." === t6[o5.length];
-                if (!e7.leadingZeros && (o5.length > 1 || 1 === o5.length && !l5)) return t6;
-                {
-                  const i6 = Number(n6), s6 = String(i6);
-                  if (0 === i6 || -0 === i6) return i6;
-                  if (-1 !== s6.search(/[eE]/)) return e7.eNotation ? i6 : t6;
-                  if (-1 !== n6.indexOf(".")) return "0" === s6 || s6 === a5 || s6 === `${r5}${a5}` ? i6 : t6;
-                  let l6 = o5 ? a5 : n6;
-                  return o5 ? l6 === s6 || r5 + l6 === s6 ? i6 : t6 : l6 === s6 || l6 === r5 + s6 ? i6 : t6;
+            })(i6);
+            if (isFinite(i6)) {
+              if (i6.includes("e") || i6.includes("E")) return (function(t7, e8, i7) {
+                if (!i7.eNotation) return t7;
+                const n6 = e8.match(F2);
+                if (n6) {
+                  let s5 = n6[1] || "";
+                  const r5 = -1 === n6[3].indexOf("e") ? "E" : "e", o5 = n6[2], a5 = s5 ? t7[o5.length + 1] === r5 : t7[o5.length] === r5;
+                  return o5.length > 1 && a5 ? t7 : (1 !== o5.length || !n6[3].startsWith(`.${r5}`) && n6[3][0] !== r5) && o5.length > 0 ? i7.leadingZeros && !a5 ? (e8 = (n6[1] || "") + n6[3], Number(e8)) : t7 : Number(e8);
                 }
+                return t7;
+              })(t6, i6, e7);
+              {
+                const s5 = V.exec(i6);
+                if (s5) {
+                  const r5 = s5[1] || "", o5 = s5[2];
+                  let a5 = (n5 = s5[3]) && -1 !== n5.indexOf(".") ? ("." === (n5 = n5.replace(/0+$/, "")) ? n5 = "0" : "." === n5[0] ? n5 = "0" + n5 : "." === n5[n5.length - 1] && (n5 = n5.substring(0, n5.length - 1)), n5) : n5;
+                  const h5 = r5 ? "." === t6[o5.length + 1] : "." === t6[o5.length];
+                  if (!e7.leadingZeros && (o5.length > 1 || 1 === o5.length && !h5)) return t6;
+                  {
+                    const n6 = Number(i6), s6 = String(n6);
+                    if (0 === n6) return n6;
+                    if (-1 !== s6.search(/[eE]/)) return e7.eNotation ? n6 : t6;
+                    if (-1 !== i6.indexOf(".")) return "0" === s6 || s6 === a5 || s6 === `${r5}${a5}` ? n6 : t6;
+                    let h6 = o5 ? a5 : i6;
+                    return o5 ? h6 === s6 || r5 + h6 === s6 ? n6 : t6 : h6 === s6 || h6 === r5 + s6 ? n6 : t6;
+                  }
+                }
+                return t6;
               }
-              return t6;
             }
-            var i5;
-          })(t5, n5);
+            var n5;
+            return (function(t7, e8, i7) {
+              const n6 = e8 === 1 / 0;
+              switch (i7.infinity.toLowerCase()) {
+                case "null":
+                  return null;
+                case "infinity":
+                  return e8;
+                case "string":
+                  return n6 ? "Infinity" : "-Infinity";
+                default:
+                  return t7;
+              }
+            })(t6, Number(i6), e7);
+          })(t5, i5);
         }
         return void 0 !== t5 ? t5 : "";
       }
-      function K(t5, e5, n5) {
-        const i5 = Number.parseInt(t5, e5);
-        return i5 >= 0 && i5 <= 1114111 ? String.fromCodePoint(i5) : n5 + t5 + ";";
+      function rt(t5, e5, i5) {
+        const n5 = Number.parseInt(t5, e5);
+        return n5 >= 0 && n5 <= 1114111 ? String.fromCodePoint(n5) : i5 + t5 + ";";
       }
-      const Q = I2.getMetaDataSymbol();
-      function J2(t5, e5) {
-        return H2(t5, e5);
+      function ot(t5, e5, i5, n5) {
+        if (t5) {
+          const n6 = t5(e5);
+          i5 === e5 && (i5 = n6), e5 = n6;
+        }
+        return { tagName: e5 = at(e5, n5), tagExp: i5 };
       }
-      function H2(t5, e5, n5) {
-        let i5;
-        const s5 = {};
-        for (let r5 = 0; r5 < t5.length; r5++) {
-          const o5 = t5[r5], a5 = tt(o5);
-          let l5 = "";
-          if (l5 = void 0 === n5 ? a5 : n5 + "." + a5, a5 === e5.textNodeName) void 0 === i5 ? i5 = o5[a5] : i5 += "" + o5[a5];
+      function at(t5, e5) {
+        if (a4.includes(t5)) throw new Error(`[SECURITY] Invalid name: "${t5}" is a reserved JavaScript keyword that could cause prototype pollution`);
+        return o4.includes(t5) ? e5.onDangerousProperty(t5) : t5;
+      }
+      const ht = $.getMetaDataSymbol();
+      function lt(t5, e5) {
+        if (!t5 || "object" != typeof t5) return {};
+        if (!e5) return t5;
+        const i5 = {};
+        for (const n5 in t5) n5.startsWith(e5) ? i5[n5.substring(e5.length)] = t5[n5] : i5[n5] = t5[n5];
+        return i5;
+      }
+      function pt(t5, e5, i5, n5) {
+        return ut(t5, e5, i5, n5);
+      }
+      function ut(t5, e5, i5, n5) {
+        let s5;
+        const r5 = {};
+        for (let o5 = 0; o5 < t5.length; o5++) {
+          const a5 = t5[o5], h5 = ct(a5);
+          if (void 0 !== h5 && h5 !== e5.textNodeName) {
+            const t6 = lt(a5[":@"] || {}, e5.attributeNamePrefix);
+            i5.push(h5, t6);
+          }
+          if (h5 === e5.textNodeName) void 0 === s5 ? s5 = a5[h5] : s5 += "" + a5[h5];
           else {
-            if (void 0 === a5) continue;
-            if (o5[a5]) {
-              let t6 = H2(o5[a5], e5, l5);
-              const n6 = nt(t6, e5);
-              void 0 !== o5[Q] && (t6[Q] = o5[Q]), o5[":@"] ? et(t6, o5[":@"], l5, e5) : 1 !== Object.keys(t6).length || void 0 === t6[e5.textNodeName] || e5.alwaysCreateTextNode ? 0 === Object.keys(t6).length && (e5.alwaysCreateTextNode ? t6[e5.textNodeName] = "" : t6 = "") : t6 = t6[e5.textNodeName], void 0 !== s5[a5] && s5.hasOwnProperty(a5) ? (Array.isArray(s5[a5]) || (s5[a5] = [s5[a5]]), s5[a5].push(t6)) : e5.isArray(a5, l5, n6) ? s5[a5] = [t6] : s5[a5] = t6;
+            if (void 0 === h5) continue;
+            if (a5[h5]) {
+              let t6 = ut(a5[h5], e5, i5, n5);
+              const s6 = ft(t6, e5);
+              if (a5[":@"] ? dt(t6, a5[":@"], n5, e5) : 1 !== Object.keys(t6).length || void 0 === t6[e5.textNodeName] || e5.alwaysCreateTextNode ? 0 === Object.keys(t6).length && (e5.alwaysCreateTextNode ? t6[e5.textNodeName] = "" : t6 = "") : t6 = t6[e5.textNodeName], void 0 !== a5[ht] && "object" == typeof t6 && null !== t6 && (t6[ht] = a5[ht]), void 0 !== r5[h5] && Object.prototype.hasOwnProperty.call(r5, h5)) Array.isArray(r5[h5]) || (r5[h5] = [r5[h5]]), r5[h5].push(t6);
+              else {
+                const i6 = e5.jPath ? n5.toString() : n5;
+                e5.isArray(h5, i6, s6) ? r5[h5] = [t6] : r5[h5] = t6;
+              }
+              void 0 !== h5 && h5 !== e5.textNodeName && i5.pop();
             }
           }
         }
-        return "string" == typeof i5 ? i5.length > 0 && (s5[e5.textNodeName] = i5) : void 0 !== i5 && (s5[e5.textNodeName] = i5), s5;
+        return "string" == typeof s5 ? s5.length > 0 && (r5[e5.textNodeName] = s5) : void 0 !== s5 && (r5[e5.textNodeName] = s5), r5;
       }
-      function tt(t5) {
+      function ct(t5) {
         const e5 = Object.keys(t5);
         for (let t6 = 0; t6 < e5.length; t6++) {
-          const n5 = e5[t6];
-          if (":@" !== n5) return n5;
+          const i5 = e5[t6];
+          if (":@" !== i5) return i5;
         }
       }
-      function et(t5, e5, n5, i5) {
+      function dt(t5, e5, i5, n5) {
         if (e5) {
           const s5 = Object.keys(e5), r5 = s5.length;
           for (let o5 = 0; o5 < r5; o5++) {
-            const r6 = s5[o5];
-            i5.isArray(r6, n5 + "." + r6, true, true) ? t5[r6] = [e5[r6]] : t5[r6] = e5[r6];
+            const r6 = s5[o5], a5 = r6.startsWith(n5.attributeNamePrefix) ? r6.substring(n5.attributeNamePrefix.length) : r6, h5 = n5.jPath ? i5.toString() + "." + a5 : i5;
+            n5.isArray(r6, h5, true, true) ? t5[r6] = [e5[r6]] : t5[r6] = e5[r6];
           }
         }
       }
-      function nt(t5, e5) {
-        const { textNodeName: n5 } = e5, i5 = Object.keys(t5).length;
-        return 0 === i5 || !(1 !== i5 || !t5[n5] && "boolean" != typeof t5[n5] && 0 !== t5[n5]);
+      function ft(t5, e5) {
+        const { textNodeName: i5 } = e5, n5 = Object.keys(t5).length;
+        return 0 === n5 || !(1 !== n5 || !t5[i5] && "boolean" != typeof t5[i5] && 0 !== t5[i5]);
       }
-      class it {
+      class gt {
         constructor(t5) {
-          this.externalEntities = {}, this.options = w4(t5);
+          this.externalEntities = {}, this.options = O(t5);
         }
         parse(t5, e5) {
           if ("string" != typeof t5 && t5.toString) t5 = t5.toString();
           else if ("string" != typeof t5) throw new Error("XML data is accepted in String or Bytes[] form.");
           if (e5) {
             true === e5 && (e5 = {});
-            const n6 = a4(t5, e5);
-            if (true !== n6) throw Error(`${n6.err.msg}:${n6.err.line}:${n6.err.col}`);
+            const i6 = l4(t5, e5);
+            if (true !== i6) throw Error(`${i6.err.msg}:${i6.err.line}:${i6.err.col}`);
           }
-          const n5 = new F2(this.options);
-          n5.addExternalEntities(this.externalEntities);
-          const i5 = n5.parseXml(t5);
-          return this.options.preserveOrder || void 0 === i5 ? i5 : J2(i5, this.options);
+          const i5 = new W(this.options);
+          i5.addExternalEntities(this.externalEntities);
+          const n5 = i5.parseXml(t5);
+          return this.options.preserveOrder || void 0 === n5 ? n5 : pt(n5, this.options, i5.matcher, i5.readonlyMatcher);
         }
         addEntity(t5, e5) {
           if (-1 !== e5.indexOf("&")) throw new Error("Entity value can't have '&'");
@@ -32513,159 +32806,305 @@ var require_fxp = __commonJS({
           this.externalEntities[t5] = e5;
         }
         static getMetaDataSymbol() {
-          return I2.getMetaDataSymbol();
+          return $.getMetaDataSymbol();
         }
       }
-      function st(t5, e5) {
-        let n5 = "";
-        return e5.format && e5.indentBy.length > 0 && (n5 = "\n"), rt(t5, e5, "", n5);
+      function mt(t5, e5) {
+        let i5 = "";
+        e5.format && e5.indentBy.length > 0 && (i5 = "\n");
+        const n5 = [];
+        if (e5.stopNodes && Array.isArray(e5.stopNodes)) for (let t6 = 0; t6 < e5.stopNodes.length; t6++) {
+          const i6 = e5.stopNodes[t6];
+          "string" == typeof i6 ? n5.push(new R(i6)) : i6 instanceof R && n5.push(i6);
+        }
+        return xt(t5, e5, i5, new G2(), n5);
       }
-      function rt(t5, e5, n5, i5) {
-        let s5 = "", r5 = false;
-        for (let o5 = 0; o5 < t5.length; o5++) {
-          const a5 = t5[o5], l5 = ot(a5);
+      function xt(t5, e5, i5, n5, s5) {
+        let r5 = "", o5 = false;
+        if (e5.maxNestedTags && n5.getDepth() > e5.maxNestedTags) throw new Error("Maximum nested tags exceeded");
+        if (!Array.isArray(t5)) {
+          if (null != t5) {
+            let i6 = t5.toString();
+            return i6 = Tt(i6, e5), i6;
+          }
+          return "";
+        }
+        for (let a5 = 0; a5 < t5.length; a5++) {
+          const h5 = t5[a5], l5 = yt(h5);
           if (void 0 === l5) continue;
-          let u5 = "";
-          if (u5 = 0 === n5.length ? l5 : `${n5}.${l5}`, l5 === e5.textNodeName) {
-            let t6 = a5[l5];
-            lt(u5, e5) || (t6 = e5.tagValueProcessor(l5, t6), t6 = ut(t6, e5)), r5 && (s5 += i5), s5 += t6, r5 = false;
+          const p5 = Nt(h5[":@"], e5);
+          n5.push(l5, p5);
+          const u5 = vt(n5, s5);
+          if (l5 === e5.textNodeName) {
+            let t6 = h5[l5];
+            u5 || (t6 = e5.tagValueProcessor(l5, t6), t6 = Tt(t6, e5)), o5 && (r5 += i5), r5 += t6, o5 = false, n5.pop();
             continue;
           }
           if (l5 === e5.cdataPropName) {
-            r5 && (s5 += i5), s5 += `<![CDATA[${a5[l5][0][e5.textNodeName]}]]>`, r5 = false;
+            o5 && (r5 += i5), r5 += `<![CDATA[${h5[l5][0][e5.textNodeName]}]]>`, o5 = false, n5.pop();
             continue;
           }
           if (l5 === e5.commentPropName) {
-            s5 += i5 + `<!--${a5[l5][0][e5.textNodeName]}-->`, r5 = true;
+            r5 += i5 + `<!--${h5[l5][0][e5.textNodeName]}-->`, o5 = true, n5.pop();
             continue;
           }
           if ("?" === l5[0]) {
-            const t6 = at(a5[":@"], e5), n6 = "?xml" === l5 ? "" : i5;
-            let o6 = a5[l5][0][e5.textNodeName];
-            o6 = 0 !== o6.length ? " " + o6 : "", s5 += n6 + `<${l5}${o6}${t6}?>`, r5 = true;
+            const t6 = wt(h5[":@"], e5, u5), s6 = "?xml" === l5 ? "" : i5;
+            let a6 = h5[l5][0][e5.textNodeName];
+            a6 = 0 !== a6.length ? " " + a6 : "", r5 += s6 + `<${l5}${a6}${t6}?>`, o5 = true, n5.pop();
             continue;
           }
-          let h5 = i5;
-          "" !== h5 && (h5 += e5.indentBy);
-          const d5 = i5 + `<${l5}${at(a5[":@"], e5)}`, p5 = rt(a5[l5], e5, u5, h5);
-          -1 !== e5.unpairedTags.indexOf(l5) ? e5.suppressUnpairedNode ? s5 += d5 + ">" : s5 += d5 + "/>" : p5 && 0 !== p5.length || !e5.suppressEmptyNode ? p5 && p5.endsWith(">") ? s5 += d5 + `>${p5}${i5}</${l5}>` : (s5 += d5 + ">", p5 && "" !== i5 && (p5.includes("/>") || p5.includes("</")) ? s5 += i5 + e5.indentBy + p5 + i5 : s5 += p5, s5 += `</${l5}>`) : s5 += d5 + "/>", r5 = true;
+          let c5 = i5;
+          "" !== c5 && (c5 += e5.indentBy);
+          const d5 = i5 + `<${l5}${wt(h5[":@"], e5, u5)}`;
+          let f5;
+          f5 = u5 ? bt(h5[l5], e5) : xt(h5[l5], e5, c5, n5, s5), -1 !== e5.unpairedTags.indexOf(l5) ? e5.suppressUnpairedNode ? r5 += d5 + ">" : r5 += d5 + "/>" : f5 && 0 !== f5.length || !e5.suppressEmptyNode ? f5 && f5.endsWith(">") ? r5 += d5 + `>${f5}${i5}</${l5}>` : (r5 += d5 + ">", f5 && "" !== i5 && (f5.includes("/>") || f5.includes("</")) ? r5 += i5 + e5.indentBy + f5 + i5 : r5 += f5, r5 += `</${l5}>`) : r5 += d5 + "/>", o5 = true, n5.pop();
         }
-        return s5;
+        return r5;
       }
-      function ot(t5) {
+      function Nt(t5, e5) {
+        if (!t5 || e5.ignoreAttributes) return null;
+        const i5 = {};
+        let n5 = false;
+        for (let s5 in t5) Object.prototype.hasOwnProperty.call(t5, s5) && (i5[s5.startsWith(e5.attributeNamePrefix) ? s5.substr(e5.attributeNamePrefix.length) : s5] = t5[s5], n5 = true);
+        return n5 ? i5 : null;
+      }
+      function bt(t5, e5) {
+        if (!Array.isArray(t5)) return null != t5 ? t5.toString() : "";
+        let i5 = "";
+        for (let n5 = 0; n5 < t5.length; n5++) {
+          const s5 = t5[n5], r5 = yt(s5);
+          if (r5 === e5.textNodeName) i5 += s5[r5];
+          else if (r5 === e5.cdataPropName) i5 += s5[r5][0][e5.textNodeName];
+          else if (r5 === e5.commentPropName) i5 += s5[r5][0][e5.textNodeName];
+          else {
+            if (r5 && "?" === r5[0]) continue;
+            if (r5) {
+              const t6 = Et(s5[":@"], e5), n6 = bt(s5[r5], e5);
+              n6 && 0 !== n6.length ? i5 += `<${r5}${t6}>${n6}</${r5}>` : i5 += `<${r5}${t6}/>`;
+            }
+          }
+        }
+        return i5;
+      }
+      function Et(t5, e5) {
+        let i5 = "";
+        if (t5 && !e5.ignoreAttributes) for (let n5 in t5) {
+          if (!Object.prototype.hasOwnProperty.call(t5, n5)) continue;
+          let s5 = t5[n5];
+          true === s5 && e5.suppressBooleanAttributes ? i5 += ` ${n5.substr(e5.attributeNamePrefix.length)}` : i5 += ` ${n5.substr(e5.attributeNamePrefix.length)}="${s5}"`;
+        }
+        return i5;
+      }
+      function yt(t5) {
         const e5 = Object.keys(t5);
-        for (let n5 = 0; n5 < e5.length; n5++) {
-          const i5 = e5[n5];
-          if (t5.hasOwnProperty(i5) && ":@" !== i5) return i5;
+        for (let i5 = 0; i5 < e5.length; i5++) {
+          const n5 = e5[i5];
+          if (Object.prototype.hasOwnProperty.call(t5, n5) && ":@" !== n5) return n5;
         }
       }
-      function at(t5, e5) {
+      function wt(t5, e5, i5) {
         let n5 = "";
-        if (t5 && !e5.ignoreAttributes) for (let i5 in t5) {
-          if (!t5.hasOwnProperty(i5)) continue;
-          let s5 = e5.attributeValueProcessor(i5, t5[i5]);
-          s5 = ut(s5, e5), true === s5 && e5.suppressBooleanAttributes ? n5 += ` ${i5.substr(e5.attributeNamePrefix.length)}` : n5 += ` ${i5.substr(e5.attributeNamePrefix.length)}="${s5}"`;
+        if (t5 && !e5.ignoreAttributes) for (let s5 in t5) {
+          if (!Object.prototype.hasOwnProperty.call(t5, s5)) continue;
+          let r5;
+          i5 ? r5 = t5[s5] : (r5 = e5.attributeValueProcessor(s5, t5[s5]), r5 = Tt(r5, e5)), true === r5 && e5.suppressBooleanAttributes ? n5 += ` ${s5.substr(e5.attributeNamePrefix.length)}` : n5 += ` ${s5.substr(e5.attributeNamePrefix.length)}="${r5}"`;
         }
         return n5;
       }
-      function lt(t5, e5) {
-        let n5 = (t5 = t5.substr(0, t5.length - e5.textNodeName.length - 1)).substr(t5.lastIndexOf(".") + 1);
-        for (let i5 in e5.stopNodes) if (e5.stopNodes[i5] === t5 || e5.stopNodes[i5] === "*." + n5) return true;
+      function vt(t5, e5) {
+        if (!e5 || 0 === e5.length) return false;
+        for (let i5 = 0; i5 < e5.length; i5++) if (t5.matches(e5[i5])) return true;
         return false;
       }
-      function ut(t5, e5) {
-        if (t5 && t5.length > 0 && e5.processEntities) for (let n5 = 0; n5 < e5.entities.length; n5++) {
-          const i5 = e5.entities[n5];
-          t5 = t5.replace(i5.regex, i5.val);
-        }
-        return t5;
-      }
-      const ht = { attributeNamePrefix: "@_", attributesGroupName: false, textNodeName: "#text", ignoreAttributes: true, cdataPropName: false, format: false, indentBy: "  ", suppressEmptyNode: false, suppressUnpairedNode: true, suppressBooleanAttributes: true, tagValueProcessor: function(t5, e5) {
-        return e5;
-      }, attributeValueProcessor: function(t5, e5) {
-        return e5;
-      }, preserveOrder: false, commentPropName: false, unpairedTags: [], entities: [{ regex: new RegExp("&", "g"), val: "&amp;" }, { regex: new RegExp(">", "g"), val: "&gt;" }, { regex: new RegExp("<", "g"), val: "&lt;" }, { regex: new RegExp("'", "g"), val: "&apos;" }, { regex: new RegExp('"', "g"), val: "&quot;" }], processEntities: true, stopNodes: [], oneListGroup: false };
-      function dt(t5) {
-        this.options = Object.assign({}, ht, t5), true === this.options.ignoreAttributes || this.options.attributesGroupName ? this.isAttribute = function() {
-          return false;
-        } : (this.ignoreAttributesFn = L(this.options.ignoreAttributes), this.attrPrefixLen = this.options.attributeNamePrefix.length, this.isAttribute = ct), this.processTextOrObjNode = pt, this.options.format ? (this.indentate = ft, this.tagEndChar = ">\n", this.newLine = "\n") : (this.indentate = function() {
-          return "";
-        }, this.tagEndChar = ">", this.newLine = "");
-      }
-      function pt(t5, e5, n5, i5) {
-        const s5 = this.j2x(t5, n5 + 1, i5.concat(e5));
-        return void 0 !== t5[this.options.textNodeName] && 1 === Object.keys(t5).length ? this.buildTextValNode(t5[this.options.textNodeName], e5, s5.attrStr, n5) : this.buildObjectNode(s5.val, e5, s5.attrStr, n5);
-      }
-      function ft(t5) {
-        return this.options.indentBy.repeat(t5);
-      }
-      function ct(t5) {
-        return !(!t5.startsWith(this.options.attributeNamePrefix) || t5 === this.options.textNodeName) && t5.substr(this.attrPrefixLen);
-      }
-      dt.prototype.build = function(t5) {
-        return this.options.preserveOrder ? st(t5, this.options) : (Array.isArray(t5) && this.options.arrayNodeName && this.options.arrayNodeName.length > 1 && (t5 = { [this.options.arrayNodeName]: t5 }), this.j2x(t5, 0, []).val);
-      }, dt.prototype.j2x = function(t5, e5, n5) {
-        let i5 = "", s5 = "";
-        const r5 = n5.join(".");
-        for (let o5 in t5) if (Object.prototype.hasOwnProperty.call(t5, o5)) if (void 0 === t5[o5]) this.isAttribute(o5) && (s5 += "");
-        else if (null === t5[o5]) this.isAttribute(o5) || o5 === this.options.cdataPropName ? s5 += "" : "?" === o5[0] ? s5 += this.indentate(e5) + "<" + o5 + "?" + this.tagEndChar : s5 += this.indentate(e5) + "<" + o5 + "/" + this.tagEndChar;
-        else if (t5[o5] instanceof Date) s5 += this.buildTextValNode(t5[o5], o5, "", e5);
-        else if ("object" != typeof t5[o5]) {
-          const n6 = this.isAttribute(o5);
-          if (n6 && !this.ignoreAttributesFn(n6, r5)) i5 += this.buildAttrPairStr(n6, "" + t5[o5]);
-          else if (!n6) if (o5 === this.options.textNodeName) {
-            let e6 = this.options.tagValueProcessor(o5, "" + t5[o5]);
-            s5 += this.replaceEntitiesValue(e6);
-          } else s5 += this.buildTextValNode(t5[o5], o5, "", e5);
-        } else if (Array.isArray(t5[o5])) {
-          const i6 = t5[o5].length;
-          let r6 = "", a5 = "";
-          for (let l5 = 0; l5 < i6; l5++) {
-            const i7 = t5[o5][l5];
-            if (void 0 === i7) ;
-            else if (null === i7) "?" === o5[0] ? s5 += this.indentate(e5) + "<" + o5 + "?" + this.tagEndChar : s5 += this.indentate(e5) + "<" + o5 + "/" + this.tagEndChar;
-            else if ("object" == typeof i7) if (this.options.oneListGroup) {
-              const t6 = this.j2x(i7, e5 + 1, n5.concat(o5));
-              r6 += t6.val, this.options.attributesGroupName && i7.hasOwnProperty(this.options.attributesGroupName) && (a5 += t6.attrStr);
-            } else r6 += this.processTextOrObjNode(i7, o5, e5, n5);
-            else if (this.options.oneListGroup) {
-              let t6 = this.options.tagValueProcessor(o5, i7);
-              t6 = this.replaceEntitiesValue(t6), r6 += t6;
-            } else r6 += this.buildTextValNode(i7, o5, "", e5);
-          }
-          this.options.oneListGroup && (r6 = this.buildObjectNode(r6, o5, a5, e5)), s5 += r6;
-        } else if (this.options.attributesGroupName && o5 === this.options.attributesGroupName) {
-          const e6 = Object.keys(t5[o5]), n6 = e6.length;
-          for (let s6 = 0; s6 < n6; s6++) i5 += this.buildAttrPairStr(e6[s6], "" + t5[o5][e6[s6]]);
-        } else s5 += this.processTextOrObjNode(t5[o5], o5, e5, n5);
-        return { attrStr: i5, val: s5 };
-      }, dt.prototype.buildAttrPairStr = function(t5, e5) {
-        return e5 = this.options.attributeValueProcessor(t5, "" + e5), e5 = this.replaceEntitiesValue(e5), this.options.suppressBooleanAttributes && "true" === e5 ? " " + t5 : " " + t5 + '="' + e5 + '"';
-      }, dt.prototype.buildObjectNode = function(t5, e5, n5, i5) {
-        if ("" === t5) return "?" === e5[0] ? this.indentate(i5) + "<" + e5 + n5 + "?" + this.tagEndChar : this.indentate(i5) + "<" + e5 + n5 + this.closeTag(e5) + this.tagEndChar;
-        {
-          let s5 = "</" + e5 + this.tagEndChar, r5 = "";
-          return "?" === e5[0] && (r5 = "?", s5 = ""), !n5 && "" !== n5 || -1 !== t5.indexOf("<") ? false !== this.options.commentPropName && e5 === this.options.commentPropName && 0 === r5.length ? this.indentate(i5) + `<!--${t5}-->` + this.newLine : this.indentate(i5) + "<" + e5 + n5 + r5 + this.tagEndChar + t5 + this.indentate(i5) + s5 : this.indentate(i5) + "<" + e5 + n5 + r5 + ">" + t5 + s5;
-        }
-      }, dt.prototype.closeTag = function(t5) {
-        let e5 = "";
-        return -1 !== this.options.unpairedTags.indexOf(t5) ? this.options.suppressUnpairedNode || (e5 = "/") : e5 = this.options.suppressEmptyNode ? "/" : `></${t5}`, e5;
-      }, dt.prototype.buildTextValNode = function(t5, e5, n5, i5) {
-        if (false !== this.options.cdataPropName && e5 === this.options.cdataPropName) return this.indentate(i5) + `<![CDATA[${t5}]]>` + this.newLine;
-        if (false !== this.options.commentPropName && e5 === this.options.commentPropName) return this.indentate(i5) + `<!--${t5}-->` + this.newLine;
-        if ("?" === e5[0]) return this.indentate(i5) + "<" + e5 + n5 + "?" + this.tagEndChar;
-        {
-          let s5 = this.options.tagValueProcessor(e5, t5);
-          return s5 = this.replaceEntitiesValue(s5), "" === s5 ? this.indentate(i5) + "<" + e5 + n5 + this.closeTag(e5) + this.tagEndChar : this.indentate(i5) + "<" + e5 + n5 + ">" + s5 + "</" + e5 + this.tagEndChar;
-        }
-      }, dt.prototype.replaceEntitiesValue = function(t5) {
-        if (t5 && t5.length > 0 && this.options.processEntities) for (let e5 = 0; e5 < this.options.entities.length; e5++) {
-          const n5 = this.options.entities[e5];
+      function Tt(t5, e5) {
+        if (t5 && t5.length > 0 && e5.processEntities) for (let i5 = 0; i5 < e5.entities.length; i5++) {
+          const n5 = e5.entities[i5];
           t5 = t5.replace(n5.regex, n5.val);
         }
         return t5;
+      }
+      const Pt = { attributeNamePrefix: "@_", attributesGroupName: false, textNodeName: "#text", ignoreAttributes: true, cdataPropName: false, format: false, indentBy: "  ", suppressEmptyNode: false, suppressUnpairedNode: true, suppressBooleanAttributes: true, tagValueProcessor: function(t5, e5) {
+        return e5;
+      }, attributeValueProcessor: function(t5, e5) {
+        return e5;
+      }, preserveOrder: false, commentPropName: false, unpairedTags: [], entities: [{ regex: new RegExp("&", "g"), val: "&amp;" }, { regex: new RegExp(">", "g"), val: "&gt;" }, { regex: new RegExp("<", "g"), val: "&lt;" }, { regex: new RegExp("'", "g"), val: "&apos;" }, { regex: new RegExp('"', "g"), val: "&quot;" }], processEntities: true, stopNodes: [], oneListGroup: false, maxNestedTags: 100, jPath: true };
+      function St(t5) {
+        if (this.options = Object.assign({}, Pt, t5), this.options.stopNodes && Array.isArray(this.options.stopNodes) && (this.options.stopNodes = this.options.stopNodes.map((t6) => "string" == typeof t6 && t6.startsWith("*.") ? ".." + t6.substring(2) : t6)), this.stopNodeExpressions = [], this.options.stopNodes && Array.isArray(this.options.stopNodes)) for (let t6 = 0; t6 < this.options.stopNodes.length; t6++) {
+          const e6 = this.options.stopNodes[t6];
+          "string" == typeof e6 ? this.stopNodeExpressions.push(new R(e6)) : e6 instanceof R && this.stopNodeExpressions.push(e6);
+        }
+        var e5;
+        true === this.options.ignoreAttributes || this.options.attributesGroupName ? this.isAttribute = function() {
+          return false;
+        } : (this.ignoreAttributesFn = "function" == typeof (e5 = this.options.ignoreAttributes) ? e5 : Array.isArray(e5) ? (t6) => {
+          for (const i5 of e5) {
+            if ("string" == typeof i5 && t6 === i5) return true;
+            if (i5 instanceof RegExp && i5.test(t6)) return true;
+          }
+        } : () => false, this.attrPrefixLen = this.options.attributeNamePrefix.length, this.isAttribute = Ct), this.processTextOrObjNode = At, this.options.format ? (this.indentate = Ot, this.tagEndChar = ">\n", this.newLine = "\n") : (this.indentate = function() {
+          return "";
+        }, this.tagEndChar = ">", this.newLine = "");
+      }
+      function At(t5, e5, i5, n5) {
+        const s5 = this.extractAttributes(t5);
+        if (n5.push(e5, s5), this.checkStopNode(n5)) {
+          const s6 = this.buildRawContent(t5), r6 = this.buildAttributesForStopNode(t5);
+          return n5.pop(), this.buildObjectNode(s6, e5, r6, i5);
+        }
+        const r5 = this.j2x(t5, i5 + 1, n5);
+        return n5.pop(), void 0 !== t5[this.options.textNodeName] && 1 === Object.keys(t5).length ? this.buildTextValNode(t5[this.options.textNodeName], e5, r5.attrStr, i5, n5) : this.buildObjectNode(r5.val, e5, r5.attrStr, i5);
+      }
+      function Ot(t5) {
+        return this.options.indentBy.repeat(t5);
+      }
+      function Ct(t5) {
+        return !(!t5.startsWith(this.options.attributeNamePrefix) || t5 === this.options.textNodeName) && t5.substr(this.attrPrefixLen);
+      }
+      St.prototype.build = function(t5) {
+        if (this.options.preserveOrder) return mt(t5, this.options);
+        {
+          Array.isArray(t5) && this.options.arrayNodeName && this.options.arrayNodeName.length > 1 && (t5 = { [this.options.arrayNodeName]: t5 });
+          const e5 = new G2();
+          return this.j2x(t5, 0, e5).val;
+        }
+      }, St.prototype.j2x = function(t5, e5, i5) {
+        let n5 = "", s5 = "";
+        if (this.options.maxNestedTags && i5.getDepth() >= this.options.maxNestedTags) throw new Error("Maximum nested tags exceeded");
+        const r5 = this.options.jPath ? i5.toString() : i5, o5 = this.checkStopNode(i5);
+        for (let a5 in t5) if (Object.prototype.hasOwnProperty.call(t5, a5)) if (void 0 === t5[a5]) this.isAttribute(a5) && (s5 += "");
+        else if (null === t5[a5]) this.isAttribute(a5) || a5 === this.options.cdataPropName ? s5 += "" : "?" === a5[0] ? s5 += this.indentate(e5) + "<" + a5 + "?" + this.tagEndChar : s5 += this.indentate(e5) + "<" + a5 + "/" + this.tagEndChar;
+        else if (t5[a5] instanceof Date) s5 += this.buildTextValNode(t5[a5], a5, "", e5, i5);
+        else if ("object" != typeof t5[a5]) {
+          const h5 = this.isAttribute(a5);
+          if (h5 && !this.ignoreAttributesFn(h5, r5)) n5 += this.buildAttrPairStr(h5, "" + t5[a5], o5);
+          else if (!h5) if (a5 === this.options.textNodeName) {
+            let e6 = this.options.tagValueProcessor(a5, "" + t5[a5]);
+            s5 += this.replaceEntitiesValue(e6);
+          } else {
+            i5.push(a5);
+            const n6 = this.checkStopNode(i5);
+            if (i5.pop(), n6) {
+              const i6 = "" + t5[a5];
+              s5 += "" === i6 ? this.indentate(e5) + "<" + a5 + this.closeTag(a5) + this.tagEndChar : this.indentate(e5) + "<" + a5 + ">" + i6 + "</" + a5 + this.tagEndChar;
+            } else s5 += this.buildTextValNode(t5[a5], a5, "", e5, i5);
+          }
+        } else if (Array.isArray(t5[a5])) {
+          const n6 = t5[a5].length;
+          let r6 = "", o6 = "";
+          for (let h5 = 0; h5 < n6; h5++) {
+            const n7 = t5[a5][h5];
+            if (void 0 === n7) ;
+            else if (null === n7) "?" === a5[0] ? s5 += this.indentate(e5) + "<" + a5 + "?" + this.tagEndChar : s5 += this.indentate(e5) + "<" + a5 + "/" + this.tagEndChar;
+            else if ("object" == typeof n7) if (this.options.oneListGroup) {
+              i5.push(a5);
+              const t6 = this.j2x(n7, e5 + 1, i5);
+              i5.pop(), r6 += t6.val, this.options.attributesGroupName && n7.hasOwnProperty(this.options.attributesGroupName) && (o6 += t6.attrStr);
+            } else r6 += this.processTextOrObjNode(n7, a5, e5, i5);
+            else if (this.options.oneListGroup) {
+              let t6 = this.options.tagValueProcessor(a5, n7);
+              t6 = this.replaceEntitiesValue(t6), r6 += t6;
+            } else {
+              i5.push(a5);
+              const t6 = this.checkStopNode(i5);
+              if (i5.pop(), t6) {
+                const t7 = "" + n7;
+                r6 += "" === t7 ? this.indentate(e5) + "<" + a5 + this.closeTag(a5) + this.tagEndChar : this.indentate(e5) + "<" + a5 + ">" + t7 + "</" + a5 + this.tagEndChar;
+              } else r6 += this.buildTextValNode(n7, a5, "", e5, i5);
+            }
+          }
+          this.options.oneListGroup && (r6 = this.buildObjectNode(r6, a5, o6, e5)), s5 += r6;
+        } else if (this.options.attributesGroupName && a5 === this.options.attributesGroupName) {
+          const e6 = Object.keys(t5[a5]), i6 = e6.length;
+          for (let s6 = 0; s6 < i6; s6++) n5 += this.buildAttrPairStr(e6[s6], "" + t5[a5][e6[s6]], o5);
+        } else s5 += this.processTextOrObjNode(t5[a5], a5, e5, i5);
+        return { attrStr: n5, val: s5 };
+      }, St.prototype.buildAttrPairStr = function(t5, e5, i5) {
+        return i5 || (e5 = this.options.attributeValueProcessor(t5, "" + e5), e5 = this.replaceEntitiesValue(e5)), this.options.suppressBooleanAttributes && "true" === e5 ? " " + t5 : " " + t5 + '="' + e5 + '"';
+      }, St.prototype.extractAttributes = function(t5) {
+        if (!t5 || "object" != typeof t5) return null;
+        const e5 = {};
+        let i5 = false;
+        if (this.options.attributesGroupName && t5[this.options.attributesGroupName]) {
+          const n5 = t5[this.options.attributesGroupName];
+          for (let t6 in n5) Object.prototype.hasOwnProperty.call(n5, t6) && (e5[t6.startsWith(this.options.attributeNamePrefix) ? t6.substring(this.options.attributeNamePrefix.length) : t6] = n5[t6], i5 = true);
+        } else for (let n5 in t5) {
+          if (!Object.prototype.hasOwnProperty.call(t5, n5)) continue;
+          const s5 = this.isAttribute(n5);
+          s5 && (e5[s5] = t5[n5], i5 = true);
+        }
+        return i5 ? e5 : null;
+      }, St.prototype.buildRawContent = function(t5) {
+        if ("string" == typeof t5) return t5;
+        if ("object" != typeof t5 || null === t5) return String(t5);
+        if (void 0 !== t5[this.options.textNodeName]) return t5[this.options.textNodeName];
+        let e5 = "";
+        for (let i5 in t5) {
+          if (!Object.prototype.hasOwnProperty.call(t5, i5)) continue;
+          if (this.isAttribute(i5)) continue;
+          if (this.options.attributesGroupName && i5 === this.options.attributesGroupName) continue;
+          const n5 = t5[i5];
+          if (i5 === this.options.textNodeName) e5 += n5;
+          else if (Array.isArray(n5)) {
+            for (let t6 of n5) if ("string" == typeof t6 || "number" == typeof t6) e5 += `<${i5}>${t6}</${i5}>`;
+            else if ("object" == typeof t6 && null !== t6) {
+              const n6 = this.buildRawContent(t6), s5 = this.buildAttributesForStopNode(t6);
+              e5 += "" === n6 ? `<${i5}${s5}/>` : `<${i5}${s5}>${n6}</${i5}>`;
+            }
+          } else if ("object" == typeof n5 && null !== n5) {
+            const t6 = this.buildRawContent(n5), s5 = this.buildAttributesForStopNode(n5);
+            e5 += "" === t6 ? `<${i5}${s5}/>` : `<${i5}${s5}>${t6}</${i5}>`;
+          } else e5 += `<${i5}>${n5}</${i5}>`;
+        }
+        return e5;
+      }, St.prototype.buildAttributesForStopNode = function(t5) {
+        if (!t5 || "object" != typeof t5) return "";
+        let e5 = "";
+        if (this.options.attributesGroupName && t5[this.options.attributesGroupName]) {
+          const i5 = t5[this.options.attributesGroupName];
+          for (let t6 in i5) {
+            if (!Object.prototype.hasOwnProperty.call(i5, t6)) continue;
+            const n5 = t6.startsWith(this.options.attributeNamePrefix) ? t6.substring(this.options.attributeNamePrefix.length) : t6, s5 = i5[t6];
+            true === s5 && this.options.suppressBooleanAttributes ? e5 += " " + n5 : e5 += " " + n5 + '="' + s5 + '"';
+          }
+        } else for (let i5 in t5) {
+          if (!Object.prototype.hasOwnProperty.call(t5, i5)) continue;
+          const n5 = this.isAttribute(i5);
+          if (n5) {
+            const s5 = t5[i5];
+            true === s5 && this.options.suppressBooleanAttributes ? e5 += " " + n5 : e5 += " " + n5 + '="' + s5 + '"';
+          }
+        }
+        return e5;
+      }, St.prototype.buildObjectNode = function(t5, e5, i5, n5) {
+        if ("" === t5) return "?" === e5[0] ? this.indentate(n5) + "<" + e5 + i5 + "?" + this.tagEndChar : this.indentate(n5) + "<" + e5 + i5 + this.closeTag(e5) + this.tagEndChar;
+        {
+          let s5 = "</" + e5 + this.tagEndChar, r5 = "";
+          return "?" === e5[0] && (r5 = "?", s5 = ""), !i5 && "" !== i5 || -1 !== t5.indexOf("<") ? false !== this.options.commentPropName && e5 === this.options.commentPropName && 0 === r5.length ? this.indentate(n5) + `<!--${t5}-->` + this.newLine : this.indentate(n5) + "<" + e5 + i5 + r5 + this.tagEndChar + t5 + this.indentate(n5) + s5 : this.indentate(n5) + "<" + e5 + i5 + r5 + ">" + t5 + s5;
+        }
+      }, St.prototype.closeTag = function(t5) {
+        let e5 = "";
+        return -1 !== this.options.unpairedTags.indexOf(t5) ? this.options.suppressUnpairedNode || (e5 = "/") : e5 = this.options.suppressEmptyNode ? "/" : `></${t5}`, e5;
+      }, St.prototype.checkStopNode = function(t5) {
+        if (!this.stopNodeExpressions || 0 === this.stopNodeExpressions.length) return false;
+        for (let e5 = 0; e5 < this.stopNodeExpressions.length; e5++) if (t5.matches(this.stopNodeExpressions[e5])) return true;
+        return false;
+      }, St.prototype.buildTextValNode = function(t5, e5, i5, n5, s5) {
+        if (false !== this.options.cdataPropName && e5 === this.options.cdataPropName) return this.indentate(n5) + `<![CDATA[${t5}]]>` + this.newLine;
+        if (false !== this.options.commentPropName && e5 === this.options.commentPropName) return this.indentate(n5) + `<!--${t5}-->` + this.newLine;
+        if ("?" === e5[0]) return this.indentate(n5) + "<" + e5 + i5 + "?" + this.tagEndChar;
+        {
+          let s6 = this.options.tagValueProcessor(e5, t5);
+          return s6 = this.replaceEntitiesValue(s6), "" === s6 ? this.indentate(n5) + "<" + e5 + i5 + this.closeTag(e5) + this.tagEndChar : this.indentate(n5) + "<" + e5 + i5 + ">" + s6 + "</" + e5 + this.tagEndChar;
+        }
+      }, St.prototype.replaceEntitiesValue = function(t5) {
+        if (t5 && t5.length > 0 && this.options.processEntities) for (let e5 = 0; e5 < this.options.entities.length; e5++) {
+          const i5 = this.options.entities[e5];
+          t5 = t5.replace(i5.regex, i5.val);
+        }
+        return t5;
       };
-      const gt = { validate: a4 };
+      const $t = St, It = { validate: l4 };
       module2.exports = e4;
     })();
   }
@@ -32680,12 +33119,17 @@ var require_xml_parser = __commonJS({
     var fast_xml_parser_1 = require_fxp();
     var parser = new fast_xml_parser_1.XMLParser({
       attributeNamePrefix: "",
+      processEntities: {
+        enabled: true,
+        maxTotalExpansions: Infinity
+      },
       htmlEntities: true,
       ignoreAttributes: false,
       ignoreDeclaration: true,
       parseTagValue: false,
       trimValues: false,
-      tagValueProcessor: (_, val) => val.trim() === "" && val.includes("\n") ? "" : void 0
+      tagValueProcessor: (_, val) => val.trim() === "" && val.includes("\n") ? "" : void 0,
+      maxNestedTags: Infinity
     });
     parser.addEntity("#xD", "\r");
     parser.addEntity("#10", "\n");
@@ -32700,11 +33144,30 @@ var require_dist_cjs21 = __commonJS({
   "node_modules/@aws-sdk/xml-builder/dist-cjs/index.js"(exports2) {
     "use strict";
     var xmlParser = require_xml_parser();
+    var ATTR_ESCAPE_RE = /[&<>"]/g;
+    var ATTR_ESCAPE_MAP = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;"
+    };
     function escapeAttribute(value) {
-      return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+      return value.replace(ATTR_ESCAPE_RE, (ch) => ATTR_ESCAPE_MAP[ch]);
     }
+    var ELEMENT_ESCAPE_RE = /[&"'<>\r\n\u0085\u2028]/g;
+    var ELEMENT_ESCAPE_MAP = {
+      "&": "&amp;",
+      '"': "&quot;",
+      "'": "&apos;",
+      "<": "&lt;",
+      ">": "&gt;",
+      "\r": "&#x0D;",
+      "\n": "&#x0A;",
+      "\x85": "&#x85;",
+      "\u2028": "&#x2028;"
+    };
     function escapeElement(value) {
-      return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&apos;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\r/g, "&#x0D;").replace(/\n/g, "&#x0A;").replace(/\u0085/g, "&#x85;").replace(/\u2028/, "&#x2028;");
+      return value.replace(ELEMENT_ESCAPE_RE, (ch) => ELEMENT_ESCAPE_MAP[ch]);
     }
     var XmlText2 = class {
       value;
@@ -32801,12 +33264,7 @@ var require_dist_cjs21 = __commonJS({
         return xmlText += !hasChildren ? "/>" : `>${this.children.map((c4) => c4.toString()).join("")}</${this.name}>`;
       }
     };
-    Object.defineProperty(exports2, "parseXML", {
-      enumerable: true,
-      get: function() {
-        return xmlParser.parseXML;
-      }
-    });
+    exports2.parseXML = xmlParser.parseXML;
     exports2.XmlNode = XmlNode2;
     exports2.XmlText = XmlText2;
   }
@@ -52846,7 +53304,7 @@ var require_dist_cjs72 = __commonJS({
       ];
     }).s("AmazonS3", "PutObjectAcl", {}).n("S3Client", "PutObjectAclCommand").sc(schemas_0.PutObjectAcl$).build() {
     };
-    var PutObjectCommand2 = class extends smithyClient.Command.classBuilder().ep({
+    var PutObjectCommand = class extends smithyClient.Command.classBuilder().ep({
       ...commonParams4,
       Bucket: { type: "contextParams", name: "Bucket" },
       Key: { type: "contextParams", name: "Key" }
@@ -53236,7 +53694,7 @@ var require_dist_cjs72 = __commonJS({
       PutBucketTaggingCommand,
       PutBucketVersioningCommand,
       PutBucketWebsiteCommand,
-      PutObjectCommand: PutObjectCommand2,
+      PutObjectCommand,
       PutObjectAclCommand,
       PutObjectLegalHoldCommand,
       PutObjectLockConfigurationCommand,
@@ -53829,7 +54287,7 @@ var require_dist_cjs72 = __commonJS({
     exports2.PutBucketVersioningCommand = PutBucketVersioningCommand;
     exports2.PutBucketWebsiteCommand = PutBucketWebsiteCommand;
     exports2.PutObjectAclCommand = PutObjectAclCommand;
-    exports2.PutObjectCommand = PutObjectCommand2;
+    exports2.PutObjectCommand = PutObjectCommand;
     exports2.PutObjectLegalHoldCommand = PutObjectLegalHoldCommand;
     exports2.PutObjectLockConfigurationCommand = PutObjectLockConfigurationCommand;
     exports2.PutObjectRetentionCommand = PutObjectRetentionCommand;
@@ -56757,6 +57215,563 @@ var require_dist_cjs76 = __commonJS({
     tslib_1.__exportStar(require_fromTemporaryCredentials(), exports2);
     tslib_1.__exportStar(require_fromTokenFile2(), exports2);
     tslib_1.__exportStar(require_fromWebToken2(), exports2);
+  }
+});
+
+// node_modules/@smithy/abort-controller/dist-cjs/index.js
+var require_dist_cjs77 = __commonJS({
+  "node_modules/@smithy/abort-controller/dist-cjs/index.js"(exports2) {
+    "use strict";
+    var AbortSignal2 = class {
+      onabort = null;
+      _aborted = false;
+      constructor() {
+        Object.defineProperty(this, "_aborted", {
+          value: false,
+          writable: true
+        });
+      }
+      get aborted() {
+        return this._aborted;
+      }
+      abort() {
+        this._aborted = true;
+        if (this.onabort) {
+          this.onabort(this);
+          this.onabort = null;
+        }
+      }
+    };
+    var AbortController2 = class {
+      signal = new AbortSignal2();
+      abort() {
+        this.signal.abort();
+      }
+    };
+    exports2.AbortController = AbortController2;
+    exports2.AbortSignal = AbortSignal2;
+  }
+});
+
+// node_modules/@aws-sdk/lib-storage/dist-cjs/runtimeConfig.shared.js
+var require_runtimeConfig_shared4 = __commonJS({
+  "node_modules/@aws-sdk/lib-storage/dist-cjs/runtimeConfig.shared.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.runtimeConfigShared = void 0;
+    exports2.runtimeConfigShared = {
+      lstatSync: () => {
+      },
+      isFileReadStream(f4) {
+        return false;
+      }
+    };
+  }
+});
+
+// node_modules/@aws-sdk/lib-storage/dist-cjs/runtimeConfig.js
+var require_runtimeConfig4 = __commonJS({
+  "node_modules/@aws-sdk/lib-storage/dist-cjs/runtimeConfig.js"(exports2) {
+    "use strict";
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.runtimeConfig = void 0;
+    var fs_1 = require("fs");
+    var runtimeConfig_shared_1 = require_runtimeConfig_shared4();
+    exports2.runtimeConfig = {
+      ...runtimeConfig_shared_1.runtimeConfigShared,
+      runtime: "node",
+      lstatSync: fs_1.lstatSync,
+      isFileReadStream(f4) {
+        return f4 instanceof fs_1.ReadStream;
+      }
+    };
+  }
+});
+
+// node_modules/@aws-sdk/lib-storage/dist-cjs/index.js
+var require_dist_cjs78 = __commonJS({
+  "node_modules/@aws-sdk/lib-storage/dist-cjs/index.js"(exports2) {
+    "use strict";
+    var clientS3 = require_dist_cjs72();
+    var abortController = require_dist_cjs77();
+    var middlewareEndpoint = require_dist_cjs43();
+    var smithyClient = require_dist_cjs20();
+    var events = require("events");
+    var buffer = require("buffer");
+    var runtimeConfig = require_runtimeConfig4();
+    var stream = require("stream");
+    var byteLength = (input) => {
+      if (input == null) {
+        return 0;
+      }
+      if (typeof input === "string") {
+        return buffer.Buffer.byteLength(input);
+      }
+      if (typeof input.byteLength === "number") {
+        return input.byteLength;
+      } else if (typeof input.length === "number") {
+        return input.length;
+      } else if (typeof input.size === "number") {
+        return input.size;
+      } else if (typeof input.start === "number" && typeof input.end === "number") {
+        return input.end + 1 - input.start;
+      } else if (runtimeConfig.runtimeConfig.isFileReadStream(input)) {
+        try {
+          return runtimeConfig.runtimeConfig.lstatSync(input.path).size;
+        } catch (error4) {
+          return void 0;
+        }
+      }
+      return void 0;
+    };
+    var BYTE_LENGTH_SOURCE;
+    (function(BYTE_LENGTH_SOURCE2) {
+      BYTE_LENGTH_SOURCE2["EMPTY_INPUT"] = "a null or undefined Body";
+      BYTE_LENGTH_SOURCE2["CONTENT_LENGTH"] = "the ContentLength property of the params set by the caller";
+      BYTE_LENGTH_SOURCE2["STRING_LENGTH"] = "the encoded byte length of the Body string";
+      BYTE_LENGTH_SOURCE2["TYPED_ARRAY"] = "the byteLength of a typed byte array such as Uint8Array";
+      BYTE_LENGTH_SOURCE2["LENGTH"] = "the value of Body.length";
+      BYTE_LENGTH_SOURCE2["SIZE"] = "the value of Body.size";
+      BYTE_LENGTH_SOURCE2["START_END_DIFF"] = "the numeric difference between Body.start and Body.end";
+      BYTE_LENGTH_SOURCE2["LSTAT"] = "the size of the file given by Body.path on disk as reported by lstatSync";
+    })(BYTE_LENGTH_SOURCE || (BYTE_LENGTH_SOURCE = {}));
+    var byteLengthSource = (input, override) => {
+      if (override != null) {
+        return BYTE_LENGTH_SOURCE.CONTENT_LENGTH;
+      }
+      if (input == null) {
+        return BYTE_LENGTH_SOURCE.EMPTY_INPUT;
+      }
+      if (typeof input === "string") {
+        return BYTE_LENGTH_SOURCE.STRING_LENGTH;
+      }
+      if (typeof input.byteLength === "number") {
+        return BYTE_LENGTH_SOURCE.TYPED_ARRAY;
+      } else if (typeof input.length === "number") {
+        return BYTE_LENGTH_SOURCE.LENGTH;
+      } else if (typeof input.size === "number") {
+        return BYTE_LENGTH_SOURCE.SIZE;
+      } else if (typeof input.start === "number" && typeof input.end === "number") {
+        return BYTE_LENGTH_SOURCE.START_END_DIFF;
+      } else if (runtimeConfig.runtimeConfig.isFileReadStream(input)) {
+        try {
+          runtimeConfig.runtimeConfig.lstatSync(input.path).size;
+          return BYTE_LENGTH_SOURCE.LSTAT;
+        } catch (error4) {
+          return void 0;
+        }
+      }
+      return void 0;
+    };
+    async function* getChunkStream(data2, partSize, getNextData) {
+      let partNumber = 1;
+      const currentBuffer = { chunks: [], length: 0 };
+      for await (const datum of getNextData(data2)) {
+        currentBuffer.chunks.push(datum);
+        currentBuffer.length += datum.byteLength;
+        while (currentBuffer.length > partSize) {
+          const dataChunk = currentBuffer.chunks.length > 1 ? buffer.Buffer.concat(currentBuffer.chunks) : currentBuffer.chunks[0];
+          yield {
+            partNumber,
+            data: dataChunk.subarray(0, partSize)
+          };
+          currentBuffer.chunks = [dataChunk.subarray(partSize)];
+          currentBuffer.length = currentBuffer.chunks[0].byteLength;
+          partNumber += 1;
+        }
+      }
+      yield {
+        partNumber,
+        data: currentBuffer.chunks.length !== 1 ? buffer.Buffer.concat(currentBuffer.chunks) : currentBuffer.chunks[0],
+        lastPart: true
+      };
+    }
+    async function* getChunkUint8Array(data2, partSize) {
+      let partNumber = 1;
+      let startByte = 0;
+      let endByte = partSize;
+      while (endByte < data2.byteLength) {
+        yield {
+          partNumber,
+          data: data2.subarray(startByte, endByte)
+        };
+        partNumber += 1;
+        startByte = endByte;
+        endByte = startByte + partSize;
+      }
+      yield {
+        partNumber,
+        data: data2.subarray(startByte),
+        lastPart: true
+      };
+    }
+    async function* getDataReadable(data2) {
+      for await (const chunk of data2) {
+        if (buffer.Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+          yield chunk;
+        } else {
+          yield buffer.Buffer.from(chunk);
+        }
+      }
+    }
+    async function* getDataReadableStream(data2) {
+      const reader = data2.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            return;
+          }
+          if (buffer.Buffer.isBuffer(value) || value instanceof Uint8Array) {
+            yield value;
+          } else {
+            yield buffer.Buffer.from(value);
+          }
+        }
+      } catch (e4) {
+        throw e4;
+      } finally {
+        reader.releaseLock();
+      }
+    }
+    var getChunk = (data2, partSize) => {
+      if (data2 instanceof Uint8Array) {
+        return getChunkUint8Array(data2, partSize);
+      }
+      if (data2 instanceof stream.Readable) {
+        return getChunkStream(data2, partSize, getDataReadable);
+      }
+      if (data2 instanceof String || typeof data2 === "string") {
+        return getChunkUint8Array(buffer.Buffer.from(data2), partSize);
+      }
+      if (typeof data2.stream === "function") {
+        return getChunkStream(data2.stream(), partSize, getDataReadableStream);
+      }
+      if (data2 instanceof ReadableStream) {
+        return getChunkStream(data2, partSize, getDataReadableStream);
+      }
+      throw new Error("Body Data is unsupported format, expected data to be one of: string | Uint8Array | Buffer | Readable | ReadableStream | Blob;.");
+    };
+    var Upload2 = class _Upload extends events.EventEmitter {
+      static MIN_PART_SIZE = 1024 * 1024 * 5;
+      MAX_PARTS = 1e4;
+      queueSize = 4;
+      partSize;
+      leavePartsOnError = false;
+      tags = [];
+      client;
+      params;
+      totalBytes;
+      totalBytesSource;
+      bytesUploadedSoFar;
+      abortController;
+      concurrentUploaders = [];
+      createMultiPartPromise;
+      abortMultipartUploadCommand = null;
+      uploadedParts = [];
+      uploadEnqueuedPartsCount = 0;
+      expectedPartsCount;
+      uploadId;
+      uploadEvent;
+      isMultiPart = true;
+      singleUploadResult;
+      sent = false;
+      constructor(options) {
+        super();
+        this.queueSize = options.queueSize || this.queueSize;
+        this.leavePartsOnError = options.leavePartsOnError || this.leavePartsOnError;
+        this.tags = options.tags || this.tags;
+        this.client = options.client;
+        this.params = options.params;
+        if (!this.params) {
+          throw new Error(`InputError: Upload requires params to be passed to upload.`);
+        }
+        this.totalBytes = this.params.ContentLength ?? byteLength(this.params.Body);
+        this.totalBytesSource = byteLengthSource(this.params.Body, this.params.ContentLength);
+        this.bytesUploadedSoFar = 0;
+        this.abortController = options.abortController ?? new abortController.AbortController();
+        this.partSize = options.partSize || Math.max(_Upload.MIN_PART_SIZE, Math.floor((this.totalBytes || 0) / this.MAX_PARTS));
+        if (this.totalBytes !== void 0) {
+          this.expectedPartsCount = Math.ceil(this.totalBytes / this.partSize);
+        }
+        this.__validateInput();
+      }
+      async abort() {
+        this.abortController.abort();
+      }
+      async done() {
+        if (this.sent) {
+          throw new Error("@aws-sdk/lib-storage: this instance of Upload has already executed .done(). Create a new instance.");
+        }
+        this.sent = true;
+        return await Promise.race([this.__doMultipartUpload(), this.__abortTimeout(this.abortController.signal)]);
+      }
+      on(event, listener) {
+        this.uploadEvent = event;
+        return super.on(event, listener);
+      }
+      async __uploadUsingPut(dataPart) {
+        this.isMultiPart = false;
+        const params = { ...this.params, Body: dataPart.data };
+        const clientConfig = this.client.config;
+        const requestHandler = clientConfig.requestHandler;
+        const eventEmitter = requestHandler instanceof events.EventEmitter ? requestHandler : null;
+        const uploadEventListener = (event) => {
+          this.bytesUploadedSoFar = event.loaded;
+          this.totalBytes = event.total;
+          this.__notifyProgress({
+            loaded: this.bytesUploadedSoFar,
+            total: this.totalBytes,
+            part: dataPart.partNumber,
+            Key: this.params.Key,
+            Bucket: this.params.Bucket
+          });
+        };
+        if (eventEmitter !== null) {
+          eventEmitter.on("xhr.upload.progress", uploadEventListener);
+        }
+        const resolved = await Promise.all([this.client.send(new clientS3.PutObjectCommand(params)), clientConfig?.endpoint?.()]);
+        const putResult = resolved[0];
+        let endpoint2 = resolved[1];
+        if (!endpoint2) {
+          endpoint2 = middlewareEndpoint.toEndpointV1(await middlewareEndpoint.getEndpointFromInstructions(params, clientS3.PutObjectCommand, {
+            ...clientConfig
+          }));
+        }
+        if (!endpoint2) {
+          throw new Error('Could not resolve endpoint from S3 "client.config.endpoint()" nor EndpointsV2.');
+        }
+        if (eventEmitter !== null) {
+          eventEmitter.off("xhr.upload.progress", uploadEventListener);
+        }
+        const locationKey = this.params.Key.split("/").map((segment) => smithyClient.extendedEncodeURIComponent(segment)).join("/");
+        const locationBucket = smithyClient.extendedEncodeURIComponent(this.params.Bucket);
+        const Location = (() => {
+          const endpointHostnameIncludesBucket = endpoint2.hostname.startsWith(`${locationBucket}.`);
+          const forcePathStyle = this.client.config.forcePathStyle;
+          const optionalPort = endpoint2.port ? `:${endpoint2.port}` : ``;
+          if (forcePathStyle) {
+            return `${endpoint2.protocol}//${endpoint2.hostname}${optionalPort}/${locationBucket}/${locationKey}`;
+          }
+          if (endpointHostnameIncludesBucket) {
+            return `${endpoint2.protocol}//${endpoint2.hostname}${optionalPort}/${locationKey}`;
+          }
+          return `${endpoint2.protocol}//${locationBucket}.${endpoint2.hostname}${optionalPort}/${locationKey}`;
+        })();
+        this.singleUploadResult = {
+          ...putResult,
+          Bucket: this.params.Bucket,
+          Key: this.params.Key,
+          Location
+        };
+        const totalSize = byteLength(dataPart.data);
+        this.__notifyProgress({
+          loaded: totalSize,
+          total: totalSize,
+          part: 1,
+          Key: this.params.Key,
+          Bucket: this.params.Bucket
+        });
+      }
+      async __createMultipartUpload() {
+        const requestChecksumCalculation = await this.client.config.requestChecksumCalculation();
+        if (!this.createMultiPartPromise) {
+          const createCommandParams = { ...this.params, Body: void 0 };
+          if (requestChecksumCalculation === "WHEN_SUPPORTED") {
+            createCommandParams.ChecksumAlgorithm = this.params.ChecksumAlgorithm || clientS3.ChecksumAlgorithm.CRC32;
+          }
+          this.createMultiPartPromise = this.client.send(new clientS3.CreateMultipartUploadCommand(createCommandParams)).then((createMpuResponse) => {
+            this.abortMultipartUploadCommand = new clientS3.AbortMultipartUploadCommand({
+              Bucket: this.params.Bucket,
+              Key: this.params.Key,
+              UploadId: createMpuResponse.UploadId
+            });
+            return createMpuResponse;
+          });
+        }
+        return this.createMultiPartPromise;
+      }
+      async __doConcurrentUpload(dataFeeder) {
+        for await (const dataPart of dataFeeder) {
+          if (this.uploadEnqueuedPartsCount > this.MAX_PARTS) {
+            throw new Error(`Exceeded ${this.MAX_PARTS} parts in multipart upload to Bucket: ${this.params.Bucket} Key: ${this.params.Key}.`);
+          }
+          if (this.abortController.signal.aborted) {
+            return;
+          }
+          if (dataPart.partNumber === 1 && dataPart.lastPart) {
+            return await this.__uploadUsingPut(dataPart);
+          }
+          if (!this.uploadId) {
+            const { UploadId } = await this.__createMultipartUpload();
+            this.uploadId = UploadId;
+            if (this.abortController.signal.aborted) {
+              return;
+            }
+          }
+          const partSize = byteLength(dataPart.data) || 0;
+          const requestHandler = this.client.config.requestHandler;
+          const eventEmitter = requestHandler instanceof events.EventEmitter ? requestHandler : null;
+          let lastSeenBytes = 0;
+          const uploadEventListener = (event, request2) => {
+            const requestPartSize = Number(request2.query["partNumber"]) || -1;
+            if (requestPartSize !== dataPart.partNumber) {
+              return;
+            }
+            if (event.total && partSize) {
+              this.bytesUploadedSoFar += event.loaded - lastSeenBytes;
+              lastSeenBytes = event.loaded;
+            }
+            this.__notifyProgress({
+              loaded: this.bytesUploadedSoFar,
+              total: this.totalBytes,
+              part: dataPart.partNumber,
+              Key: this.params.Key,
+              Bucket: this.params.Bucket
+            });
+          };
+          if (eventEmitter !== null) {
+            eventEmitter.on("xhr.upload.progress", uploadEventListener);
+          }
+          this.uploadEnqueuedPartsCount += 1;
+          this.__validateUploadPart(dataPart);
+          const partResult = await this.client.send(new clientS3.UploadPartCommand({
+            ...this.params,
+            ContentLength: void 0,
+            UploadId: this.uploadId,
+            Body: dataPart.data,
+            PartNumber: dataPart.partNumber
+          }));
+          if (eventEmitter !== null) {
+            eventEmitter.off("xhr.upload.progress", uploadEventListener);
+          }
+          if (this.abortController.signal.aborted) {
+            return;
+          }
+          if (!partResult.ETag) {
+            throw new Error(`Part ${dataPart.partNumber} is missing ETag in UploadPart response. Missing Bucket CORS configuration for ETag header?`);
+          }
+          this.uploadedParts.push({
+            PartNumber: dataPart.partNumber,
+            ETag: partResult.ETag,
+            ...partResult.ChecksumCRC32 && { ChecksumCRC32: partResult.ChecksumCRC32 },
+            ...partResult.ChecksumCRC32C && { ChecksumCRC32C: partResult.ChecksumCRC32C },
+            ...partResult.ChecksumSHA1 && { ChecksumSHA1: partResult.ChecksumSHA1 },
+            ...partResult.ChecksumSHA256 && { ChecksumSHA256: partResult.ChecksumSHA256 }
+          });
+          if (eventEmitter === null) {
+            this.bytesUploadedSoFar += partSize;
+          }
+          this.__notifyProgress({
+            loaded: this.bytesUploadedSoFar,
+            total: this.totalBytes,
+            part: dataPart.partNumber,
+            Key: this.params.Key,
+            Bucket: this.params.Bucket
+          });
+        }
+      }
+      async __doMultipartUpload() {
+        const dataFeeder = getChunk(this.params.Body, this.partSize);
+        const concurrentUploaderFailures = [];
+        for (let index = 0; index < this.queueSize; index++) {
+          const currentUpload = this.__doConcurrentUpload(dataFeeder).catch((err) => {
+            concurrentUploaderFailures.push(err);
+          });
+          this.concurrentUploaders.push(currentUpload);
+        }
+        await Promise.all(this.concurrentUploaders);
+        if (concurrentUploaderFailures.length >= 1) {
+          await this.markUploadAsAborted();
+          throw concurrentUploaderFailures[0];
+        }
+        if (this.abortController.signal.aborted) {
+          await this.markUploadAsAborted();
+          throw Object.assign(new Error("Upload aborted."), { name: "AbortError" });
+        }
+        let result;
+        if (this.isMultiPart) {
+          const { expectedPartsCount, uploadedParts, totalBytes, totalBytesSource } = this;
+          if (totalBytes !== void 0 && expectedPartsCount !== void 0 && uploadedParts.length !== expectedPartsCount) {
+            throw new Error(`Expected ${expectedPartsCount} part(s) but uploaded ${uploadedParts.length} part(s).
+The expected part count is based on the byte-count of the input.params.Body,
+which was read from ${totalBytesSource} and is ${totalBytes}.
+If this is not correct, provide an override value by setting a number
+to input.params.ContentLength in bytes.
+`);
+          }
+          this.uploadedParts.sort((a4, b4) => a4.PartNumber - b4.PartNumber);
+          const uploadCompleteParams = {
+            ...this.params,
+            Body: void 0,
+            UploadId: this.uploadId,
+            MultipartUpload: {
+              Parts: this.uploadedParts
+            }
+          };
+          result = await this.client.send(new clientS3.CompleteMultipartUploadCommand(uploadCompleteParams));
+          if (typeof result?.Location === "string" && result.Location.includes("%2F")) {
+            result.Location = result.Location.replace(/%2F/g, "/");
+          }
+        } else {
+          result = this.singleUploadResult;
+        }
+        this.abortMultipartUploadCommand = null;
+        if (this.tags.length) {
+          await this.client.send(new clientS3.PutObjectTaggingCommand({
+            ...this.params,
+            Tagging: {
+              TagSet: this.tags
+            }
+          }));
+        }
+        return result;
+      }
+      async markUploadAsAborted() {
+        if (this.uploadId && !this.leavePartsOnError && null !== this.abortMultipartUploadCommand) {
+          await this.client.send(this.abortMultipartUploadCommand);
+          this.abortMultipartUploadCommand = null;
+        }
+      }
+      __notifyProgress(progress) {
+        if (this.uploadEvent) {
+          this.emit(this.uploadEvent, progress);
+        }
+      }
+      async __abortTimeout(abortSignal) {
+        return new Promise((resolve, reject) => {
+          abortSignal.onabort = () => {
+            const abortError = new Error("Upload aborted.");
+            abortError.name = "AbortError";
+            reject(abortError);
+          };
+        });
+      }
+      __validateUploadPart(dataPart) {
+        const actualPartSize = byteLength(dataPart.data);
+        if (actualPartSize === void 0) {
+          throw new Error(`A dataPart was generated without a measurable data chunk size for part number ${dataPart.partNumber}`);
+        }
+        if (dataPart.partNumber === 1 && dataPart.lastPart) {
+          return;
+        }
+        if (!dataPart.lastPart && actualPartSize !== this.partSize) {
+          throw new Error(`The byte size for part number ${dataPart.partNumber}, size ${actualPartSize} does not match expected size ${this.partSize}`);
+        }
+      }
+      __validateInput() {
+        if (!this.client) {
+          throw new Error(`InputError: Upload requires a AWS client to do uploads with.`);
+        }
+        if (this.partSize < _Upload.MIN_PART_SIZE) {
+          throw new Error(`EntityTooSmall: Your proposed upload part size [${this.partSize}] is smaller than the minimum allowed size [${_Upload.MIN_PART_SIZE}] (5MB)`);
+        }
+        if (this.queueSize < 1) {
+          throw new Error(`Queue size: Must have at least one uploading queue.`);
+        }
+      }
+    };
+    exports2.Upload = Upload2;
   }
 });
 
@@ -60481,7 +61496,7 @@ function getOctokit(token, options, ...additionalPlugins) {
 }
 
 // src/index.ts
-var import_client_s33 = __toESM(require_dist_cjs72());
+var import_client_s32 = __toESM(require_dist_cjs72());
 var import_credential_providers = __toESM(require_dist_cjs76());
 
 // node_modules/js-yaml/dist/js-yaml.mjs
@@ -63452,24 +64467,27 @@ var riffraffPrefix = (m4) => {
 // src/s3.ts
 var fs2 = __toESM(require("fs"));
 var core4 = __toESM(require_core());
-var import_client_s32 = __toESM(require_dist_cjs72());
+var import_lib_storage = __toESM(require_dist_cjs78());
 var S3Store = class {
   client;
   constructor(client) {
     this.client = client;
   }
   async put(data2, bucket, key) {
-    const cmd = new import_client_s32.PutObjectCommand({
-      Body: data2,
-      Key: key,
-      Bucket: bucket
+    const upload = new import_lib_storage.Upload({
+      client: this.client,
+      params: {
+        Body: data2,
+        Key: key,
+        Bucket: bucket
+      }
     });
-    await this.client.send(cmd);
+    await upload.done();
   }
 };
 var sync = async (store, dir, bucket, keyPrefix) => {
   const responses = walk(dir, (filePath) => {
-    const data2 = fs2.readFileSync(filePath);
+    const data2 = fs2.createReadStream(filePath);
     const key = keyPrefix + filePath.substring(dir.length);
     core4.info(`s3 sync: ${filePath} -> ${key}`);
     return store.put(data2, bucket, key);
@@ -63535,7 +64553,7 @@ var main = async (options) => {
   }
   const idToken = await core5.getIDToken(GITHUB_OIDC_AUDIENCE);
   const store = new S3Store(
-    new import_client_s33.S3Client({
+    new import_client_s32.S3Client({
       region: "eu-west-1",
       credentials: (0, import_credential_providers.fromWebToken)({
         roleArn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@actions/github": "^9.0.0",
         "@aws-sdk/client-s3": "3.989.0",
         "@aws-sdk/credential-providers": "3.989.0",
+        "@aws-sdk/lib-storage": "3.989.0",
         "esbuild": "^0.27.3",
         "js-yaml": "^4.1.1"
       },
@@ -752,6 +753,26 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.989.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.989.0.tgz",
+      "integrity": "sha512-8pJXMJ7MT5At/5ANFC68IbhfG8hNe0/ISsbtdVopgQEsiZEAHr0HDNoPcyoRnc3RTzjykz7Q95uf/Lpz3PQNmA==",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.14",
+        "@smithy/smithy-client": "^4.11.3",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.989.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
@@ -4950,6 +4971,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -5036,6 +5076,15 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "node_modules/buffer-from": {
@@ -6258,6 +6307,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6939,6 +6996,25 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -7022,7 +7098,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -9148,6 +9223,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -9278,6 +9366,25 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -9575,6 +9682,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -10404,6 +10528,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@actions/github": "^9.0.0",
     "@aws-sdk/client-s3": "3.989.0",
     "@aws-sdk/credential-providers": "3.989.0",
+    "@aws-sdk/lib-storage": "3.989.0",
     "esbuild": "^0.27.3",
     "js-yaml": "^4.1.1"
   },

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
+import type { Readable } from 'stream';
 import * as core from '@actions/core';
 import type { S3Client } from '@aws-sdk/client-s3';
-import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
 import { walk } from './file';
 
 export interface Store {
-	put: (data: Buffer, bucket: string, key: string) => Promise<void>;
+	put: (data: Buffer | Readable, bucket: string, key: string) => Promise<void>;
 }
 
 export class S3Store implements Store {
@@ -15,14 +16,21 @@ export class S3Store implements Store {
 		this.client = client;
 	}
 
-	async put(data: Buffer, bucket: string, key: string): Promise<void> {
-		const cmd = new PutObjectCommand({
-			Body: data,
-			Key: key,
-			Bucket: bucket,
+	async put(
+		data: Buffer | Readable,
+		bucket: string,
+		key: string,
+	): Promise<void> {
+		const upload = new Upload({
+			client: this.client,
+			params: {
+				Body: data,
+				Key: key,
+				Bucket: bucket,
+			},
 		});
 
-		await this.client.send(cmd);
+		await upload.done();
 	}
 }
 
@@ -33,7 +41,7 @@ export const sync = async (
 	keyPrefix: string,
 ): Promise<void> => {
 	const responses = walk(dir, (filePath: string) => {
-		const data = fs.readFileSync(filePath);
+		const data = fs.createReadStream(filePath);
 		const key = keyPrefix + filePath.substring(dir.length);
 
 		core.info(`s3 sync: ${filePath} -> ${key}`);


### PR DESCRIPTION
## What does this change?
Recently I've been trying to bundle up some very large artifacts -e.g. compiled version of https://github.com/ggml-org/llama.cpp for CUDA or AI models https://github.com/guardian/transcription-service/pull/280

These currently can't be uploaded via actions-riff-raff because it loads the entire file into memory and node enforces a 2GB limit for this. You get errors like [this](https://github.com/guardian/transcription-service/actions/runs/24466125203/job/71493566688):

```
Error: RangeError [ERR_FS_FILE_TOO_LARGE]: File size (3549049161) is greater than 2 GiB
Error: File size (3549049161) is greater than 2 GiB
```

This PR refactors actions-riff-raff to stream the file from disk to s3 and to use a multipart upload, which should resolve the 2GB limit.

## How has this change been tested?
I've tested this using the transcription service project, I was able to upload a 4GB artifact