### PR TITLE
fix: Target Node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A GitHub Action to build and upload Riff-Raff artifacts.",
   "main": "dist/index.js",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --packages=bundle --outfile=dist/index.js",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node24 --packages=bundle --outfile=dist/index.js",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "tsc": "tsc --noEmit",
     "lint": "eslint src --ext .ts --no-error-on-unmatched-pattern",


### PR DESCRIPTION
Missed in https://github.com/guardian/actions-riff-raff/pull/320, this change ensures `esbuild` targets the desired version of Node.

As it happens, there's no change to the built artifact for this repository.