### PR TITLE
fix: Correctly obtain revision

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -65943,6 +65943,14 @@ var getRoleArn = () => {
   }
   return roleArn;
 };
+var getRevision = () => {
+  if (context2.eventName === "pull_request") {
+    const payload2 = context2.payload;
+    return payload2.pull_request.head.sha;
+  } else {
+    return context2.sha;
+  }
+};
 function getConfiguration() {
   const riffRaffYaml = getRiffRaffYaml();
   const projectName = getProjectName(riffRaffYaml);
@@ -65963,7 +65971,7 @@ function getConfiguration() {
     buildNumber,
     branchName: branchName() ?? "dev",
     vcsURL: vcsURL() ?? "dev",
-    revision: envOrUndefined("GITHUB_SHA") ?? "dev",
+    revision: getRevision(),
     deployments: getDeployments(),
     stagingDirInput,
     githubToken: githubToken(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@guardian/eslint-config": "14.0.1",
         "@guardian/prettier": "^10.0.0",
         "@guardian/tsconfig": "^1.0.1",
+        "@octokit/webhooks-definitions": "^3.68.1",
         "@types/jest": "30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "25.6.0",
@@ -2965,6 +2966,14 @@
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
+    },
+    "node_modules/@octokit/webhooks-definitions": {
+      "version": "3.68.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.68.1.tgz",
+      "integrity": "sha512-wa8koFift24mUsMarWP/wfl9kIwqL5TK9smsCRIyJYfs9iYQEoJsQjcmhyKCmevPA8Ja/K1ZTE4W8ABA0yMM8g==",
+      "deprecated": "Use @octokit/webhooks-types, @octokit/webhooks-schemas, or @octokit/webhooks-examples instead. See https://github.com/octokit/webhooks/issues/447",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@guardian/eslint-config": "14.0.1",
     "@guardian/prettier": "^10.0.0",
     "@guardian/tsconfig": "^1.0.1",
+    "@octokit/webhooks-definitions": "^3.68.1",
     "@types/jest": "30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "25.6.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,6 @@
 import * as core from '@actions/core';
+import { context } from '@actions/github';
+import type { PullRequestEvent } from '@octokit/webhooks-definitions/schema';
 import * as yaml from 'js-yaml';
 import { read } from './file';
 import type { Deployment, RiffraffYaml } from './riffraff';
@@ -190,6 +192,16 @@ const getRoleArn = (): string => {
 	return roleArn;
 };
 
+const getRevision = (): string => {
+	if (context.eventName === 'pull_request') {
+		// See https://github.com/orgs/community/discussions/26325
+		const payload = context.payload as PullRequestEvent;
+		return payload.pull_request.head.sha;
+	} else {
+		return context.sha;
+	}
+};
+
 export function getConfiguration(): Configuration {
 	const riffRaffYaml = getRiffRaffYaml();
 	const projectName = getProjectName(riffRaffYaml);
@@ -215,7 +227,7 @@ export function getConfiguration(): Configuration {
 		buildNumber,
 		branchName: branchName() ?? 'dev',
 		vcsURL: vcsURL() ?? 'dev',
-		revision: envOrUndefined('GITHUB_SHA') ?? 'dev',
+		revision: getRevision(),
 		deployments: getDeployments(),
 		stagingDirInput,
 		githubToken: githubToken(),


### PR DESCRIPTION
## What does this change?
Corrects how the commit SHA is obtained from a pull request. When a workflow is triggered by a pull request, the SHA of the latest commit on the branch is obtained from a different place from when the trigger is merge to main. See https://github.com/orgs/community/discussions/26325.

### ❌  Before

Let's consider PR https://github.com/guardian/cdk-playground/pull/1086, the latest commit is:

```bash
❯ gh api repos/guardian/cdk-playground/commits/akash1810-patch-2 | jq -r .sha
2f3bb079b10d81f842e17425d97939ea5426f998
```

When we [deploy](https://riffraff.gutools.co.uk/deployment/view/dc7655a3-ed78-428f-a672-c458b434a007) the branch, Riff-Raff shows the commit as:

<img width="781" height="259" alt="image" src="https://github.com/user-attachments/assets/67482855-8e29-4f43-b2da-52199d0283c3" />

Clicking on the link leads to https://github.com/guardian/cdk-playground/commit/a1fa0dfa3dbf3bab2718064eeeb3a8378c8aa686:

<img width="796" height="377" alt="image" src="https://github.com/user-attachments/assets/34b21420-7d4c-4bbd-bd94-1af23194cb62" />

This is incorrect 😢.

### ✅ After
Let's consider PR https://github.com/guardian/cdk-playground/pull/1087, which uses `guardian/actions-riff-raff` from this branch, the latest commit is:

```bash
❯ gh api repos/guardian/cdk-playground/commits/akash1810-patch-3 | jq -r .sha
0d4a9628940559b108b7293c0265d2618dc77bbb
```

When we [deploy](https://riffraff.gutools.co.uk/deployment/view/3b61945a-4085-49d8-baf2-2ad270eddfb4) the branch, Riff-Raff shows the correct commit:

<img width="773" height="260" alt="image" src="https://github.com/user-attachments/assets/ba3730e6-0728-4846-a054-38f8db5b2257" />

This is correct 🎉.

## How has this change been tested?
See above.

## How can we measure success?
Improved DX.