### PR TITLE
Update docs to recommend using projectName in GHA workflow config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,26 @@ jobs:
 
 ## Available inputs
 
-### `app`
-*Required* (unless setting `projectName`)
-
-The app name, used for the creating Riff-Raff project name with the format `stack::app`.
-Where `stack` is read from the provided `riff-raff.yaml` config.
-
-Note: If you have multiple stacks specified, use `projectName` instead.
-
 ### `roleArn`
 
-_Required_
+*Required*
 
 The ARN for a role that the action assumes using AssumeRoleWithWebIdentity. This is required to upload artifacts to the Riff-Raff bucket.
 
 ### `projectName`
-Used instead of `app` to override the default Riff-Raff project naming strategy.
+
+*Required*
+
+The recommended way to specify the riff raff name for your project. By convention this is often `<stack>::<app>`. Make sure this matches your entry in [the riffraff-platform repository](https://github.com/guardian/riffraff-platform).
+
+### `app`
+
+*Required* if you are not setting `projectName`.
+
+The app name, used for the creating Riff-Raff project name with the format `stack::app`.
+Where `stack` is read from the provided `riff-raff.yaml` config.
+
+Note: If you have multiple stacks specified, use `projectName` instead, and this may not work with automatically generated riff-raff.yaml configurations.
 
 ### `config`
 *Required* (unless setting `configPath`)


### PR DESCRIPTION
Switch to recommending `projectName` over `app` in GHA workflow configurations.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


Paraphrasing a chat message from @akash1810, in response to an issue setting up a new project:

> TL;DR; Use `projectName` instead of `app`.
>
> When `app` is provided, the project name is calculated using [the contents of the riff-raff.yaml](https://github.com/guardian/actions-riff-raff/blob/f0806aac5659b052afe2416f5d35723448e7807f/src/config.ts#L21-L45). The way it does this is quite naive and only reads stacks at the root of the riff-raff.yaml. The generated file in your repo puts stack at the individual deployment level, as you say.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
